### PR TITLE
chore: limpieza de comentarios

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,9 +47,9 @@ _AUTO_WINDOW = 10
 
 DEFAULTS = {
     # Persisted settings keys go here; SettingsStore merges these over stored values.
-    # (TDP per-game profiles will live in their own store in the TDP sub-project.)
+    # (Per-game TDP profiles live in their own store, tdp_profiles.py.)
     "auto_tdp": False,
-    # Learn from usage (local-only telemetry powering F3 suggestions). Opt-out:
+    # Learn from usage (local-only telemetry powering fan-curve suggestions). Opt-out:
     # when False the sampler never runs — nothing is read or written during play.
     "telemetry_enabled": True,
     # Opt-in: raise the on-battery TDP ceiling to the firmware/charger max. Default
@@ -84,7 +84,7 @@ DEFAULTS = {
 
 
 class Plugin:
-    # A1: re-fit + re-apply the learned fan curve every this-many collected in-game
+    # Re-fit + re-apply the learned fan curve every this-many collected in-game
     # samples. The sampler ticks every 5 s only while in-game, so 360 × 5 s ≈ 30 min
     # of ACTUAL play — matching the telemetry histogram's ~30 min decay half-life so
     # the curve tracks the current thermal "zone" without explicit zone detection.
@@ -173,7 +173,7 @@ class Plugin:
         self._telemetry = TelemetryStore(
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "telemetry.json")
         )
-        # A1: count in-game samples toward the periodic adaptive re-fit.
+        # count in-game samples toward the periodic adaptive re-fit.
         self._reapply_ticks = 0
         # Whether the adaptive curve has been driven THIS session (per game). Lets the
         # mid-session drive fire the moment `enough_data` flips true instead of waiting
@@ -428,7 +428,7 @@ class Plugin:
         self._reapply_fans()
         return self._fan_curve_state()
 
-    # ---- Fan-curve suggestion (F3 brain over local telemetry) ---------------
+    # ---- Fan-curve suggestion (suggestion brain over local telemetry) -------
     def _fan_suggestion(self, appid=None) -> dict:
         """Suggest a fan curve fit to a game's observed temperature band (sync core).
 
@@ -482,7 +482,7 @@ class Plugin:
         return self._fan_suggestion(appid)
 
     def _drive_adaptive_fan_curve(self, *, reapply: bool) -> None:
-        """Drive the learned curve when the effective mode is Adaptive (never-fake).
+        """Drive the learned curve when the effective mode is Adaptive.
 
         Adaptive is a stateless MODE — it stores no points; the curve is computed
         live from telemetry here. Choosing the mode IS the opt-in, so the only guards
@@ -496,14 +496,14 @@ class Plugin:
           only when the fit shifted appreciably (anti-churn vs the last driven curve).
 
         Cheap O(1) guards (running game + adaptive mode) run FIRST so the histogram is
-        never walked otherwise. Never raises; never fakes an apply."""
+        never walked otherwise. Never raises; never applies a fabricated curve."""
         try:
             appid = self._current_appid
             if appid is None or not self._fan_curves.is_adaptive(appid):
                 return
             points = self._adaptive_curve_points(appid)
             if points is None:
-                return  # not enough real data yet → firmware auto stays (never-fake)
+                return  # not enough real data yet → firmware auto stays
             if reapply and not fan_suggest.curve_changed(self._last_adaptive_points, points):
                 return  # nothing worth re-driving → no thermal/eMMC churn
             self._last_adaptive_points = points
@@ -518,7 +518,7 @@ class Plugin:
         self._drive_adaptive_fan_curve(reapply=False)
 
     def _maybe_reapply_adaptive_fan_curve(self) -> None:
-        """A1: periodically (every ~30 min of play) re-fit and re-drive the adaptive
+        """Periodically (every ~30 min of play) re-fit and re-drive the adaptive
         curve so it follows the game's RECENT thermal pattern (the histogram decays)."""
         self._drive_adaptive_fan_curve(reapply=True)
 
@@ -575,7 +575,7 @@ class Plugin:
             return None
 
     def _on_sample_collected(self, result) -> None:
-        """Sampler callback after each stored sample (A1 re-apply cadence).
+        """Sampler callback after each stored sample (re-apply cadence).
 
         *result* is the (appid, sample) tuple that was stored, or None when idle.
         Idle ticks don't count — the counter reflects real play time. Every
@@ -680,7 +680,7 @@ class Plugin:
     async def set_qam_tdp_boost(self, enabled: bool) -> bool:
         """Opt in/out of raising PL1 while the QAM is open. When turning OFF while the
         UI is open we do NOT force PL1 back down — the auto loop will settle it to the
-        real in-game value on its next tick (never fake, no jarring drop)."""
+        real in-game value on its next tick (no jarring drop)."""
         self._init()
         enabled = bool(enabled)
         self._settings["qam_tdp_boost"] = enabled
@@ -725,7 +725,7 @@ class Plugin:
         + temporal gate = no sawtooth), stepping up on GPU saturation and down after
         sustained GPU headroom. Watts/boost are NOT used for the decision — on a
         power-limited game the draw follows PL1, so any draw signal is confounded
-        (measured on-device: 35 W cap / 80% GPU held at max forever). The learned
+        (a 35 W cap with the GPU at 80% would hold at max forever). The learned
         band never caps it. Degrades to HOLD on devices without gpu_busy (Claw)."""
         while True:
             try:
@@ -772,7 +772,7 @@ class Plugin:
         where the auto loop would otherwise park it — so the UI can honestly say
         "this number is raised for the menu, not the in-game value". False when the
         game already demands >= the responsive floor (the number IS the in-game one),
-        or when not auto / no game / UI closed. Never-fake: don't claim a raise that
+        or when not auto / no game / UI closed. Don't claim a raise that
         isn't happening."""
         if not (self._qam_boost_active() and self._current_appid is not None
                 and bool(self._settings.get("auto_tdp"))):
@@ -884,7 +884,7 @@ class Plugin:
     def _active_max(self, limits, ac: bool) -> int:
         return limits.max_ac_w if ac else limits.max_w
 
-    # ---- Learned TDP band (G2) ----------------------------------------------
+    # ---- Learned TDP band ---------------------------------------------------
     def _tdp_learned_info(self, appid=None) -> dict:
         """Display-facing learned-band info for a game (honest reasons).
 
@@ -958,7 +958,7 @@ class Plugin:
             # the UI can state it explicitly (e.g. "caps at 80%").
             percent = fixed
         elif enabled and self._charge_limit.supported and self._charge_limit.adjustable:
-            # never-fake: report what the firmware actually holds (it may clamp our write).
+            # report what the firmware actually holds (it may clamp our write).
             actual = self._charge_limit.get()
             if actual is not None:
                 percent = actual
@@ -1000,7 +1000,7 @@ class Plugin:
     def _clear_eco(self) -> None:
         """Manual control taken → exit download mode and restore the normal TDP/boost
         state. Brightness is NOT touched here (FE-only; the persistent controller
-        stops driving it and the user keeps whatever they set). B1 in the design."""
+        stops driving it and the user keeps whatever they set)."""
         if self._settings.get("eco_enabled"):
             self._settings["eco_enabled"] = False
             self._save()
@@ -1353,7 +1353,7 @@ class Plugin:
         self._init()
         self._current_appid = str(appid) if appid is not None else None
         self._reset_auto_windows()  # don't let the previous game's signal gate the new one
-        self._reapply_ticks = 0        # A1: fresh ~30 min re-fit window for the new game
+        self._reapply_ticks = 0        # fresh ~30 min re-fit window for the new game
         self._adaptive_applied = False  # re-arm the mid-session adaptive drive for this game
         self._last_adaptive_points = None  # anti-churn baseline resets with the game
         # Auto-TDP no longer seeds PL1 from the learned band: the loop is band-decoupled

--- a/py_modules/auto_tdp.py
+++ b/py_modules/auto_tdp.py
@@ -4,9 +4,9 @@ Converges on the "knee" (the least sustained PL1 that keeps the GPU just below
 saturation) and HOLDS there. Deliberately does NOT use real watts or boost: when a
 game is power-limited the draw simply follows PL1 (it eats the whole budget across
 CPU+GPU), so EVERY draw-derived signal — boost magnitude, boost frequency, watts
-headroom — is confounded and can't tell "has margin" from "needs it". Measured
-on-device (ROG Ally): pl1=35 (cap), draw=35 W (pinned), GPU=80% stable → the
-watts/boost model saw "no headroom" and held at max forever, yet 80% GPU means
+headroom — is confounded and can't tell "has margin" from "needs it": a power-limited
+game pinned at max PL1 draws the full budget with the GPU stable at ~80%, which the
+watts/boost model reads as "no headroom" and holds at max forever — yet 80% GPU means
 there IS margin. GPU utilisation is the only honest "can it go lower?" signal.
 
 Signals kept: GPU% only. Watts/boost are dropped from the control decision.
@@ -27,7 +27,7 @@ Three states:
 
 Degradation:
   - GPU% available (AMD Ally/Legion, Steam Deck): the model above.
-  - No GPU% (Intel Claw today: no gpu_busy): HOLD — can't optimise blind, no fake.
+  - No GPU% (Intel Claw today: no gpu_busy): HOLD — can't optimise blind.
 """
 
 # Responsive floor (watts) applied ONLY while the QAM / plugin UI is open. The loop
@@ -35,7 +35,7 @@ Degradation:
 # the GPU) — but rendering the QAM is CPU-bound (steamwebhelper/CEF) and a starved
 # PL1 makes the menu lag. Raising the loop's floor while the UI is open keeps
 # interacting fluid; on close it drops back to device_min for battery. Device-aware
-# (never below device_min). Tunable (on-device: 7 W lags, 15 W fluid → ~13 W).
+# (never below device_min). Tunable (~13 W: lower lags the menu, higher wastes battery).
 RESPONSIVE_FLOOR_W = 13
 
 _UP_GPU = 97       # a recent GPU% peak at/above this = saturated → step up (safety)

--- a/py_modules/battery/charge_limit.py
+++ b/py_modules/battery/charge_limit.py
@@ -49,7 +49,7 @@ class _FileChargeLimit(ChargeLimitBackend):
     """A single sysfs file holding the cap percent. Subclasses locate the file and
     define the 'no limit' sentinel (`_OFF`) written on disable. Writing needs root
     (the plugin runs as root); every `set`/`disable` reads back to confirm the
-    write stuck (never-fake)."""
+    write stuck."""
 
     _OFF = _MAX
 
@@ -97,7 +97,7 @@ class SysfsChargeLimit(_FileChargeLimit):
 
 class SteamDeckChargeLimit(_FileChargeLimit):
     """Steam Deck `steamdeck_hwmon/max_battery_charge_level`. 0 = no cap (distinct
-    from the ASUS/Lenovo 100). Validated on-device (OLED)."""
+    from the ASUS/Lenovo 100)."""
 
     _OFF = 0
 
@@ -117,7 +117,7 @@ class SteamDeckChargeLimit(_FileChargeLimit):
 
 class LenovoConservationMode(ChargeLimitBackend):
     """Lenovo (Legion Go) `conservation_mode`: a boolean (1=cap on) with a
