### PR TITLE
style: smaller Auto-TDP "Experimental" pill with more label spacing

### DIFF
--- a/src/components/AutoTdpToggle.tsx
+++ b/src/components/AutoTdpToggle.tsx
@@ -17,12 +17,12 @@ interface Props {
 export const AutoTdpToggle: FC<Props> = ({ checked, onChange }) => {
   const { t } = useI18n();
   const label = (
-    <span style={{ display: "inline-flex", alignItems: "center", gap: theme.space.xs }}>
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
       {t("tdp.auto.title")}
       <span
         style={{
-          fontSize: theme.font.caption,
-          padding: "1px 6px",
+          fontSize: 10,
+          padding: "1px 5px",
           borderRadius: 999,
           color: theme.color.warn,
           boxShadow: `inset 0 0 0 1px ${theme.color.warn}`,


### PR DESCRIPTION
Minor Potencia polish: the Auto-TDP "Experimental" badge is a touch smaller (font 11→10, padding 6→5px) with a bit more gap from the label (4→6px). Eyeball-approved on the ROG Ally X.