### PR TITLE
fix: spawn modprobe (MSI) and gamescopectl (color) via clean_env + absolute path

### DIFF
--- a/py_modules/display/gamescope.py
+++ b/py_modules/display/gamescope.py
@@ -67,8 +67,14 @@ def is_native(state):
 
 def _run(args, env):
     try:
-        p = subprocess.run(args, capture_output=True, text=True, timeout=5,
-                           env={**os.environ, **env})
+        # Resolve the binary absolutely + start from clean_env (restores the
+        # pre-bundle LD_LIBRARY_PATH + a sane PATH that Decky's frozen loader
+        # strips), then overlay the caller's Wayland env (XDG_RUNTIME_DIR /
+        # WAYLAND_DISPLAY). Same spawn hygiene as the controller/fan backends.
+        from controllers.detect import clean_env, resolve_bin
+        argv = [resolve_bin(args[0]), *args[1:]]
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=5,
+                           env={**clean_env(), **env})
         return p.returncode, (p.stdout or "")
     except (OSError, subprocess.SubprocessError):
         return 1, ""

--- a/py_modules/fans/control.py
+++ b/py_modules/fans/control.py
@@ -330,8 +330,13 @@ class MsiFanCurveBackend(HwmonCurveBackend):
         if root == "/" and _is_msi_vendor(root):
             try:
                 import subprocess
-                subprocess.run(["modprobe", "msi_wmi_platform"],
-                               check=False, capture_output=True, timeout=5)
+                # Decky's PyInstaller-frozen loader gives the child an empty PATH +
+                # a poisoned LD_LIBRARY_PATH → a bare "modprobe" silently fails and
+                # the msi_wmi_platform chip never appears. Resolve to an absolute
+                # path + clean_env (same fix as fans/expose.py and software_loop).
+                from controllers.detect import clean_env, resolve_bin
+                subprocess.run([resolve_bin("modprobe"), "msi_wmi_platform"],
+                               check=False, capture_output=True, timeout=5, env=clean_env())
             except Exception:  # noqa: BLE001
                 pass
         super().__init__(_MSI_CHIP, n_points=6, fixed_temps=_MSI_TEMPS, root=root)


### PR DESCRIPTION
Two more subprocess spawns hit the PyInstaller-frozen-loader trap we already fixed for `systemctl` (Deck) and `modprobe` (Legion Go S) — bare binary name + poisoned `LD_LIBRARY_PATH`/empty `PATH`. Routed both through `controllers.detect.clean_env()` + `resolve_bin()`:

- **`fans/control.py`** — `modprobe msi_wmi_platform` on the **MSI Claw**. Under the frozen loader the bare spawn silently fails; if the module isn't autoloaded, the Claw fan chip never appears → empty fan monitor. (Guarded to MSI devices; `except: pass` masked it.)
- **`display/gamescope.py`** — `gamescopectl` for panel color (all color-capable devices). Was the only spawn still inheriting the poisoned env; `clean_env()` preserves the caller's Wayland env (`XDG_RUNTIME_DIR`/`WAYLAND_DISPLAY`) and only fixes `PATH`/`LD_LIBRARY_PATH`.

Both changes are behavior-preserving on a normal env (clean_env keeps all other vars; resolve_bin falls back to the bare name), and strictly more robust under the frozen loader.

Gate: ruff · 605 pytest · typecheck · build — green.