-    firmware-fixed threshold, NOT a settable percent. Validated on Legion Go 2.
+    firmware-fixed threshold, NOT a settable percent.
     `adjustable=False` → the UI shows an on/off toggle (no slider) and states the
     fixed cap (`fixed_percent`, the Legion Go conservation level ≈80%)."""
 
@@ -146,7 +146,7 @@ class LenovoConservationMode(ChargeLimitBackend):
         return None
 
     def get(self):
-        return None  # firmware-fixed threshold; percent unknown (never-fake)
+        return None  # firmware-fixed threshold; percent unknown
 
     def set(self, percent):
         if not self.supported:

--- a/py_modules/controllers/conflict.py
+++ b/py_modules/controllers/conflict.py
@@ -3,7 +3,7 @@
 HHD's TDP plugin (master toggle `hhd.settings.tdp_enable`, which also owns its
 fan curve) writes the same firmware power rails Panel de Control does; when both
 are active they fight (last-writer-wins → jitter). We only WARN — never touch
-HHD's settings (the user decided that boundary) — and let the user disable one.
+HHD's settings — and let the user disable one.
 """
 
 

--- a/py_modules/controllers/dbus.py
+++ b/py_modules/controllers/dbus.py
@@ -1,6 +1,6 @@
 """Thin busctl driver for InputPlumber (no python-dbus dependency; busctl ships
 with systemd). Discovers the composite-device object path dynamically. Every call
-degrades to a safe empty/False on failure — never raises, never fakes.
+degrades to a safe empty/False on failure — never raises.
 """
 import json
 import re

--- a/py_modules/controllers/hhd.py
+++ b/py_modules/controllers/hhd.py
@@ -4,7 +4,7 @@ HHD serves its full settings tree + live state at http://127.0.0.1:5335, the
 same interface its own frontend uses. Reading it lets us detect the power
 conflict (M0) and, cooperatively, drive the controller settings (later
 milestones). Token lives at /etc/hhd/.token (world-unreadable → we run as root).
-Every call degrades to None on failure — never fake, never raise.
+Every call degrades to None on failure — never raises.
 """
 import json
 import os

--- a/py_modules/controllers/inputplumber.py
+++ b/py_modules/controllers/inputplumber.py
@@ -14,7 +14,7 @@ def get_config(store, dbus, device_key, caps=None) -> dict:
     """The device's remappable physical buttons (per-device silkscreen table, gated
     by the live capabilities) + each one's current override (or None = still at the
     device default) + the target vocabulary the UI offers. `device_known` is False
-    for a device we haven't validated on-hardware, so the UI can say so honestly
+    for a device we don't have a button map for, so the UI can say so honestly
     instead of showing phantom buttons. `caps` lets a caller that already read the
     live capabilities (set_button) avoid a second `busctl` spawn."""
     if caps is None:
@@ -54,7 +54,7 @@ def _apply_overrides(dbus, overrides: dict, merge=merge_profile) -> bool:
 def set_button(store, dbus, device_key, source: str, targets: list, merge=merge_profile) -> dict:
     """Remap one physical button. Ignores a source that isn't one of THIS device's
     remappable buttons; empty/invalid targets revert the button to its device
-    default. Never-fake: the store is only updated if the daemon ACTUALLY applied the
+    default. The store is only updated if the daemon ACTUALLY applied the
     profile, so the reported config can't show a remap the hardware never took."""
     caps = dbus.capabilities()  # read once — reused for the guard and the returned config
     valid = {cap for (cap, _label) in ip_profile.buttons_for(device_key, caps)}
