### PR TITLE
fix: ruff lint failure on main (unused import in tests/)

### DIFF
--- a/tests/test_fans_suggest.py
+++ b/tests/test_fans_suggest.py
@@ -1,4 +1,3 @@
-import pytest
 
 from fans.suggest import band, enough_data, suggest_curves
 


### PR DESCRIPTION
CI lints `py_modules main.py tests` but the local gate had only checked `py_modules main.py`, so an unused `import pytest` in tests/test_fans_suggest.py slipped through and turned main red after PR #4. Removes the import; `ruff check py_modules main.py tests` clean, 275 pytest green.