### PR TITLE
fix: average GPU busy over a short burst to fix noisy Steam Deck readings

### DIFF
--- a/main.py
+++ b/main.py
@@ -384,7 +384,14 @@ class Plugin:
         Never raises; any error degrades to None (no sample recorded).
         """
         try:
-            if self._current_appid is None:
+            # Snapshot the appid once: this method now runs on a worker thread
+            # (via asyncio.to_thread) and spans a ~120 ms gpu_busy burst + fan
+            # I/O, during which an event-loop RPC could reassign _current_appid.
+            # Reading it once keeps the guard, the setpoint, and the returned
+            # appid consistent so a sample is never mislabelled across a game
+            # switch (telemetry honesty).
+            appid = self._current_appid
+            if appid is None:
                 return None
 
             pr = self._power_reader.read()
@@ -399,7 +406,7 @@ class Plugin:
             fan_rpm = max(fan_rpms) if fan_rpms else None
 
             # Clamped effective setpoint (mirrors get_power_draw)
-            pl1 = self._effective_levels(self._current_appid)[0]["pl1"]
+            pl1 = self._effective_levels(appid)[0]["pl1"]
 
             # boost = was the chip boosting at this PL1 (draw > PL1 + deadband)?
             # 1.0/0.0/None; its per-bin average = the honest "power-limited here?"
@@ -417,7 +424,7 @@ class Plugin:
                 "temp_gpu": temp_gpu,
                 "fan_rpm": fan_rpm,
             }
-            return (self._current_appid, sample)
+            return (appid, sample)
         except Exception:  # noqa: BLE001
             return None
 
@@ -583,7 +590,9 @@ class Plugin:
                 if self._current_appid is None:
                     self._reset_auto_windows()
                     continue
-                pr = self._power_reader.read()
+                # read() sub-samples gpu_busy over a short blocking burst -> off
+                # the event loop so it can't stall other Decky RPC handling.
+                pr = await asyncio.to_thread(self._power_reader.read)
                 levels, active, _ac = self._effective_levels(self._current_appid)
                 cur = levels["pl1"]
                 lim = self._limits()
@@ -627,7 +636,7 @@ class Plugin:
 
     async def get_power_draw(self) -> dict:
         self._init()
-        pr = self._power_reader.read()
+        pr = await asyncio.to_thread(self._power_reader.read)
         auto = bool(self._settings.get("auto_tdp"))
         setpoint = self._effective_levels(self._current_appid)[0]["pl1"]
         return {

--- a/py_modules/power/reader.py
+++ b/py_modules/power/reader.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import time
 
 
 class PowerReader:
@@ -10,10 +11,22 @@ class PowerReader:
     None for any field that is unavailable (honest 'unknown').
 
     Sysfs paths are resolved once at construction and cached. If a cached path
-    is absent at read time (e.g. module loaded later) the lookup is retried."""
+    is absent at read time (e.g. module loaded later) the lookup is retried.
 