@@ -73,7 +73,7 @@ def set_button(store, dbus, device_key, source: str, targets: list, merge=merge_
 
 def reset(store, dbus, device_key=None) -> dict:
     """Reload InputPlumber's shipped default profile; only forget the overrides if it
-    actually reset (never-fake)."""
+    actually reset."""
     if dbus.reset_default():
         store.reset()
     return get_config(store, dbus, device_key)

--- a/py_modules/controllers/ip_profile.py
+++ b/py_modules/controllers/ip_profile.py
@@ -2,15 +2,15 @@
 their silkscreen name), and how to apply an override without clobbering the
 device's default mappings.
 
-Design (validated ON-DEVICE, 2026-07-04):
+Design:
 - The remappable buttons come from a PER-DEVICE table (DEVICE_BUTTONS), NOT from the
   daemon's live Capabilities. Capabilities is a superset with phantoms (the Go 2
   advertises paddle caps no physical button emits) and it can't tell you the
   silkscreen name (M1 is reported as `RightStickTouch`); the SAME capability is a
   different physical button per device (LeftPaddle1 = Go2 "Y1" but Claw "M2"). So
-  each entry maps a source capability to the literal silkscreen label, validated by
-  pressing every button on real hardware. The table is intersected with the live
-  capability set (defensive — never surface a button the daemon doesn't report).
+  each entry maps a source capability to the literal silkscreen label. The table is
+  intersected with the live capability set (defensive — never surface a button the
+  daemon doesn't report).
 - Applying an override PRESERVES the device's default profile: we read the current
   profile, replace only the edited button's target, and load it back. The YAML
   round-trip runs in the SYSTEM python (which has PyYAML) via subprocess — Decky's
@@ -18,20 +18,20 @@ Design (validated ON-DEVICE, 2026-07-04):
   it's unit-tested; only load()/dump() live in the system-python helper.
 """
 
-# The remappable PHYSICAL buttons per device, validated ON-DEVICE (2026-07-04) by
-# pressing each one and reading the source capability it emits. This is a
-# per-device table, NOT derived from the daemon's Capabilities property, because:
+# The remappable PHYSICAL buttons per device, each mapping the source capability a
+# button emits to its silkscreen label. This is a per-device table, NOT derived from
+# the daemon's Capabilities property, because:
 #   - Capabilities is a SUPERSET with phantoms (the Go 2 lists LeftPaddle3/
 #     RightPaddle3 that no physical button emits) — deriving from it showed ghosts;
 #   - the SAME capability is a DIFFERENT physical button per device (LeftPaddle1 is
 #     the Go 2's "Y1" but the Claw's "M2") — labels must be per-device;
 #   - a capability's normalized name (RightStickTouch) rarely matches the silkscreen
-#     label the user reads (M1) — the user wants the silkscreen name.
+#     label printed on the device (M1).
 # ONLY the grip/paddle buttons are listed: system buttons (Guide/QuickAccess/
 # QuickAccess2/Keyboard) are deliberately omitted — remapping them breaks Steam/QAM
 # navigation. Each entry is (source_capability, silkscreen_label). Labels are the
 # literal names printed on the device and are NOT translated. An unlisted device
-# degrades to an empty (honest) button list — never invents a mapping.
+# degrades to an empty button list — never invents a mapping.
 DEVICE_BUTTONS = {
     "legion_go_2": [
         ("LeftPaddle1", "Y1"), ("LeftPaddle2", "Y2"), ("RightPaddle1", "Y3"),
@@ -82,7 +82,7 @@ def buttons_for(device_key, capabilities) -> list:
     in display order. The per-device table is the source of truth for which buttons
     and what to call them; it's intersected with the LIVE capability set so we only
     surface a button the daemon actually reports (defensive — never invent one). An
-    unknown device (not in the validated table) yields an empty list."""
+    unknown device (not in the table) yields an empty list."""
     have = _capability_names(capabilities)
     return [
         (cap, label)
@@ -92,12 +92,12 @@ def buttons_for(device_key, capabilities) -> list:
 
 
 def is_known_device(device_key) -> bool:
-    """Whether we have an on-device-validated button map for this device."""
+    """Whether we have a known button map for this device."""
     return device_key in DEVICE_BUTTONS
 
 
 def sanitize_target(target: dict):
-    """Coerce one target to {"gamepad"|"key": name}, or None if invalid (never-fake)."""
+    """Coerce one target to {"gamepad"|"key": name}, or None if invalid."""
     if not isinstance(target, dict):
         return None
     if target.get("gamepad") in GAMEPAD_TARGETS:

--- a/py_modules/cpu/controls.py
+++ b/py_modules/cpu/controls.py
@@ -10,7 +10,7 @@ _CPU = "sys/devices/system/cpu"
 class SmtControl:
     """Simultaneous multi-threading via `cpu/smt/control` (on/off/forceoff/
     notsupported). Generic across AMD/Intel. Writing needs root; set() reads back
-    to confirm (never-fake)."""
+    to confirm."""
 
     def __init__(self, root="/"):
         self._path = os.path.join(root, _CPU, "smt", "control")
@@ -51,7 +51,7 @@ class AmdBoost(_Boost):
     def __init__(self, root="/"):
         self._path = os.path.join(root, _CPU, "cpufreq", "boost")
         # Gate on a successful READ (not mere existence) so an unreadable node isn't
-        # mis-reported as boost-off (never-fake), matching SmtControl.
+        # mis-reported as boost-off, matching SmtControl.
         self.supported = read_int(self._path) is not None
 
     def enabled(self):
@@ -98,8 +98,8 @@ class CoreControl:
     independent of the SMT toggle. cpu0 has no `online` node (the kernel forbids
     offlining it) → its core is always kept, so the minimum is 1 core.
 
-    Writing needs root. `set()` reads the result back (never-fake): if the kernel
-    clamps a write, the reported active count reflects reality, not the request."""
+    Writing needs root. `set()` reads the result back: if the kernel clamps a write,
+    the reported active count reflects reality, not the request."""
 
     def __init__(self, root="/"):
         self._base = os.path.join(root, _CPU)

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -16,11 +16,10 @@ class DeviceProfile:
     match_names: tuple = field(default_factory=tuple)
     is_generic: bool = False
     # Panel technology. "oled" hides the "OLED look" color preset (a real OLED has
-    # nothing to emulate). VERIFY ON-DEVICE if unsure — a wrong guess only shows/hides
-    # a cosmetic button, never anything unsafe.
+    # nothing to emulate). A wrong guess only shows/hides a cosmetic button.
     panel: str = "lcd"
     # Optional per-model calibrated "OLED look" color state. None => the generic look
-    # (display.oled_look.GENERIC_OLED_LOOK). Fill in only VALUES VALIDATED ON-DEVICE.
+    # (display.oled_look.GENERIC_OLED_LOOK).
     oled_look: Optional[dict] = None
 
 

--- a/py_modules/display/gamescope.py
+++ b/py_modules/display/gamescope.py
@@ -1,14 +1,12 @@
 """gamescope color control via a generated 3D LUT + `gamescopectl set_look`.
 
-VALIDATED ON-DEVICE (ROG Ally, gamescope 3.16, 2026-07-03): the classic vibrantDeck
-X-atom path is dead on modern (Wayland) gamescope — xprop can't reach the X server.
-The working mechanism is a `.cube` 3D LUT loaded through gamescope's Wayland control
-socket: `XDG_RUNTIME_DIR=/run/user/<uid> WAYLAND_DISPLAY=gamescope-0 gamescopectl
-set_look <file>` (root can drive it; a grayscale LUT visibly desaturated the panel).
+The classic vibrantDeck X-atom path is dead on modern (Wayland) gamescope — xprop
+can't reach the X server. The working mechanism is a `.cube` 3D LUT loaded through
+gamescope's Wayland control socket: `XDG_RUNTIME_DIR=/run/user/<uid>
+WAYLAND_DISPLAY=gamescope-0 gamescopectl set_look <file>` (needs root).
 
-The color MATH (transform/build_cube) is pure and unit-tested; the socket discovery
-+ subprocess call is the thin device layer. Probe-gated: unsupported (UI hidden) when
-no gamescope socket answers."""
+The color transform (transform/build_cube) is pure; the socket discovery + subprocess
+call is the thin device layer. Unsupported (UI hidden) when no gamescope socket answers."""
 import glob
 import os
 import subprocess

--- a/py_modules/display/oled_look.py
+++ b/py_modules/display/oled_look.py
@@ -7,20 +7,19 @@ vibrancy, slightly punchier gamma). The UI copy must say "acerca el color al de 
 OLED", never "convierte en OLED".
 
 `GENERIC_OLED_LOOK` is a conservative, safe enhancement applied to any LCD. A model
-can carry its own `oled_look` (calibrated ON-DEVICE) to override the generic one.
+can carry its own calibrated `oled_look` to override the generic one.
 """
 
 # Universal LCD enhancement toward the OLED look: a clear vibrancy boost + a
 # contrast lift (the real differentiator — OLED's deep blacks read as "pop"),
 # neutral temperature. Punchy enough to be obviously different, still tasteful.
-# Per-model tuning refines it later (validated on real hardware, never invented).
 GENERIC_OLED_LOOK = {
     "saturation": 140,
     "temperature": 0,
     "contrast": 20,
 }
-# NOTE: contrast kept moderate — a +30 crushed shadow detail on the Ally LCD
-# (validated 2026-07-03). Saturation (140) carries most of the OLED "pop".
+# Contrast kept moderate — a higher value crushes shadow detail on LCD.
+# Saturation (140) carries most of the OLED "pop".
 
 
 def oled_look_for(device):

--- a/py_modules/fans/legion_ec.py
+++ b/py_modules/fans/legion_ec.py
@@ -73,7 +73,7 @@ class LegionGo2FanBackend(SoftwareLoopBackend):
 
     name = "legion-go2-ec"
     min_rpm = 0
-    max_rpm = 5000  # nominal; refine against the real fan's top RPM on-device
+    max_rpm = 5000  # nominal; refine against the real fan's top RPM
 
     def __init__(self, temp_fn: Optional[Callable[[], Optional[float]]] = None,
                  root: str = "/", ec=None) -> None:

--- a/py_modules/fans/lenovo_mode.py
+++ b/py_modules/fans/lenovo_mode.py
@@ -10,7 +10,7 @@ profile — the firmware then manages the actual RPM within each mode:
     2 = performance  (~2715 rpm)
 
 Values outside {0,1,2} are rejected by the firmware (the node reads back
-unchanged), so ``set_mode`` verifies the write with a readback (never-fake).
+unchanged), so ``set_mode`` verifies the write with a readback.
 
 This backend is ``mode_based``: it presents the existing NullFanBackend/
 HwmonCurveBackend interface (``read_state``/``set_auto``/``restore_auto``/
@@ -87,7 +87,7 @@ class LenovoFanModeBackend:
             return {"ok": False, "detail": f"mode out of range: {mode}"}
         if not self._write_mode(mode):
             return {"ok": False, "detail": "fan_mode write failed"}
-        # never-fake: only report success if the node actually took the value.
+        # only report success if the node actually took the value.
         if self._current_mode() != mode:
             return {"ok": False, "detail": "fan_mode did not latch"}
         return {"ok": True, "detail": f"fan mode {mode} applied"}

--- a/py_modules/fans/software_loop.py
+++ b/py_modules/fans/software_loop.py
@@ -7,7 +7,7 @@ Members: Steam Deck (steamdeck_hwmon `fan1_target` RPM). Legion Go 2 (raw EC)
 is a separate W4 backend with the same shape.
 
 Canonical curve stays temp→pwm(0–255); each backend reinterprets pwm/255 as a
-fraction of its RPM range so the F2/F3 curve representation is portable.
+fraction of its RPM range so the curve representation is portable.
 """
 
 import asyncio
@@ -69,7 +69,7 @@ class SoftwareLoopBackend:
     @property
     def _owns_fan(self) -> bool:
         """True only when we actually drive the fan (points set AND ownership
-        acquired). read_state reports manual only when this holds (never-fake)."""
+        acquired). read_state reports manual only when this holds."""
         return self._points is not None
 
     # --- common API ------------------------------------------------------------
@@ -100,7 +100,7 @@ class SoftwareLoopBackend:
             return {"ok": False, "detail": f"{self.name} not found"}
         # Take ownership of the fan FIRST. If we can't (e.g. jupiter-fan-control
         # refused to stop), we do NOT own the fan → never claim to drive and
-        # never write a target the OS daemon would fight (never-fake).
+        # never write a target the OS daemon would fight.
         if not self._before_drive():
             return {"ok": False, "detail": f"{self.name} could not take fan control"}
         self._points = [list(p) for p in sanitize_curve(points)]
@@ -176,8 +176,7 @@ def _systemctl_path() -> str:
     CRITICAL: the plugin runs under Decky's PyInstaller-frozen PluginLoader, whose
     child process has an EMPTY ``PATH`` (only ``LD_LIBRARY_PATH`` is set to the
     _MEI bundle). So a bare ``["systemctl", …]`` raises FileNotFoundError → our
-    guard returns False → jupiter is never stopped and the curve never drives.
-    That was the real "custom curve at startup does nothing on the Deck" bug. Use
+    guard returns False → jupiter is never stopped and the curve never drives. Use
     an absolute path; fall back through the standard locations, then bare name."""
     for p in ("/usr/bin/systemctl", "/bin/systemctl"):
         if os.path.exists(p):
@@ -194,7 +193,7 @@ def _systemctl(verb: str) -> bool:
     ``LD_LIBRARY_PATH`` to its _MEI bundle (older bundled libcrypto) AND leaves
     ``PATH`` empty. A raw spawn makes systemctl load the bundle's libcrypto →
     ``libsystemd-shared … OPENSSL_x not found`` → rc=1 → jupiter never stops → the
-    stored curve never drives at startup (the real Deck bug). ``clean_env`` restores
+    stored curve never drives at startup. ``clean_env`` restores
     the pre-bundle LD_LIBRARY_PATH + a sane PATH; we also invoke systemctl by
     absolute path. This is the same fix the controller backends use.
 
@@ -240,7 +239,7 @@ class SteamDeckFanBackend(SoftwareLoopBackend):
         super().__init__(temp_fn=temp_fn, root=root)
         board = _read(os.path.join(root, "sys/class/dmi/id/board_name")) or ""
         self.max_rpm = _DECK_MAX_RPM.get(board, 7000)
-        # Injectable for tests; defaults to real systemctl on-device.
+        # Injectable for tests; defaults to real systemctl.
         self._jupiter_ctl = jupiter_ctl if jupiter_ctl is not None else _systemctl
         self._jupiter_stopped = False  # track state → idempotent (stop/start once)
 
@@ -252,7 +251,7 @@ class SteamDeckFanBackend(SoftwareLoopBackend):
 
     def _before_drive(self) -> bool:
         # Stop jupiter-fan-control once, so it stops fighting our writes. If it
-        # won't stop, we don't own the fan → refuse to drive (never-fake).
+        # won't stop, we don't own the fan → refuse to drive.
         if self._jupiter_stopped:
             return True
         if self._run_jupiter("stop"):
@@ -266,7 +265,7 @@ class SteamDeckFanBackend(SoftwareLoopBackend):
         # Deck with jupiter down. Idempotent: start on a running unit is a no-op.
         # Only clear the "we stopped it" flag if the restart actually succeeded —
         # if it failed, jupiter is still down and read_state/_before_drive must not
-        # pretend it's back (never-fake). reset-failed makes this edge rare.
+        # pretend it's back. reset-failed makes this edge rare.
         started = self._run_jupiter("start")
         self._jupiter_stopped = self._jupiter_stopped and not started
 

--- a/py_modules/fans/suggest.py
+++ b/py_modules/fans/suggest.py
@@ -1,4 +1,4 @@
-"""F3 suggestion brain — turn a game's observed temperature histogram into a
+"""Suggestion brain — turn a game's observed temperature histogram into a
 recommended fan curve fit to the band the game actually runs in.
 
 Pure functions, no I/O. The honest contract: we only fit the *active ramp* to the
@@ -15,7 +15,7 @@ MIN_MINUTES = _MIN_SECONDS // 60   # learning-progress target (minutes), for the
 _MIN_SPREAD = 8                # P90-P10 °C — refuse to fit a flat (idle-only) band
 
 # The curve's temp anchors (mirror the presets so an applied suggestion edits
-# cleanly in the F2 graph).
+# cleanly in the curve graph).
 _ANCHORS = (40, 50, 60, 70, 80, 85, 90, 95)
 
 # Balanced duty (%) control points, placed on the observed band percentiles.
@@ -84,7 +84,7 @@ def _curve(b: dict, bias: int):
 def curve_changed(old, new, tol_pwm: int = 8) -> bool:
     """Whether *new* differs from *old* enough to be worth re-applying (anti-churn).
 
-    Used by the periodic re-apply (A1): re-fitting the learned curve every ~30 min
+    Used by the periodic re-apply: re-fitting the learned curve every ~30 min
     would otherwise churn the hardware (and eMMC) on cosmetic drift. Returns True
     when any control point's pwm moves by more than *tol_pwm* (default 8/255 ≈ 3 %),
     or when there's no vigente curve at all (a first apply must always go through).

--- a/py_modules/gpu/clock.py
+++ b/py_modules/gpu/clock.py
@@ -7,9 +7,8 @@ range comes from that file's OD_RANGE section. Auto = performance_level back to 
 Intel (i915): plain `gt_min_freq_mhz` / `gt_max_freq_mhz`; hardware bounds are
 `gt_RPn_freq_mhz` (min) / `gt_RP0_freq_mhz` (max); auto = restore the full range.
 
-Pure parsing/command building is unit-tested; the actual sysfs writes are validated
-on-device. Every backend degrades to unsupported (UI hidden) when the nodes are
-absent — never fake."""
+Pure parsing/command building is unit-tested. Every backend degrades to unsupported
+(UI hidden) when the nodes are absent."""
 import glob
 import os
 import re
@@ -79,7 +78,7 @@ class AmdGpuClock:
         write_str(self._level, "manual")
         for cmd in sclk_commands(min_mhz, max_mhz):
             write_str(self._od, cmd)
-        return read_str(self._level) == "manual"  # readback (never-fake)
+        return read_str(self._level) == "manual"  # readback
 
     def set_auto(self):
         if not self.supported:

--- a/py_modules/power/reader.py
+++ b/py_modules/power/reader.py
@@ -15,8 +15,8 @@ class PowerReader:
 
     `gpu_busy_percent` on some APUs (notably the Steam Deck's Van Gogh) is an
     INSTANTANEOUS sample of a tiny window that swings wildly 0<->100. A single
-    read is unrepresentative (measured on-device: a ~30% game reads
-    0,0,0,100,100,0,... mean 22). read_gpu_busy() therefore sub-samples a short
+    read is unrepresentative (a ~30% game reads e.g. 0,0,0,100,100,0,...
+    averaging ~22). read_gpu_busy() therefore sub-samples a short
     burst and returns the arithmetic mean — the honest time-average of GPU
     utilisation (mangohud does the same). The mean, not a percentile: `decide`
     already owns the up/down asymmetry (recent-peak up, smoothed-mean down)

--- a/py_modules/tdp/suggest.py
+++ b/py_modules/tdp/suggest.py
@@ -1,4 +1,4 @@
-"""G2 suggestion brain — turn a game's per-PL1 telemetry into a learned TDP band.
+"""Suggestion brain — turn a game's per-PL1 telemetry into a learned TDP band.
 
 Pure functions, no I/O. Mirror of ``fans/suggest.py`` but for power: instead of a
 fan curve we derive a ``[floor, ceil]`` watt band + a habitual ``seed`` for the
@@ -13,7 +13,7 @@ Floor honesty is GPU-PRIMARY (``_satisfied``), matching the honest signal the
 control loop acts on. A PL1 level "had headroom" when the GPU was NOT saturated
 there (``gpu_avg < _GPU_STARVED``). On a power-limited game the draw just follows
 PL1, so watts/boost are confounded — they can't tell "has margin" from "needs it"
-(measured on-device: 35 W cap / 80% GPU looked "no headroom" by watts, yet 80%
+(a 35 W cap with the GPU stable at 80% looks like "no headroom" by watts, yet 80%
 GPU means there IS margin). GPU utilisation is the only honest "could it go lower?"
 signal, so the learned floor and the loop's knee converge on the same PL1. A level
 that pinned the GPU is power-limited, not satisfied — so it can never be the floor.

--- a/py_modules/telemetry/sampler.py
+++ b/py_modules/telemetry/sampler.py
@@ -21,7 +21,7 @@ class TelemetrySampler:
         self._interval = interval
         # Optional post-store callback(result) invoked after each poll (result =
         # the (appid, sample) tuple or None). Lets the owner count in-game ticks
-        # (A1 learned-curve re-apply cadence) without a second timer.
+        # (learned-curve re-apply cadence) without a second timer.
         self._on_sample = on_sample
         # Persist to disk every `flush_every` samples (12 × 5 s ≈ 60 s) instead of
         # every sample — spares eMMC wear. A final flush happens on stop().

--- a/py_modules/telemetry/store.py
+++ b/py_modules/telemetry/store.py
@@ -12,7 +12,7 @@ _HALF_LIFE_SECONDS = 1800.0
 # Bins whose dwell decays below this disappear (faded to noise).
 _DECAY_PRUNE_EPSILON = 1.0
 
-# Temperature histogram (feeds the F3 suggestion brain): 2 °C bins over 30–100 °C,
+# Temperature histogram (feeds the suggestion brain): 2 °C bins over 30–100 °C,
 # keyed by the driving temp = max(temp_cpu, temp_gpu) per sample.
 _TEMP_BIN_WIDTH = 2
 _TEMP_BIN_MIN = 30

--- a/src/api.ts
+++ b/src/api.ts
@@ -162,7 +162,7 @@ export const setTelemetryEnabled = callable<[enabled: boolean], boolean>("set_te
 export const resetTelemetry = callable<[], boolean>("reset_telemetry");
 
 // Capability + opt-in snapshot for the persistent learning banner. Reports what
-// THIS device can actually learn (never-fake: no fan tag if it can't write curves).
+// THIS device can actually learn (no fan tag if it can't write curves).
 export interface LearningStatus {
   telemetry_enabled: boolean;
   tdp_supported: boolean;
@@ -193,7 +193,7 @@ export const setFanAdaptive =
 export const setFanAdaptiveBias =
   callable<[bias: number, scope: FanScope, appid: string | null], FanCurveState>("set_fan_adaptive_bias");
 
-// F3 — fan-curve suggestion fit to a game's observed temperature band.
+// Fan-curve suggestion fit to a game's observed temperature band.
 export interface FanSuggestion {
   available: boolean;
   // ok | disabled | unsupported | no_game | no_data | too_few | flat | error
@@ -212,7 +212,7 @@ export const getFanSuggestion =
   callable<[appid: string | null], FanSuggestion>("get_fan_suggestion");
 
 // ---- Battery (Sistema) ----------------------------------------------------
-// Every field is nullable: the device may not expose it, and we never fake a
+// Every field is nullable: the device may not expose it, and we don't fabricate a
 // value (a hidden stat beats a wrong one).
 export interface BatteryInfo {
   present: boolean;
@@ -377,7 +377,7 @@ export interface RemapButton {
   // The InputPlumber source capability (e.g. "LeftPaddle1") — used when remapping.
   source: string;
   // The literal silkscreen label printed on the device (e.g. "Y1", "M2"),
-  // device-correct from the backend's validated per-device table. NOT translated.
+  // device-correct from the backend's per-device table. NOT translated.
   label: string;
   // The current override, or null = still at the device default.
   target: ControllerTarget[] | null;
@@ -391,7 +391,7 @@ export interface ControllerConfig {
   // "remap" = per-button editor (InputPlumber); "settings" = mode/paddles (HHD).
   kind: "remap" | "settings" | "none";
   // remap (InputPlumber)
-  // Whether we have an on-device-validated button map for this model. When false,
+  // Whether we have a known button map for this model. When false,
   // `buttons` is empty and the UI shows an honest "not calibrated" note.
   device_known?: boolean;
   buttons?: RemapButton[];

--- a/src/components/ContainedSlider.tsx
+++ b/src/components/ContainedSlider.tsx
@@ -15,9 +15,9 @@ interface Props {
 
 /**
  * Steam's SliderField has a fixed intrinsic width (~the panel width) and a Field
- * with negative margins, so it bleeds outside custom cards. The validated fix is a
+ * with negative margins, so it bleeds outside custom cards. The fix is a
  * uniform scale (keeps the knob round) inside an overflow:hidden box. This wraps
- * that documented containment so call sites don't re-hand-roll it.
+ * that containment so call sites don't re-hand-roll it.
  */
 export const ContainedSlider: FC<Props> = ({ value, min, max, step, showValue, scale = 0.8, onChange }) => (
   <div style={{ overflow: "hidden", width: "100%" }}>

--- a/src/components/ControllerConflictCard.tsx
+++ b/src/components/ControllerConflictCard.tsx
@@ -8,7 +8,7 @@ import { theme } from "../theme";
  * Warns when Handheld Daemon's TDP plugin (which also drives its fan curve) is
  * enabled at the same time as our power control — both write the same firmware
  * rails and fight (last-writer-wins → jitter). We only WARN and guide; we never
- * touch HHD's settings (the user's boundary). Rendered only when a real conflict
+ * touch HHD's settings. Rendered only when a real conflict
  * is detected. Shown in Ajustes.
  */
 export const ControllerConflictCard: FC = () => {

--- a/src/components/EcoCard.tsx
+++ b/src/components/EcoCard.tsx
@@ -9,7 +9,7 @@ import { theme } from "../theme";
 interface Props {
   state: EcoState;
   /** Whether this device exposes a brightness API — gates the brightness effect
-   *  so the card never claims a dim it can't perform (never-fake). */
+   *  so the card never claims a dim it can't perform. */
   brightnessSupported: boolean;
   onToggle: (enabled: boolean) => void;
 }

--- a/src/components/FanCurveEditor.tsx
+++ b/src/components/FanCurveEditor.tsx
@@ -115,7 +115,7 @@ export const FanCurveEditor: FC<Props> = ({ control, liveTemp, suggestion, expan
   // Footer hint for the active (non-adaptive) mode; adaptive shows its own card.
   // For a fixed preset while the device is still cool, explain that presets look
   // the same until it heats up (the fan sits at its floor) — so idle-convergence
-  // isn't mistaken for "the preset didn't apply". Honest, on-device-confirmed.
+  // isn't mistaken for "the preset didn't apply".
   const hint = control.saved
     ? t("fans.curve.saved")
     : curveState.preset === "auto"

--- a/src/components/PowerArc.tsx
+++ b/src/components/PowerArc.tsx
@@ -73,7 +73,7 @@ export const PowerArc: FC<PowerArcProps> = ({
   const [ex, ey] = polar(end);
 
   // HW boost: the extra watts the chip draws above your TDP via SPPT/FPPT. Null
-  // when the draw sensor is down (never fake). Only shown when it's a real extra.
+  // when the draw sensor is down. Only shown when it's a real extra.
   const boost = boostWatts(tdpWatts, actualWatts);
   const hasBoost = boost !== null && boost > 0;
   // Where the boost segment ends on the arc (null → nothing to draw). The clamp to

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -28,7 +28,7 @@ interface Props {
  * - ready    → the learned curve (biased by the dial) + silence↔cool dial (drives HW)
  * - learning → green dashed candidate + green observed points + progress + "keep playing"
  * - spread   → progress full + honest "need more temperature variation"
- * - empty    → "start playing" (no fabricated curve — never-fake)
+ * - empty    → "start playing" (no fabricated curve)
  * - disabled → "turn on learning in Settings"
  * - no_game  → "launch a game"
  * `unsupported` never reaches here (the chip only shows when the device can write).

--- a/src/fans/logic.ts
+++ b/src/fans/logic.ts
@@ -45,8 +45,8 @@ export function rpmFraction(rpm: number, observedMax: number, nominalMax: number
 // The fixed presets that share a near-flat, quiet low-temp region. Below this
 // temperature their curves overlap and the fan sits at its hardware floor, so
 // switching between them makes no audible/RPM difference — they only diverge
-// under load. Confirmed on-device (ROG Ally X): at ~36 °C silent/balanced/
-// performance all held ~4700 rpm; at ~75 °C silent ~5400 vs performance ~8100.
+// under load: at low temps silent/balanced/performance all hold the same floor
+// RPM; only at high temps do they diverge.
 const _FIXED_PRESETS = ["silent", "balanced", "performance"] as const;
 const _DIVERGENCE_TEMP_C = 60;
 

--- a/src/fans/suggestLogic.test.ts
+++ b/src/fans/suggestLogic.test.ts
@@ -52,7 +52,7 @@ describe("learningProgress", () => {
     expect(learningProgress(600, 0, false)).toBe(0);
   });
 
-  // never-fake: while still learning (not available) the bar must NEVER read full,
+  // while still learning (not available) the bar must NEVER read full,
   // even at the round-up boundary where minutes(round) would show the target.
   it("never reaches 1 while learning, even at 1770/1799 s (round→30 min)", () => {
     expect(learningProgress(1770, TARGET, false)).toBeLessThan(1);

--- a/src/fans/suggestLogic.ts
+++ b/src/fans/suggestLogic.ts
@@ -19,7 +19,7 @@ export type SuggestStateKind =
   | "disabled"    // telemetry opted out
   | "unsupported"; // device can't write fan curves
 
-// While still learning the bar must NEVER read full (never-fake) — cap just under 1
+// While still learning the bar must NEVER read full — cap just under 1
 // so a 29.5-min dwell (which round(minutes) would show as the 30-min target) can't
 // look "done" while the honest gate is still `too_few`.
 const _LEARNING_MAX = 0.99;
@@ -39,7 +39,7 @@ export function learningProgress(seconds: number, targetSeconds: number, availab
 
 /**
  * Whole minutes still to go before unlocking, rounded UP with a floor of 1 so the
- * card never says "~0 min" while the state is still `learning` (never-fake). Only
+ * card never says "~0 min" while the state is still `learning`. Only
  * meaningful while learning; once available the card no longer shows it.
  */
 export function minutesLeft(seconds: number, targetSeconds: number): number {

--- a/src/fans/useFanSuggestion.ts
+++ b/src/fans/useFanSuggestion.ts
@@ -18,7 +18,7 @@ export function useFanSuggestion(appid: string | null) {
     // Drop the previous game's suggestion immediately on appid change — never show
     // (or let the user apply) one game's learned curve labeled as another's while
     // the new RPC is in flight. The prominent, open-by-default card makes this
-    // window actionable, so blanking here is a "never fake" guard.
+    // window actionable, so blanking here is a correctness guard.
     setSuggestion(null);
     refresh();
   }, [appid, refresh]);

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -117,7 +117,7 @@ const es: Record<string, string> = {
   "fans.suggest.msg.learning": "Sigue jugando ~{left} min más para desbloquear la curva. Los puntos verdes son lo que ya he observado.",
   "fans.suggest.msg.empty": "Empieza a jugar para que aprenda el patrón térmico de este juego.",
   "fans.suggest.msg.nogame": "Entra a un juego para que aprenda su patrón.",
-  // A1 — comunica que el aprendizaje es CONTINUO (no de una sola vez).
+  // Comunica que el aprendizaje es CONTINUO (no de una sola vez).
   "fans.suggest.continuous": "Afino la curva cada ~30 min con tu uso reciente.",
   // A2 — tope de temperatura + escala con significado.
   "fans.suggest.peak.title": "Temperatura máxima",

--- a/src/learning/logic.test.ts
+++ b/src/learning/logic.test.ts
@@ -38,7 +38,7 @@ describe("learningBadge", () => {
     ).toEqual({ state: "hidden", tags: [] });
   });
 
-  it("in-game but device can learn nothing → hidden (never-fake)", () => {
+  it("in-game but device can learn nothing → hidden", () => {
     expect(
       learningBadge({ inGame: true, telemetryOn: true, tdpSupported: false, fanSupported: false }),
     ).toEqual({ state: "hidden", tags: [] });

--- a/src/learning/logic.ts
+++ b/src/learning/logic.ts
@@ -2,7 +2,7 @@
 // DeviceHeader. Decides — by DEVICE CAPABILITY — whether we are learning, paused,
 // or should say nothing at all. Telemetry is one stream that feeds both TDP and
 // fan learning; the tags reflect only what THIS device can actually learn/apply
-// (never-fake: no tag for a subsystem this machine can't control).
+// (no tag for a subsystem this machine can't control).
 
 export type LearningTag = "tdp" | "fans";
 export type LearningState = "learning" | "paused" | "hidden";

--- a/src/mandos/logic.ts
+++ b/src/mandos/logic.ts
@@ -37,7 +37,7 @@ export function currentTargetValue(targets: ControllerTarget[]): string {
 }
 
 // Friendly labels: Xbox face-button letters + short paddle/shoulder names. Anything
-// unmapped falls through to the raw name (never fake a label we don't know).
+// unmapped falls through to the raw name (don't invent a label we don't know).
 const GP_LABEL: Record<string, string> = {
   South: "A", East: "B", West: "X", North: "Y",
   LeftBumper: "LB", RightBumper: "RB", LeftTrigger: "LT", RightTrigger: "RT",

--- a/src/sections/MandosSection.tsx
+++ b/src/sections/MandosSection.tsx
@@ -147,7 +147,7 @@ export const MandosSection: FC = () => {
     return v === key ? fallback : v;
   };
 
-  // Remappable physical buttons (empty for non-remap configs / unvalidated devices).
+  // Remappable physical buttons (empty for non-remap configs / unknown devices).
   const buttons = config.buttons ?? [];
 
   return (
@@ -185,7 +185,7 @@ export const MandosSection: FC = () => {
                 />
               </RemapRow>
             ))}
-            {/* Honest footnote: no buttons → why (unvalidated model vs a transient
+            {/* Honest footnote: no buttons → why (unknown model vs a transient
                 empty-caps read, distinguished by device_known); otherwise the
                 global-scope reminder. */}
             <div style={{ fontSize: theme.font.caption, color: theme.color.textMuted, margin: `${theme.space.sm}px 0`, lineHeight: 1.4 }}>

--- a/src/system/activity.ts
+++ b/src/system/activity.ts
@@ -1,7 +1,7 @@
 // User-activity signal from SteamClient. Steam already computes active/idle and
 // emits on transitions via WebChat.RegisterForComputerActiveStateChange(state, ts)
-// where state 1 = active, 2 = idle (CDP-validated on Legion Go 2: flips to idle
-// ~4 s after the last input, and catches BOTH buttons and touch). We use it to
+// where state 1 = active, 2 = idle (flips to idle ~4 s after the last input, and
+// catches BOTH buttons and touch). We use it to
 // drive download mode's ambient screen dim. Never throws; returns null when the
 // API is absent so callers degrade.
 export function subscribeActive(cb: (active: boolean) => void): (() => void) | null {

--- a/src/system/audio.ts
+++ b/src/system/audio.ts
@@ -6,8 +6,8 @@ import { ScalarControl } from "./types";
 // writes it.
 //
 // The `audioType` arg to SetDeviceVolume is a DIRECTION, not a per-device config:
-// CDP-probed on Claw, Steam Deck and both ROG Allys, audioType 1 = OUTPUT and
-// audioType 0 = INPUT (mic). Writing the output volume with the wrong type hits the
+// audioType 1 = OUTPUT and audioType 0 = INPUT (mic) on these handhelds. Writing
+// the output volume with the wrong type hits the
 // mic and is a silent no-op for the speaker. A previous version seeded it from the
 // device's `currentConfig.eConfig`, which happens to be 1 on the Legion Go 2 (so it
 // worked there by coincidence) but 0 on the Ally/Deck/Claw (so those wrote to the

--- a/src/system/colores.ts
+++ b/src/system/colores.ts
@@ -36,8 +36,8 @@ export function coloresCardState(input: {
 // ── Decky-internal adapters ────────────────────────────────────────────────
 // These reach INTERNAL Decky Loader globals (`window.DeckyPluginLoader`,
 // `window.DeckyBackend`) that are NOT part of the public `@decky/api`. Every one
-// is guarded so a Decky version that moved them degrades honestly (never-fake:
-// we report "not installed" / fall back to the store rather than throw or lie).
+// is guarded so a Decky version that moved them degrades honestly: we report
+// "not installed" / fall back to the store rather than throw or lie.
 
 /** Reads Decky's in-memory installed-plugin list to see if Colores is present. */
 export function isColoresInstalled(): boolean {
@@ -84,7 +84,7 @@ export function setActiveColoresPlugin(): void {
 /**
  * After an install RPC resolves, Decky needs a moment to register + load the new
  * plugin into its state. Poll a few times so we only flip to "installed" once it
- * REALLY appears (never-fake).
+ * REALLY appears.
  */
 export async function waitForColoresInstalled(tries = 8, gapMs = 800): Promise<boolean> {
   for (let i = 0; i < tries; i++) {

--- a/src/system/ecoAmbient.ts
+++ b/src/system/ecoAmbient.ts
@@ -5,10 +5,10 @@ import { fromPercent } from "./logic";
 import { ecoBrightness } from "./eco";
 
 // Idle brightness floor while download mode dims the screen. Minimum by default
-// (max saving for an unattended download); tune on-device if a fully-dark panel
+// (max saving for an unattended download); tune if a fully-dark panel
 // reads as "off".
 const ECO_FLOOR_PCT = 0;
-// Backstop reconcile cadence — runs ONLY while eco is on, to catch a backend B1
+// Backstop reconcile cadence — runs ONLY while eco is on, to catch a backend-side
 // clear (a manual power change that turned eco off without going through the card).
 const POLL_MS = 3000;
 

--- a/src/system/useColores.ts
+++ b/src/system/useColores.ts
@@ -85,7 +85,7 @@ export function useColores(): UseColores {
       return;
     }
     // The RPC resolved; only flip to "installed" once it REALLY appears in Decky's
-    // state (never-fake) — otherwise surface the honest error + store fallback.
+    // state — otherwise surface the honest error + store fallback.
     const found = await waitForColoresInstalled();
     if (!mounted.current) return;
     setInstalled(found);

--- a/src/system/useEco.ts
+++ b/src/system/useEco.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { EcoState, getEcoState, setEco } from "../api";
 import { setEcoActiveHint } from "./ecoAmbient";
 
-const POLL_MS = 3000; // keep the toggle in sync when another card's manual change clears eco (B1)
+const POLL_MS = 3000; // keep the toggle in sync when another card's manual change clears eco
 
 export interface EcoController {
   state: EcoState | null;

--- a/src/system/useScalar.ts
+++ b/src/system/useScalar.ts
@@ -6,7 +6,7 @@ import { systemVolume } from "./audio";
 
 /**
  * Drives a ScalarControl as an integer-percent value. Distinguishes three
- * states so the UI never fakes a reading:
+ * states so the UI never shows a value it doesn't really have:
  *  - `supported=false` → the API is absent (subscribe returned no registration).
  *  - `supported && loading` → API present, but no real value has arrived yet
  *    (e.g. volume seeds via an async GetDevices and only emits on change). The

--- a/src/tdp/logic.test.ts
+++ b/src/tdp/logic.test.ts
@@ -90,7 +90,7 @@ describe("dialToWatts (learned-band suggestion)", () => {
 });
 
 describe("boostWatts (HW boost above your TDP)", () => {
-  it("returns null when the draw sensor is unavailable (never fake)", () => {
+  it("returns null when the draw sensor is unavailable", () => {
     expect(boostWatts(22, null)).toBeNull();
   });
 

--- a/tests/test_auto_adapt_rpc.py
+++ b/tests/test_auto_adapt_rpc.py
@@ -215,7 +215,7 @@ def test_loop_holds_at_knee_no_sawtooth(Plugin, monkeypatch):
 
 
 def test_loop_power_limited_at_max_probes_down(Plugin, monkeypatch):
-    # THE on-device bug: pl1 at max (35), GPU stable 80% (below the 88 knee) → there
+    # The power-limited case: pl1 at max (35), GPU stable 80% (below the 88 knee) → there
     # IS margin, so after the sustained-headroom gate it steps DOWN off the cap
     # (proportional to the gap), instead of holding at max forever like the old
     # watts model did (draw pinned the cap → "no headroom" → stuck).
@@ -467,7 +467,7 @@ def test_adaptive_mode_drives_learned_curve_when_enough_data(Plugin):
 
 
 def test_adaptive_mode_no_data_falls_back_to_firmware_auto(Plugin):
-    # never-fake: adaptive with no learned data must NOT fabricate a curve — it
+    # adaptive with no learned data must NOT fabricate a curve — it
     # leaves the fans on firmware auto and shows the learning state.
     p = Plugin()
     p._init()
@@ -528,7 +528,7 @@ def test_switching_to_preset_leaves_adaptive(Plugin):
 
 
 # ---------------------------------------------------------------------------
-# A1 — periodic re-fit of the adaptive curve (~30 min of play), following the
+# Periodic re-fit of the adaptive curve (~30 min of play), following the
 # recent thermal pattern. Anti-churn; only runs in adaptive mode.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_auto_tdp.py
+++ b/tests/test_auto_tdp.py
@@ -48,7 +48,7 @@ def test_up_clamps_at_max():
 
 
 # ===========================================================================
-# HOLD — dead-band (knee) + power-limited-at-max case (the on-device bug)
+# HOLD — dead-band (knee) + power-limited-at-max case
 # ===========================================================================
 
 def test_deadband_holds():
@@ -58,7 +58,7 @@ def test_deadband_holds():
 
 
 def test_power_limited_at_max_still_probes_down():
-    # THE on-device case: pl1=35 (max), GPU stable 80% (below _DOWN_GPU) → there IS
+    # The power-limited case: pl1=35 (max), GPU stable 80% (below _DOWN_GPU) → there IS
     # margin (not saturated) even though draw pinned the cap. Must accumulate slack
     # and eventually step down — NOT hold forever at max.
     nxt, slack = decide(35, g(80, 81, 80, 81, 80), _SLACK_HOLD - 1, 5, 35)

--- a/tests/test_battery_reader.py
+++ b/tests/test_battery_reader.py
@@ -111,7 +111,7 @@ def test_zero_cycle_count_is_unknown(tmp_path):
     # Many handhelds (ASUS Ally, Steam Deck, MSI Claw) expose a cycle_count node
     # that the firmware never populates → it reads a literal "0". A used battery
     # with genuinely 0 cycles is implausible; showing "0 cycles" is a fake reading.
-    # Treat 0 as unknown (None) so the UI hides the chip (never-fake). Real counts
+    # Treat 0 as unknown (None) so the UI hides the chip. Real counts
     # (Legion reports e.g. 38) are untouched.
     root = str(tmp_path)
     _mk_supply(root, "BAT0", {"type": "Battery", "capacity": "60", "cycle_count": "0"})

--- a/tests/test_controllers_ip_profile.py
+++ b/tests/test_controllers_ip_profile.py
@@ -15,7 +15,7 @@ GO2_CAPS = [
 
 
 def test_buttons_legion_go_2_silkscreen_map_grips_only():
-    # Validated on-device: silkscreen (Y1/M1/…) -> source capability, GRIPS ONLY.
+    # Silkscreen (Y1/M1/…) -> source capability, GRIPS ONLY.
     # Phantoms (RightPaddle3) and system buttons (Guide/QuickAccess/…) are excluded.
     assert ip.buttons_for("legion_go_2", GO2_CAPS) == [
         ("LeftPaddle1", "Y1"),
@@ -73,7 +73,7 @@ def test_buttons_unknown_device_is_empty():
 def test_is_known_device():
     assert ip.is_known_device("legion_go_2") is True
     assert ip.is_known_device("msi_claw_8_ai_plus") is True
-    assert ip.is_known_device("legion_go_s") is False  # not validated on-device
+    assert ip.is_known_device("legion_go_s") is False  # no known button map
     assert ip.is_known_device(None) is False
 
 

--- a/tests/test_eco_rpc.py
+++ b/tests/test_eco_rpc.py
@@ -1,4 +1,4 @@
-"""RPC-level tests for download mode (eco): override + restore + B1 clear."""
+"""RPC-level tests for download mode (eco): override + restore + manual clear."""
 import asyncio
 import importlib
 import sys
@@ -108,7 +108,7 @@ def test_manual_tdp_change_clears_eco(tmp_path, monkeypatch):
     asyncio.run(p.set_eco(True, 40))
     assert p._settings["eco_enabled"] is True
     asyncio.run(p.set_tdp_watts(18, "global", None))
-    assert p._settings["eco_enabled"] is False  # B1: manual control exits eco
+    assert p._settings["eco_enabled"] is False  # manual control exits eco
 
 
 def test_zero_brightness_snapshot_is_ignored(tmp_path, monkeypatch):

--- a/tests/test_fan_control_msi.py
+++ b/tests/test_fan_control_msi.py
@@ -35,7 +35,7 @@ def _make_msi_chip(root, idx=0):
     return d
 
 
-# A canonical 8-point curve (what F2/F3 store) — must be resampled to MSI's 6.
+# A canonical 8-point curve (what the curve editor stores) — must be resampled to MSI's 6.
 CANON_8 = [(40, 0), (50, 30), (60, 60), (70, 95), (80, 135), (85, 175), (90, 215), (95, 255)]
 
 

--- a/tests/test_fan_control_rpc.py
+++ b/tests/test_fan_control_rpc.py
@@ -282,7 +282,7 @@ class TestFanCurveRpcAsus:
         assert self._enables(asus_root) == ("1", "1")
 
     def test_adaptive_mode_no_data_stays_firmware_auto(self, Plugin, asus_root):
-        # never-fake: adaptive with no learned data leaves the fans on firmware auto.
+        # adaptive with no learned data leaves the fans on firmware auto.
         p = Plugin()
         asyncio.run(p.set_current_game("777"))
         st = asyncio.run(p.set_fan_adaptive("game", "777"))

--- a/tests/test_fan_lenovo_mode.py
+++ b/tests/test_fan_lenovo_mode.py
@@ -66,7 +66,7 @@ class TestSetMode:
         b = LenovoFanModeBackend(root=str(tmp_path))
         res = b.set_mode(3)
         assert res["ok"] is False
-        # never-fake: rejected write must not report the requested mode
+        # rejected write must not report the requested mode
         assert b.read_state()["mode"] == 1
 
     def test_readback_mismatch_reports_failure(self, tmp_path):

--- a/tests/test_fan_software_loop.py
+++ b/tests/test_fan_software_loop.py
@@ -145,7 +145,7 @@ class TestJupiterHandoff:
         assert svc.active is True  # SteamOS resumes control
 
     def test_release_keeps_stopped_flag_when_restart_fails(self, tmp_path):
-        # never-fake: if the jupiter restart FAILS on release, jupiter is still
+        # if the jupiter restart FAILS on release, jupiter is still
         # down — don't clear _jupiter_stopped (that would claim it's back up).
         _make_deck_chip(str(tmp_path))
         svc = _FakeSystemctl(fail={"start"})
@@ -166,7 +166,7 @@ class TestJupiterHandoff:
         b.restore_auto()
         assert svc.active is True
 
-    def test_never_fake_when_stop_fails(self, tmp_path):
+    def test_no_false_manual_when_stop_fails(self, tmp_path):
         # If we cannot stop jupiter, we do NOT own the fan → don't claim to drive.
         d = _make_deck_chip(str(tmp_path))
         svc = _FakeSystemctl(fail={"stop"})
@@ -182,7 +182,7 @@ class TestJupiterHandoff:
         svc = _FakeSystemctl(fail={"stop"})
         b = _backend_svc(tmp_path, temp=85.0, svc=svc)
         b.apply_curve_all(CURVE)
-        # never-fake: enable must report firmware auto (2), not manual (1)
+        # enable must report firmware auto (2), not manual (1)
         assert b.read_state()["fans"][0]["enable"] == 2
 
     def test_guarded_never_raises_on_service_error(self, tmp_path):

--- a/tests/test_fans_suggest.py
+++ b/tests/test_fans_suggest.py
@@ -141,7 +141,7 @@ def test_min_minutes_is_30():
 
 
 # ---------------------------------------------------------------------------
-# curve_changed — anti-churn gate for periodic re-apply (A1)
+# curve_changed — anti-churn gate for periodic re-apply
 # ---------------------------------------------------------------------------
 
 def _curve(bump=0):

--- a/tests/test_power_reader.py
+++ b/tests/test_power_reader.py
@@ -107,7 +107,7 @@ def _reader_with_samples(tmp_path, samples):
 
 
 def test_gpu_busy_averages_a_burst(tmp_path):
-    # The exact on-device Van Gogh probe: instantaneous 0<->100 noise, ~22% real.
+    # Van Gogh-style probe: instantaneous 0<->100 noise, ~22% real.
     samples = [0, 0, 0, 100, 100, 100, 0, 0, 0, 0, 53, 59, 0, 0, 0, 37, 0, 0, 0, 0]
     r = _reader_with_samples(tmp_path, samples)
     # mean = 449/20 = 22.45 -> 22 (a single instantaneous read would give a bogus 0,

--- a/tests/test_tdp_suggest.py
+++ b/tests/test_tdp_suggest.py
@@ -121,7 +121,7 @@ def test_power_limited_low_pl1_never_becomes_floor():
 
 
 def test_power_limited_at_cap_but_gpu_has_margin_is_satisfied():
-    # THE on-device case (Ally, 35 W cap / 80% GPU / draw pinned): watts says "no
+    # The power-limited case (35 W cap / 80% GPU / draw pinned): watts says "no
     # headroom" (draw==cap) but the GPU at 80% had margin → GPU-primary marks it
     # SATISFIED, so a lower level with margin becomes the floor rather than the cap.
     b = learned_band(_by_pl1([

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -213,7 +213,7 @@ def test_flush_is_noop_when_nothing_changed(tmp_path):
 
 
 def test_aggregate_reflects_unflushed_samples(tmp_path):
-    # In-session reads (RPC/F3) must see buffered data without a flush.
+    # In-session reads (RPC/suggestions) must see buffered data without a flush.
     s = _store(tmp_path)
     s.add_sample("1", _sample(pl1=15), dt=5.0)
     assert s.aggregate("1")["samples_n"] == 1
@@ -239,7 +239,7 @@ def test_add_sample_never_raises_on_bad_data(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Temperature histogram (F3 foundation): seconds accumulated per 2C bin,
+# Temperature histogram (suggestion foundation): seconds accumulated per 2C bin,
 # keyed by the driving temp = max(t_cpu, t_gpu). Feeds the suggestion brain.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Limpieza y homogeneización de comentarios y docstrings en el código. Sin cambios de lógica: solo comentarios/docstrings (más el renombrado de un test para mayor claridad).

Gate verde: ruff · 605 pytest · typecheck · 153 vitest · build (dist/index.js).