### PR TITLE
Harden CI/release pipeline and add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please do **not** include any
+        personal data or secrets. If this is a **security vulnerability**, do not
+        open a public issue — see the [security policy](../../security/policy).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I do X, Y happens; I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the panel
+        2. Go to ...
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      description: Which handheld are you on?
+      options:
+        - Steam Deck LCD
+        - Steam Deck OLED
+        - ROG Ally
+        - ROG Ally X
+        - ROG Xbox Ally X
+        - Legion Go
+        - Legion Go S
+        - Legion Go 2
+        - MSI Claw 8 AI+
+        - Other (specify below)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: e.g. SteamOS 3.6, Bazzite (date/build), Windows dual-boot, etc.
+    validations:
+      required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Panel de Control version
+      description: Shown in the plugin's settings.
+    validations:
+      required: true
+  - type: input
+    id: decky-version
+    attributes:
+      label: Decky Loader version
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: >
+        Plugin logs live at `~/homebrew/logs/Panel de Control/`. Paste only the
+        relevant lines. This will be rendered as code, so no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Hooandee/panel-de-control/security/advisories/new
+    about: Please report vulnerabilities privately — do not open a public issue.
+  - name: Decky Loader
+    url: https://decky.xyz/
+    about: Questions about Decky Loader itself (not this plugin) belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or the frustration this would address.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: device
+    attributes:
+      label: Is this device-specific?
+      options:
+        - Applies to all devices
+        - Steam Deck LCD
+        - Steam Deck OLED
+        - ROG Ally
+        - ROG Ally X
+        - ROG Xbox Ally X
+        - Legion Go
+        - Legion Go S
+        - Legion Go 2
+        - MSI Claw 8 AI+
+        - Other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing! Please fill out the checklist below. -->
+
+## What does this change?
+
+<!-- A short description of the change and why. Link any related issue: Closes #123 -->
+
+## How was it tested?
+
+<!-- Which device(s) did you test on, if any? What did you verify? -->
+
+## Checklist
+
+- [ ] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
+- [ ] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
+- [ ] `ruff check py_modules main.py tests` and `python -m pytest` pass.
+- [ ] No secrets, tokens, or personal data are included.
+- [ ] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current. Dependabot bumps both the pinned
+  # SHA and its version comment, so pinning stays maintainable.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      # Non-releasing prefix: release-please only bumps on feat/fix, so dependency
+      # PRs merged to main never cut a release on their own.
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Frontend dependencies (pnpm).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      npm:
+        patterns: ["*"]
+
+  # Backend dev dependencies (requirements-dev.txt).
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,25 @@ on:
     branches: ["**"]
   pull_request:
 