-    def __init__(self, root="/"):
+    `gpu_busy_percent` on some APUs (notably the Steam Deck's Van Gogh) is an
+    INSTANTANEOUS sample of a tiny window that swings wildly 0<->100. A single
+    read is unrepresentative (measured on-device: a ~30% game reads
+    0,0,0,100,100,0,... mean 22). read_gpu_busy() therefore sub-samples a short
+    burst and returns the arithmetic mean — the honest time-average of GPU
+    utilisation (mangohud does the same). The mean, not a percentile: `decide`
+    already owns the up/down asymmetry (recent-peak up, smoothed-mean down)
+    across its outer window; biasing this reading upward would corrupt both
+    branches. Cheap: ~12 microsecond sysfs reads over ~120 ms vs a 2 s loop."""
+
+    def __init__(self, root="/", gpu_samples=12, gpu_sample_gap=0.01):
         self._root = root
+        self._gpu_samples = max(1, gpu_samples)
+        self._gpu_sample_gap = max(0.0, gpu_sample_gap)
         self._amdgpu_hwmon: str | None = self._find_amdgpu_dir()
         self._gpu_busy_path: str | None = self._find_gpu_busy_path()
 
@@ -56,16 +69,26 @@ class PowerReader:
         return None
 
     def read_gpu_busy(self):
-        """GPU utilisation as an integer percent (0–100), or None if unavailable."""
+        """GPU utilisation as an integer percent (0–100), or None if unavailable.
+
+        Sub-samples a short burst and returns the mean of the valid reads, to
+        de-noise the instantaneous sensor (see class docstring). Honest: returns
+        None only if EVERY read failed (never fabricates a 0)."""
         if self._gpu_busy_path is None or not os.path.exists(self._gpu_busy_path):
             self._gpu_busy_path = self._find_gpu_busy_path()
         path = self._gpu_busy_path
         if path is None:
             return None
-        raw = self._read_int(path)
-        if raw is None:
+        valid = []
+        for i in range(self._gpu_samples):
+            raw = self._read_int(path)
+            if raw is not None:
+                valid.append(max(0, min(raw, 100)))
+            if self._gpu_sample_gap and i < self._gpu_samples - 1:
+                time.sleep(self._gpu_sample_gap)
+        if not valid:
             return None
-        return max(0, min(raw, 100))
+        return round(sum(valid) / len(valid))
 
     def read(self):
         return {"watts": self.read_watts(), "gpu_busy": self.read_gpu_busy()}

--- a/py_modules/telemetry/sampler.py
+++ b/py_modules/telemetry/sampler.py
@@ -50,7 +50,9 @@ class TelemetrySampler:
         while True:
             try:
                 await asyncio.sleep(self._interval)
-                result = self._sample_fn()
+                # sample_fn does blocking sysfs I/O (incl. a gpu_busy sub-sample
+                # burst) -> run it off the event loop so it can't stall Decky.
+                result = await asyncio.to_thread(self._sample_fn)
                 if result is not None:
                     appid, sample = result
                     self._store.add_sample(appid, sample, dt=self._interval, ts=time.time())

--- a/tests/test_power_reader.py
+++ b/tests/test_power_reader.py
@@ -87,3 +87,52 @@ def test_read_returns_both_fields(tmp_path):
     r = PowerReader(root=str(tmp_path)).read()
     assert r["watts"] == 15.0
     assert r["gpu_busy"] == 55
+
+
+# --- gpu_busy sub-sampling (Van Gogh instantaneous-sensor de-noise) ---
+
+def _reader_with_samples(tmp_path, samples):
+    """A PowerReader whose gpu_busy path resolves, but whose per-read value is
+    driven by a scripted sequence (simulating the noisy instantaneous sensor).
+    Sleeps are disabled so tests run instantly."""
+    _mk_drm_card(str(tmp_path), 0, 0)  # make _find_gpu_busy_path succeed
+    r = PowerReader(root=str(tmp_path), gpu_samples=len(samples), gpu_sample_gap=0.0)
+    seq = list(samples)
+
+    def fake_read_int(_path):
+        return seq.pop(0) if seq else None
+
+    r._read_int = fake_read_int
+    return r
+
+
+def test_gpu_busy_averages_a_burst(tmp_path):
+    # The exact on-device Van Gogh probe: instantaneous 0<->100 noise, ~22% real.
+    samples = [0, 0, 0, 100, 100, 100, 0, 0, 0, 0, 53, 59, 0, 0, 0, 37, 0, 0, 0, 0]
+    r = _reader_with_samples(tmp_path, samples)
+    # mean = 449/20 = 22.45 -> 22 (a single instantaneous read would give a bogus 0,
+    # matching gamescope's smoothed ~30% and the 5.2 W real draw)
+    assert r.read_gpu_busy() == 22
+
+
+def test_gpu_busy_burst_of_constant_is_that_value(tmp_path):
+    r = _reader_with_samples(tmp_path, [72] * 12)
+    assert r.read_gpu_busy() == 72
+
+
+def test_gpu_busy_averages_only_valid_reads(tmp_path):
+    # Corrupt reads (None) are ignored; the mean is over the valid ones only.
+    r = _reader_with_samples(tmp_path, [None, 80, None, 40, None])
+    assert r.read_gpu_busy() == 60  # mean(80, 40)
+
+
+def test_gpu_busy_none_when_no_valid_reads(tmp_path):
+    # File vanished mid-burst / all corrupt -> honest None, never a fake 0.
+    r = _reader_with_samples(tmp_path, [None, None, None])
+    assert r.read_gpu_busy() is None
+
+
+def test_gpu_busy_burst_clamps_per_read(tmp_path):
+    r = _reader_with_samples(tmp_path, [150, 100, -5])
+    # each read clamped to [0,100] -> mean(100, 100, 0) = 66.67 -> 67
+    assert r.read_gpu_busy() == 67


### PR DESCRIPTION
## Problem

`gpu_busy_percent` on the Steam Deck APU (Van Gogh) is an **instantaneous** snapshot that bounces between 0 and 100. A single read per ~2s auto-TDP tick almost always caught a 0 (false headroom) or a 100 (false saturation), so the control loop's GPU window filled with garbage and sawtoothed. The UI showed GPU 0% while gamescope showed the smoothed ~30%.

This is an auto-TDP **correctness** bug on the Deck, not just cosmetic: GPU% is the only honest control signal, so noisy single reads made the loop starve the game / oscillate.

## Fix

- `read_gpu_busy()` sub-samples the file over a short burst (12 reads, ~110ms) and returns the **mean** — the honest time-average of utilisation, matching gamescope/mangoapp. Chose mean over a high percentile so the loop's down-branch still fires (a percentile would bias every sample up and over-feed permanently). The loop algorithm is unchanged; it just receives an honest number.
- The burst is blocking sysfs I/O, so the three call sites (`_auto_loop`, `get_power_draw`, telemetry sampler) run `read()` via `asyncio.to_thread` to keep it off the event loop.
- `_collect_sample` snapshots `_current_appid` once so a game switch during the ~120ms window can't mislabel a telemetry sample.

## Validation

- Full suite green: 387 pytest, ruff, typecheck, build.
- On-device (Deck OLED, in-game): raw reads averaged ~25% bouncing 0↔100; `read_gpu_busy()` returned a stable ~25%. Plugin loaded cleanly.