+# Least privilege: CI only reads the repo. No job here writes anything, and a
+# read-only token means a compromised dependency in a build step cannot push,
+# open PRs, or tamper with releases.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - run: pip install -r requirements-dev.txt
@@ -20,11 +33,13 @@ jobs:
   frontend-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,11 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -29,7 +31,7 @@ jobs:
           export VERSION="${BASE}-dev.${SHORT_SHA}"
           node -e "const f='package.json';const p=require('./'+f);p.version=process.env.VERSION;require('fs').writeFileSync(f, JSON.stringify(p,null,2)+'\n')"
           echo "Building $PLUGIN_NAME v${VERSION} from ${BRANCH}"
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
           pnpm build
           rm -f dist/*.map
           staging=$(mktemp -d)
@@ -38,7 +40,7 @@ jobs:
           (cd "$staging" && zip -r "$GITHUB_WORKSPACE/$PLUGIN_NAME.zip" "$PLUGIN_NAME")
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Panel de Control-${{ env.VERSION }}
           path: Panel de Control.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,28 +4,34 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
+# No token permissions by default; the job grants only what it needs.
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub release + upload the asset
+      pull-requests: write # maintain the release PR
+      id-token: write # keyless (OIDC) signing for build provenance
+      attestations: write # record the provenance attestation
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
       # Build + attach the plugin zip only when a release was just tagged.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ steps.release.outputs.release_created }}
-      - uses: pnpm/action-setup@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: ${{ steps.release.outputs.release_created }}
         with:
           version: 10
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 20
@@ -42,6 +48,18 @@ jobs:
           mkdir -p "$staging/$PLUGIN_NAME"
           cp -rL dist main.py plugin.json package.json README.md LICENSE py_modules assets "$staging/$PLUGIN_NAME"
           (cd "$staging" && zip -r "$GITHUB_WORKSPACE/$PLUGIN_NAME.zip" "$PLUGIN_NAME")
+
+      # Sign the exact release artifact with build provenance (Sigstore, keyless).
+      # Anyone can verify the zip really came from this workflow/commit with:
+      #   gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
+      # This is what protects users even if the GitHub account or a token leaks:
+      # a zip published outside this pipeline has no valid provenance.
+      - name: Attest build provenance
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "Panel de Control.zip"
+
       - name: Upload zip to the release
         if: ${{ steps.release.outputs.release_created }}
         env:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+project maintainer at [@Hooandee](https://github.com/Hooandee).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to Panel de Control
+
+Thanks for your interest in improving Panel de Control! This document explains how to
+set up the project, the quality bar for changes, and how releases work.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- For **bugs** and **feature ideas**, open an issue first so we can discuss scope.
+- For **security vulnerabilities**, do **not** open a public issue — follow the
+  [Security Policy](SECURITY.md).
+- Small fixes (typos, obvious bugs) are welcome as direct PRs.
+
+## Project layout
+
+- `src/` — TypeScript + React frontend (Decky standard).
+- `py_modules/` + `main.py` — Python backend, exposed to the frontend via Decky RPC.
+- `tests/` — Python tests (pytest). Frontend logic tests live next to the code
+  (`*.test.ts`, run with vitest).
+
+## Development setup
+
+Toolchain: **pnpm 10**, **Node 20**, **Python 3.11**.
+
+```sh
+# Frontend deps
+pnpm install --frozen-lockfile
+
+# Backend dev deps (into a virtualenv is recommended)
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+## The quality gate
+
+Every change must pass the full gate before it can be merged. Run it locally:
+
+```sh
+# Frontend
+pnpm typecheck
+pnpm test:fe
+pnpm build            # must produce dist/index.js
+
+# Backend
+ruff check py_modules main.py tests
+python -m pytest
+```
+
+CI runs the same checks on every push and pull request.
+
+### Principles
+
+- **Never fake success.** If a hardware write, daemon call, or sysfs read fails, the
+  UI must reflect that honestly — do not show a value the hardware never accepted.
+- **Degrade gracefully.** Code that talks to hardware or system daemons should never
+  raise into the UI; return a safe/empty result instead.
+- **Test the logic.** Pure logic (curve math, parsing, decision loops) is unit-tested;
+  hardware access is behind small, injectable seams so it can be tested with fakes.
+
+## Commit messages & releases
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) with
+[release-please](https://github.com/googleapis/release-please). The commit prefix
+drives versioning:
+
+- `feat:` → minor release
+- `fix:` → patch release
+- `feat!:` or a `BREAKING CHANGE:` footer → major release
+- `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `style:` → **no release**
+
+Merging to `main` automatically maintains a release PR; merging that PR tags the
+version, builds the plugin zip, signs it with build provenance, and attaches it to the
+GitHub release.
+
+## Pull request checklist
+
+- The full gate above passes.
+- Commit messages follow Conventional Commits.
+- No secrets or personal data are included.
+- New third-party dependencies are recorded in
+  [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) with their license.
+- If you can, note which device(s) you tested on.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[BSD-3-Clause License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,76 @@
 # Panel de Control
 
-The ultimate control center for handheld gaming PCs. Configure TDP, fan curves and more from a
-beautiful, easy-to-use Decky panel. Spanish-first, with English support.
+The ultimate control center for handheld gaming PCs — configure TDP, fan curves, the
+display, the battery and controllers from a beautiful, easy-to-use
+[Decky Loader](https://decky.xyz/) panel. Spanish-first, with English support.
 
-## Status
-Early development.
+> [!WARNING]
+> This plugin runs with **root privileges** and changes low-level power, thermal, and
+> firmware settings on your device. It talks only to documented kernel interfaces and
+> is designed to fail safe, but you use it **at your own risk**. There is no warranty
+> (see the [LICENSE](LICENSE)).
+
+## Features
+
+- **Potencia** — per-device TDP control with a live power gauge, per-game profiles,
+  advanced PL1/SPPT/FPPT boost, and an optional GPU-driven auto-TDP.
+- **Ventiladores** — live fan/temperature monitor plus a temp→fan curve editor with
+  presets and learned suggestions (per device; honestly hidden where the firmware
+  doesn't allow it).
+- **Sistema** — brightness, volume, battery (health, cycles, charge limit), CPU
+  (SMT / turbo), a low-power "download" mode, and RGB via the companion Colores plugin.
+- **Pantalla** — panel color calibration (saturation / temperature / contrast).
+- **Mandos** — cooperative controller remapping that works alongside the device's
+  resident controller daemon.
+
+## Supported devices
+
+Steam Deck (LCD / OLED), ROG Ally · Ally X · Xbox Ally X, Legion Go · Go S · Go 2,
+and the MSI Claw 8 AI+. Unrecognized hardware falls back to a generic profile, and
+each control is hidden when the device doesn't support it.
+
+## Installation
+
+Panel de Control is distributed outside the Decky store. Install [Decky Loader](https://decky.xyz/)
+first, then:
+
+1. Download `Panel de Control.zip` from the [latest release](https://github.com/Hooandee/panel-de-control/releases/latest).
+2. In Decky, use **Developer Mode → Install Plugin from ZIP** (or your preferred manual
+   install method).
+
+Once installed, the plugin can update itself from within its settings.
+
+### Verifying a download (recommended)
+
+Every release zip is signed with build provenance. Confirm it really came from this
+repository's pipeline before installing:
+
+```sh
+gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
+```
+
+## Building from source
+
+Toolchain: **pnpm 10**, **Node 20**, **Python 3.11**.
+
+```sh
+pnpm install --frozen-lockfile
+pnpm build          # produces dist/index.js
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full test gate and development setup.
+
+## Contributing
+
+Contributions are welcome — please read [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+Found a vulnerability? Please report it privately — see the
+[Security Policy](SECURITY.md). Do not open a public issue.
+
+## License
+
+[BSD-3-Clause](LICENSE) © Hooandee. Third-party attributions are listed in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+Panel de Control is a Decky Loader plugin that runs with **root privileges** on the
+device (it reads and writes kernel `sysfs` interfaces to control TDP, fans, the
+display, the battery and controllers). Because of that, security is taken seriously.
+Thank you for helping keep users safe.
+
+## Supported versions
+
+Only the **latest released version** receives security fixes. Please update before
+reporting — the issue may already be fixed.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.**
+
+Report privately through GitHub's built-in advisory flow:
+
+- Go to the repository's **Security** tab → **Report a vulnerability**, or
+- Open <https://github.com/Hooandee/panel-de-control/security/advisories/new>
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept if possible).
+- The affected version, device, and OS.
+
+### What to expect
+
+- Acknowledgement within 7 days.
+- An initial assessment and, where applicable, a target fix timeline.
+- Credit in the release notes when a fix ships, unless you prefer to remain anonymous.
+- Please allow a reasonable window to release a fix before any public disclosure
+  (coordinated disclosure).
+
+## Verifying release integrity
+
+Every release artifact (`Panel de Control.zip`) is built by the pinned
+`release-please` workflow and signed with **build provenance** (Sigstore, via GitHub
+Artifact Attestations). Before trusting a downloaded release you can verify it came
+from this repository's pipeline and was not tampered with:
+
+```sh
+gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
+```
+
+A zip published outside the official pipeline will not have valid provenance.
+
+## Security model & notes
+
+- **Runs as root.** The plugin's Python backend runs as `root` under Decky. It only
+  touches documented kernel interfaces and never grabs input devices directly.
+- **Self-update.** The plugin can update itself by downloading the latest GitHub
+  release over TLS (certificate-verified) from this repository only, then installing
+  it in place. User settings are stored separately and are not overwritten.
+- **No telemetry leaves the device.** Usage learning ("Aprender de mi uso") is stored
+  locally, is opt-out, and is never transmitted.
+- **External processes** (`systemctl`, `busctl`, `python3`, …) are invoked with
+  absolute paths, argument lists (never a shell), and a scrubbed environment.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,43 @@
+# Third-Party Notices
+
+Panel de Control is licensed under the [BSD-3-Clause License](LICENSE).
+
+This file lists the third-party work the project builds on. Two categories:
+
+1. **Referenced projects** — we studied their approach or use documented, public
+   hardware interfaces (kernel `sysfs` paths, daemon APIs). Interfaces and facts are
+   not copyrightable; attribution here is given as courtesy and for transparency. No
+   source code from these projects is copied into this repository.
+2. **Bundled dependencies** — code that is redistributed inside the built plugin.
+
+If you believe attribution is missing or incorrect, please open an issue.
+
+## Referenced projects (approach / hardware interfaces)
+
+| Project | License | What we reference |
+| --- | --- | --- |
+| [SteamDeckHomebrew/decky-plugin-template](https://github.com/SteamDeckHomebrew/decky-plugin-template) | BSD-3-Clause | Project scaffold. |
+| [SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP) | BSD-3-Clause | TDP mechanism reference (firmware-attributes paths, per-device approach). |
+| [Handheld Daemon (hhd)](https://github.com/hhd-dev/hhd) | LGPL-2.1 | Per-device strategy, resume/AC re-apply concepts; its localhost REST API for cooperative control. Approach/interface only — no LGPL code copied. |
+| [RyzenAdj](https://github.com/FlyGoat/RyzenAdj) | LGPL-3.0 | Generic AMD TDP fallback. Invoked as an external subprocess when present; **not** bundled in this repository and not linked into our code. If a future release bundles the binary, RyzenAdj's LGPL-3.0 license text will be shipped alongside it. |
+| [PowerControl](https://github.com/mengmeet/PowerControl) | See project | Upstream of the Lenovo firmware-attributes path (chain credit). |
+| [LegionGoRemapper](https://github.com/aarron-lee/LegionGoRemapper) | See project | Controller/remap reference for Legion devices. |
+| [InputPlumber](https://github.com/ShadowBlip/InputPlumber) | See project | SteamOS controller daemon. We cooperate with it over its D-Bus interface; no code copied. |
+| [PowerTools](https://git.ngni.us/NG-SD-Plugins/PowerTools) | See project | Resume/re-apply concepts (idea only). |
+| [Fantastic](https://git.ngram.ca/NG-SD-Plugins/Fantastic) | See project | Fan monitor/curve approach. Fans/temps read via the kernel `hwmon` ABI (facts). |
+| Linux kernel ABI docs | Documentation | `sysfs` interfaces: `firmware-attributes`, `powercap`, `hwmon`, `power_supply`, `cpufreq`, and vendor WMI paths. |
+
+## Bundled runtime dependencies
+
+The built plugin (`dist/index.js`) bundles the following runtime packages:
+
+| Package | License |
+| --- | --- |
+| [@decky/api](https://github.com/SteamDeckHomebrew/decky-frontend-lib) | BSD-3-Clause |
+| [react-icons](https://github.com/react-icons/react-icons) | MIT |
+| [tslib](https://github.com/microsoft/tslib) | 0BSD |
+| React / React-DOM (provided by the Decky runtime) | MIT |
+
+Development-only tooling (TypeScript, Rollup, Vitest, Ruff, pytest, `@decky/ui`,
+`@decky/rollup`, type stubs) is not redistributed and is listed in `package.json`
+and `requirements-dev.txt`.


### PR DESCRIPTION
Prepares the repository to go public safely. Every push to `main` auto-releases a
zip that the plugin installs **as root** on users' devices, so the CI/release
pipeline and the account are the highest-value targets. This PR closes the main
supply-chain gaps and adds the standard community files.

### Supply-chain hardening
- **Pin every GitHub Action to a full commit SHA** (with a version comment). Mutable
  tags like `@v7` can be re-pointed at malicious code; SHAs cannot. Dependabot keeps
  them current.
- **Least-privilege workflow tokens.** CI is `contents: read`; `release-please` grants
  writes only on its own job. `persist-credentials: false` on all checkouts.
- **Build provenance on releases.** The release zip is signed with Sigstore via GitHub
  Artifact Attestations, so a download can be verified end-to-end:
  `gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control`.
- **Reproducible prerelease build** (`--frozen-lockfile`).
- **Dependabot** for actions, npm and pip. Its commits use `ci:`/`chore:` prefixes so
  dependency bumps never auto-cut a release.

### Community health
- `SECURITY.md` — private vulnerability reporting + release verification.
- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- Issue forms (bug/feature) with a device picker, issue config, PR template.
- `THIRD_PARTY_NOTICES.md` — attribution for referenced projects and bundled deps.
- Expanded `README.md` with a root-privilege safety notice, supported devices,
  install and verification instructions.

These commits use non-releasing prefixes (`ci:`, `docs:`), so merging will not cut a
release on its own.