### PR TITLE
docs: Spanish-first README (+ English) and fix release-zip upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,20 +46,11 @@ jobs:
           rm -f dist/*.map
           staging=$(mktemp -d)
           mkdir -p "$staging/$PLUGIN_NAME"
-          cp -rL dist main.py plugin.json package.json README.md LICENSE py_modules assets "$staging/$PLUGIN_NAME"
+          cp -rL dist main.py plugin.json package.json README.md README.en.md LICENSE py_modules assets "$staging/$PLUGIN_NAME"
           (cd "$staging" && zip -r "$GITHUB_WORKSPACE/$PLUGIN_NAME.zip" "$PLUGIN_NAME")
 
-      # Sign the exact release artifact with build provenance (Sigstore, keyless).
-      # Anyone can verify the zip really came from this workflow/commit with:
-      #   gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
-      # This is what protects users even if the GitHub account or a token leaks:
-      # a zip published outside this pipeline has no valid provenance.
-      - name: Attest build provenance
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: "Panel de Control.zip"
-
+      # Attach the artifact first, so provenance signing can never block the release
+      # asset (e.g. build provenance is unavailable on private repos).
       - name: Upload zip to the release
         if: ${{ steps.release.outputs.release_created }}
         env:
@@ -67,3 +58,16 @@ jobs:
           TAG: ${{ steps.release.outputs.tag_name }}
           PLUGIN_NAME: Panel de Control
         run: gh release upload "$TAG" "$PLUGIN_NAME.zip" --clobber
+
+      # Sign the exact release artifact with build provenance (Sigstore, keyless).
+      # Anyone can verify the zip really came from this workflow/commit with:
+      #   gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
+      # This is what protects users even if the GitHub account or a token leaks:
+      # a zip published outside this pipeline has no valid provenance.
+      # Skipped while the repo is private (attestations require a public repo);
+      # it turns on automatically once the repo is made public.
+      - name: Attest build provenance
+        if: ${{ steps.release.outputs.release_created && !github.event.repository.private }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "Panel de Control.zip"

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,212 @@
+# Panel de Control
+
+[Español](README.md) · **English**
+
+The control center your handheld gaming PC was missing. Tune power, fan curves, battery, display and
+controllers from a single panel inside Steam's quick access menu, without leaving your game and
+without memorizing sysfs paths.
+
+It's a plugin for [Decky Loader](https://decky.xyz/), built for the Steam Deck, ROG Ally, Legion Go,
+MSI Claw and friends. One idea runs through the whole thing: every control should look good, always
+show your machine's real model at the top, and never lie to you about what the hardware is actually
+doing.
+
+The interface ships in Spanish by default and falls back to English when your system asks for it.
+
+> [!WARNING]
+> This plugin runs with **root privileges** and changes low-level power, thermal, and firmware
+> settings on your device. It talks only to documented kernel interfaces and is designed to fail
+> safe, but you use it **at your own risk**. There is no warranty (see the [LICENSE](LICENSE)).
+
+## What it does
+
+The panel is organized into tabs. Each one covers a part of the machine.
+
+### Power (Potencia)
+
+The heart of the plugin. A visual arc that fills with TDP across your machine's real range (no made
+up numbers, it reads them from firmware). You set the watts with a slider, get quick presets, and
+can save a global profile or a per-game one.
+
+- **Auto-TDP.** An automatic mode that watches GPU load and raises or lowers power on its own to give
+  you the frames you need while spending as little as possible. It learns from how you play and
+  self-corrects, no need to touch anything.
+- **Advanced modes.** If your firmware allows it, a collapsible section to fine-tune the boost limits
+  (SPPT and FPPT) as margins over the base limit.
+- **GPU clock.** Set the minimum and maximum graphics clock.
+
+### System (Sistema)
+
+Everything that isn't raw power but is day-to-day management.
+
+- **Battery.** State, health, cycles and capacity, in a card that fills up and changes color. It
+  includes a charge limit (cap charging at a percentage to protect the battery), adapted to how each
+  vendor exposes it.
+- **CPU.** Toggles for multithreading (SMT) and turbo boost, with a cores-and-threads view and the
+  base-to-turbo frequency range.
+- **Brightness and volume.** Sliders that show the exact number, something Steam's native controls
+  hide.
+- **Download Mode.** A single button for leaving the machine downloading a game unattended: it drops
+  TDP to the minimum, turns off boost and dims the screen while you aren't touching it. Fully
+  reversible.
+- **RGB lighting.** If you have the sibling plugin [Colores](https://github.com/Hooandee/decky-colores)
+  installed, this card opens it; if not, it offers to install it.
+
+### Fans (Ventiladores)
+
+It starts as a live monitor (RPM and CPU/GPU temperatures with sparklines) and, on machines that
+allow it, turns into a temperature-to-speed curve editor you can drag with your finger, with presets
+(quiet, balanced, performance) and per-game curves.
+
+It also learns. Over time it suggests a curve tuned to how each game behaves on your machine, and you
+can apply it with one tap. If your machine doesn't allow writing the curve, the editor hides itself
+and tells you exactly why, instead of pretending it works.
+
+### Display (Pantalla)
+
+Panel color calibration through gamescope: per-game saturation, global temperature and contrast, and
+a one-tap "OLED look" preset for panels that aren't OLED. It comes with a confirmation timer that
+reverts changes only if something looks wrong, so you never get stuck with an unreadable screen.
+
+### Controllers (Mandos)
+
+Button remapping that cooperates with the daemon already controlling your gamepad (Handheld Daemon on
+Bazzite, InputPlumber on SteamOS) instead of fighting it. It shows a warning in Settings if it
+detects a configuration conflict. This part is still early.
+
+### Settings (Ajustes)
+
+Language (with flags, not a dropdown), the "learn from my usage" switch (telemetry is 100% local and
+can be turned off), and a button to erase what has been learned.
+
+## Per-device compatibility
+
+Panel de Control knows nine models and, for anything else, tries to work by probing the real
+capabilities of the hardware. This table sums up what you'll find in each family. Differences usually
+come from what the vendor lets you touch in firmware, not from the plugin.
+
+Legend: **●** works · **◐** limited, read-only or default values · **○** not available
+
+| Feature | Steam Deck | ROG Ally | Legion Go | MSI Claw 8 AI+ | Other devices |
+|---|:---:|:---:|:---:|:---:|:---:|
+| TDP limit | ● | ● | ● | ● | ◐ |
+| Advanced modes (SPPT/FPPT) | ○ | ● | ● | ○ | ○ |
+| Auto-TDP by GPU load | ● [¹](#notes) | ● | ● | ○ [²](#notes) | ◐ |
+| GPU clock | ● | ● | ● | ● | ◐ |
+| Battery: state, health, cycles | ● | ● | ● | ● | ● |
+| Charge limit | ● | ● | ◐ [³](#notes) | ◐ | ◐ |
+| CPU: turbo boost | ● | ● | ● | ● | ◐ |
+| CPU: multithreading (SMT) | ● | ● | ● | ○ [⁴](#notes) | ◐ |
+| CPU: active cores | ● | ● | ● | ● | ● |
+| Brightness and volume | ● | ● | ● | ● | ● |
+| Download Mode | ● | ● | ● | ● | ● |
+| Fan monitor | ● | ● | ● | ● | ● |
+| Fan curves | ● | ● | ◐ [⁵](#notes) | ● | ◐ |
+| Learned per-game curves | ● | ● | ◐ [⁵](#notes) | ● | ◐ |
+| Color calibration | ● | ● | ● | ● [⁶](#notes) | ● |
+| "OLED look" preset | ◐ [⁷](#notes) | ● | ◐ [⁷](#notes) | ● | ● |
+| Controller remap (beta) | ◐ | ◐ | ◐ | ◐ | ○ |
+| RGB lighting (via Colores) | ○ [⁸](#notes) | ● | ● | ● | ◐ |
+
+Each family covers: **Steam Deck** (LCD and OLED), **ROG Ally** (Ally 2023, Ally X, Xbox Ally X),
+**Legion Go** (Go, Go S, Go 2). Every other handheld falls under "Other devices", where the plugin
+marks itself as experimental and works with whatever it can probe.
+
+### Notes
+
+1. On the Steam Deck the GPU-load reading is instantaneous and very noisy; auto-TDP averages it
+   before deciding.
+2. Power profiling on Intel (RAPL / i915) isn't implemented yet, so GPU-based auto-TDP isn't
+   available on the Claw. The rest of the TDP control is.
+3. On Legion, the charge limit is a "conservation mode" toggle with a firmware-fixed percentage, not
+   an adjustable value. On the Claw it depends on what each unit exposes.
+4. The Claw's Intel Core Ultra has no hyperthreading, so there's no multithreading to enable or
+   disable.
+5. Legion Go 2 has a full curve; Legion Go S only coarse modes (quiet, balanced, performance); the
+   original Legion Go is limited depending on the OS.
+6. On Intel the color is only applied while the compositor is active, so that path is forced and the
+   small cost is disclosed.
+7. The "OLED look" preset is hidden on panels that are already OLED (Steam Deck OLED, Legion Go 2)
+   since it makes no sense there.
+8. The Steam Deck has no RGB lighting, so this card doesn't appear.
+
+## Installation
+
+Panel de Control is distributed outside the Decky store. Install [Decky Loader](https://decky.xyz/)
+first, then:
+
+1. Download `Panel de Control.zip` from the [latest release](https://github.com/Hooandee/panel-de-control/releases/latest).
+2. In Decky, use **Developer Mode → Install Plugin from ZIP** (or your preferred manual install
+   method).
+
+Once installed, the plugin can update itself from within its settings.
+
+### Verifying a download (recommended)
+
+Every release zip is signed with build provenance. Confirm it really came from this repository's
+pipeline before installing:
+
+```sh
+gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
+```
+
+## Building from source
+
+Toolchain: **pnpm 10**, **Node 20**, **Python 3.11**.
+
+```sh
+pnpm install --frozen-lockfile
+pnpm build          # produces dist/index.js
+```
+
+Copy the resulting folder to `~/homebrew/plugins/` on your device and restart Decky. The Python
+backend needs root (the plugin declares it) to write to sysfs; model detection, on the other hand,
+doesn't. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full test gate and development setup.
+
+## How it learns (and why it stays local)
+
+The point of Panel de Control isn't just having nice buttons, it's that it learns from how you play
+each game to suggest a better setup: which fan curve keeps you cool without noise, which power gives
+you stable frames without draining the battery. All that learning stays on your device, never leaves
+it, and you can turn it off or wipe it whenever you want from Settings.
+
+The principle running through the whole project: never fake it. If a reading isn't available it's
+hidden instead of showing a fake zero. If the hardware rejects a change, the interface reflects it. A
+number on screen is a real number.
+
+## Acknowledgments
+
+This plugin stands on the work of many people in the handheld community. We reference kernel
+interfaces (which are facts, not code) freely, and when we adapt ideas or code we credit it here. The
+full list with licenses is in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
+- **[SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP)** (BSD-3, Aarron Lee). The primary
+  reference for the per-device TDP mechanism: the Lenovo and ASUS firmware-attributes paths, the
+  `platform_profile=custom` prestep, and ryzenadj usage.
+- **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Reference for the
+  per-device strategy, re-applying on resume and on AC/DC changes, and cooperating with the
+  controller daemon. We only reference the approach, we don't copy its code.
+- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Bundled as a binary for the generic
+  AMD path when there's no better firmware route.
+- **[PowerControl](https://github.com/mengmeet/PowerControl)**. Origin of the Lenovo
+  firmware-attributes path that SimpleDeckyTDP inherits.
+- **[Fantastic](https://git.ngram.ca/NG-SD-Plugins/Fantastic)** and **[PowerTools](https://git.ngni.us/NG-SD-Plugins/PowerTools)**.
+  Reference for the fan monitor and curve control and for periodic re-apply.
+- **[Decky Loader](https://decky.xyz/)** and its plugin template. The base everything runs on.
+- **The Linux kernel documentation** (firmware-attributes, powercap, asus-wmi, hwmon, power_supply).
+  The source of the sysfs paths we read and write.
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+Found a vulnerability? Please report it privately, see the [Security Policy](SECURITY.md). Do not
+open a public issue.
+
+## License
+
+[BSD-3-Clause](LICENSE) © Hooandee. The bundled ryzenadj binary keeps its own LGPL-3.0 license.
+Third-party attributions are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -1,76 +1,214 @@
 # Panel de Control
 
-The ultimate control center for handheld gaming PCs — configure TDP, fan curves, the
-display, the battery and controllers from a beautiful, easy-to-use
-[Decky Loader](https://decky.xyz/) panel. Spanish-first, with English support.
+**Español** · [English](README.en.md)
+
+El centro de control que le faltaba a tu PC portátil de juego. Ajusta la potencia, las curvas de
+ventilador, la batería, la pantalla y los mandos desde un único panel dentro del menú de acceso
+rápido de Steam, sin salir del juego y sin memorizar rutas de sysfs.
+
+Es un plugin para [Decky Loader](https://decky.xyz/). Está pensado para Steam Deck, ROG Ally, Legion
+Go, MSI Claw y compañía, con una idea fija: que cada control se vea bien, muestre siempre el modelo
+real de tu equipo arriba, y nunca te mienta sobre lo que de verdad está pasando en el hardware.
+
+La interfaz viene en español por defecto y cae a inglés si tu sistema lo pide.
 
 > [!WARNING]
-> This plugin runs with **root privileges** and changes low-level power, thermal, and
-> firmware settings on your device. It talks only to documented kernel interfaces and
-> is designed to fail safe, but you use it **at your own risk**. There is no warranty
-> (see the [LICENSE](LICENSE)).
+> Este plugin corre con **privilegios de root** y cambia ajustes de bajo nivel de potencia,
+> temperatura y firmware de tu equipo. Solo habla con interfaces documentadas del kernel y está
+> diseñado para fallar de forma segura, pero lo usas **bajo tu propia responsabilidad**. No hay
+> garantía (mira la [LICENCIA](LICENSE)).
 
-## Features
+## Qué hace
 
-- **Potencia** — per-device TDP control with a live power gauge, per-game profiles,
-  advanced PL1/SPPT/FPPT boost, and an optional GPU-driven auto-TDP.
-- **Ventiladores** — live fan/temperature monitor plus a temp→fan curve editor with
-  presets and learned suggestions (per device; honestly hidden where the firmware
-  doesn't allow it).
-- **Sistema** — brightness, volume, battery (health, cycles, charge limit), CPU
-  (SMT / turbo), a low-power "download" mode, and RGB via the companion Colores plugin.
-- **Pantalla** — panel color calibration (saturation / temperature / contrast).
-- **Mandos** — cooperative controller remapping that works alongside the device's
-  resident controller daemon.
+El panel se organiza en pestañas. Cada una cubre una parte del equipo.
 
-## Supported devices
+### Potencia
 
-Steam Deck (LCD / OLED), ROG Ally · Ally X · Xbox Ally X, Legion Go · Go S · Go 2,
-and the MSI Claw 8 AI+. Unrecognized hardware falls back to a generic profile, and
-each control is hidden when the device doesn't support it.
+El corazón del plugin. Un arco visual que se llena con el TDP a lo largo del rango real de tu
+máquina (no valores inventados: los lee del firmware). Ajustas los vatios con un deslizador, tienes
+presets rápidos, y puedes guardar un perfil global o uno propio por juego.
 
-## Installation
+- **Auto-TDP.** Un modo automático que observa la carga de la GPU y sube o baja la potencia sola
+  para darte los fotogramas que necesitas gastando lo mínimo. Aprende de cómo juegas y se
+  autocorrige; no hace falta que toques nada.
+- **Modos avanzados.** Si tu firmware lo permite, un apartado plegable para afinar los límites de
+  boost (SPPT y FPPT) como márgenes sobre el límite base.
+- **Frecuencia de GPU.** Fija el reloj mínimo y máximo de la gráfica.
 
-Panel de Control is distributed outside the Decky store. Install [Decky Loader](https://decky.xyz/)
-first, then:
+### Sistema
 
-1. Download `Panel de Control.zip` from the [latest release](https://github.com/Hooandee/panel-de-control/releases/latest).
-2. In Decky, use **Developer Mode → Install Plugin from ZIP** (or your preferred manual
-   install method).
+Todo lo que no es potencia pura pero sí gestión del día a día.
 
-Once installed, the plugin can update itself from within its settings.
+- **Batería.** Estado, salud, ciclos y capacidad, con una tarjeta que se rellena y cambia de color.
+  Incluye límite de carga (topar la carga en un porcentaje para cuidar la batería), adaptado a cómo
+  lo expone cada fabricante.
+- **CPU.** Interruptores para el multihilo (SMT) y el turbo boost, con una vista de núcleos e hilos
+  y el rango de frecuencia base a turbo.
+- **Brillo y volumen.** Deslizadores que muestran el número exacto, algo que los controles nativos
+  de Steam esconden.
+- **Modo Descarga.** Un botón para dejar el equipo bajando un juego desatendido: baja el TDP al
+  mínimo, apaga el boost y atenúa la pantalla cuando no lo estás tocando. Todo reversible.
+- **Iluminación RGB.** Si tienes instalado el plugin hermano [Colores](https://github.com/Hooandee/decky-colores),
+  esta tarjeta lo abre; si no, te ofrece instalarlo.
 
-### Verifying a download (recommended)
+### Ventiladores
 
-Every release zip is signed with build provenance. Confirm it really came from this
-repository's pipeline before installing:
+Empieza como un monitor en vivo (RPM y temperaturas de CPU y GPU con gráficas) y, en los equipos que
+lo permiten, se convierte en un editor de curvas temperatura a velocidad que puedes arrastrar con el
+dedo, con presets (silencioso, equilibrado, rendimiento) y curvas por juego.
+
+Además aprende. Con el tiempo te propone una curva ajustada a cómo se comporta cada juego en tu
+equipo, y puedes aplicarla de un toque. Si tu máquina no deja escribir la curva, el editor se oculta
+y se te dice claramente por qué, en lugar de fingir que funciona.
+
+### Pantalla
+
+Calibración de color del panel a través de gamescope: saturación por juego, temperatura y contraste
+globales, y un preset "Aspecto OLED" de un toque para los paneles que no son OLED. Trae un
+temporizador de confirmación que revierte los cambios solo si algo se ve mal, para que no te quedes
+con una pantalla ilegible.
+
+### Mandos
+
+Remapeo de botones cooperando con el demonio que ya controla el mando en tu sistema (Handheld Daemon
+en Bazzite, InputPlumber en SteamOS), en lugar de pelearse con él. Incluye un aviso en Ajustes si
+detecta un conflicto de configuración. Esta parte está todavía en fase temprana.
+
+### Ajustes
+
+Idioma (con banderas, no un desplegable), el interruptor de "aprender de mi uso" (la telemetría es
+100% local y se puede apagar), y un botón para borrar lo aprendido.
+
+## Compatibilidad por equipo
+
+Panel de Control conoce nueve modelos y, para cualquier otro, intenta funcionar sondeando las
+capacidades reales del hardware. Esta tabla resume qué encontrarás en cada familia. Las diferencias
+suelen venir de lo que el fabricante deja tocar por firmware, no del plugin.
+
+Leyenda: **●** funciona · **◐** limitado, solo lectura o valores por defecto · **○** no disponible
+
+| Característica | Steam Deck | ROG Ally | Legion Go | MSI Claw 8 AI+ | Otros equipos |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Límite de TDP | ● | ● | ● | ● | ◐ |
+| Modos avanzados (SPPT/FPPT) | ○ | ● | ● | ○ | ○ |
+| Auto-TDP por carga de GPU | ● [¹](#notas) | ● | ● | ○ [²](#notas) | ◐ |
+| Frecuencia de GPU | ● | ● | ● | ● | ◐ |
+| Batería: estado, salud, ciclos | ● | ● | ● | ● | ● |
+| Límite de carga | ● | ● | ◐ [³](#notas) | ◐ | ◐ |
+| CPU: turbo boost | ● | ● | ● | ● | ◐ |
+| CPU: multihilo (SMT) | ● | ● | ● | ○ [⁴](#notas) | ◐ |
+| CPU: núcleos activos | ● | ● | ● | ● | ● |
+| Brillo y volumen | ● | ● | ● | ● | ● |
+| Modo Descarga | ● | ● | ● | ● | ● |
+| Monitor de ventiladores | ● | ● | ● | ● | ● |
+| Curvas de ventilador | ● | ● | ◐ [⁵](#notas) | ● | ◐ |
+| Curvas aprendidas por juego | ● | ● | ◐ [⁵](#notas) | ● | ◐ |
+| Calibración de color | ● | ● | ● | ● [⁶](#notas) | ● |
+| Preset "Aspecto OLED" | ◐ [⁷](#notas) | ● | ◐ [⁷](#notas) | ● | ● |
+| Remapeo de mandos (beta) | ◐ | ◐ | ◐ | ◐ | ○ |
+| Iluminación RGB (vía Colores) | ○ [⁸](#notas) | ● | ● | ● | ◐ |
+
+Cada familia agrupa: **Steam Deck** (LCD y OLED), **ROG Ally** (Ally 2023, Ally X, Xbox Ally X),
+**Legion Go** (Go, Go S, Go 2). El resto de portátiles caen en "Otros equipos", donde el plugin se
+marca como experimental y funciona con lo que consiga sondear.
+
+### Notas
+
+1. En Steam Deck la lectura de carga de GPU es instantánea y muy ruidosa; el auto-TDP la promedia
+   antes de decidir.
+2. El perfilado de consumo en Intel (RAPL / i915) todavía no está implementado, así que el auto-TDP
+   por GPU no está disponible en el Claw. El resto del control de TDP sí.
+3. En Legion el límite de carga es un interruptor de "modo conservación" con un porcentaje fijo por
+   firmware, no un valor ajustable. En el Claw depende de lo que exponga cada unidad.
+4. El Intel Core Ultra del Claw no tiene hyperthreading, así que no hay multihilo que activar o
+   desactivar.
+5. Legion Go 2 tiene curva completa; Legion Go S solo modos gruesos (silencioso, equilibrado,
+   rendimiento); el Legion Go original queda limitado según el sistema.
+6. En Intel el color solo se aplica mientras el compositor está activo, así que se fuerza esa ruta y
+   se avisa del pequeño coste.
+7. El preset "Aspecto OLED" se oculta en los paneles que ya son OLED (Steam Deck OLED, Legion Go 2)
+   porque no tiene sentido allí.
+8. La Steam Deck no lleva iluminación RGB, así que esta tarjeta no aparece.
+
+## Instalación
+
+Panel de Control se distribuye fuera de la tienda de Decky. Instala primero
+[Decky Loader](https://decky.xyz/) y luego:
+
+1. Descarga `Panel de Control.zip` de la [última release](https://github.com/Hooandee/panel-de-control/releases/latest).
+2. En Decky, usa **Modo desarrollador → Instalar plugin desde ZIP** (o tu método de instalación
+   manual preferido).
+
+Una vez instalado, el plugin puede actualizarse solo desde sus ajustes.
+
+### Verificar la descarga (recomendado)
+
+Cada zip de release va firmado con build provenance. Antes de instalar, confirma que de verdad salió
+del pipeline de este repositorio:
 
 ```sh
 gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
 ```
 
-## Building from source
+## Compilar desde el código
 
-Toolchain: **pnpm 10**, **Node 20**, **Python 3.11**.
+Herramientas: **pnpm 10**, **Node 20**, **Python 3.11**.
 
 ```sh
 pnpm install --frozen-lockfile
-pnpm build          # produces dist/index.js
+pnpm build          # genera dist/index.js
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full test gate and development setup.
+Copia la carpeta resultante a `~/homebrew/plugins/` en tu equipo y reinicia Decky. El backend en
+Python necesita root (lo declara el plugin) para escribir en sysfs; la detección del modelo, en
+cambio, no lo necesita. Mira [CONTRIBUTING.md](CONTRIBUTING.md) para el conjunto de pruebas completo
+y la configuración de desarrollo.
 
-## Contributing
+## Cómo aprende (y por qué es local)
 
-Contributions are welcome — please read [CONTRIBUTING.md](CONTRIBUTING.md) and the
-[Code of Conduct](CODE_OF_CONDUCT.md).
+La gracia de Panel de Control no es solo tener botones bonitos, es que aprende de cómo usas cada
+juego para proponerte una configuración mejor: qué curva de ventilador te mantiene fresco sin ruido,
+qué potencia te da fotogramas estables sin vaciar la batería. Todo ese aprendizaje se queda en tu
+equipo, no sale de él, y puedes apagarlo o borrarlo cuando quieras desde Ajustes.
 
-## Security
+El principio que atraviesa todo el proyecto: nunca fingir. Si una lectura no está disponible, se
+oculta en vez de mostrar un cero falso. Si el hardware rechaza un cambio, la interfaz lo refleja. Un
+número en pantalla es un número real.
 
-Found a vulnerability? Please report it privately — see the
-[Security Policy](SECURITY.md). Do not open a public issue.
+## Agradecimientos
 
-## License
+Este plugin se apoya en el trabajo de mucha gente de la comunidad de handhelds. Referenciamos
+interfaces del kernel (que son hechos, no código) libremente, y cuando adaptamos ideas o código lo
+citamos aquí. La lista completa con licencias está en [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
-[BSD-3-Clause](LICENSE) © Hooandee. Third-party attributions are listed in
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+- **[SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP)** (BSD-3, Aarron Lee). La
+  referencia principal del mecanismo de TDP por dispositivo: las rutas de firmware-attributes de
+  Lenovo y ASUS, el paso previo de `platform_profile=custom`, y el uso de ryzenadj.
+- **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Referencia para la
+  estrategia por dispositivo, la reaplicación al despertar y al cambiar de corriente, y la
+  cooperación con el demonio de mandos. Solo consultamos el enfoque, no copiamos su código.
+- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Lo incluimos como binario para el
+  camino genérico de AMD cuando no hay una ruta de firmware mejor.
+- **[PowerControl](https://github.com/mengmeet/PowerControl)**. Origen de la ruta de
+  firmware-attributes de Lenovo que hereda SimpleDeckyTDP.
+- **[Fantastic](https://git.ngram.ca/NG-SD-Plugins/Fantastic)** y **[PowerTools](https://git.ngni.us/NG-SD-Plugins/PowerTools)**.
+  Referencia para el monitor y el control de ventiladores y para la reaplicación periódica.
+- **[Decky Loader](https://decky.xyz/)** y su plantilla de plugins. La base sobre la que corre todo
+  esto.
+- **La documentación del kernel de Linux** (firmware-attributes, powercap, asus-wmi, hwmon,
+  power_supply). De donde salen las rutas de sysfs que leemos y escribimos.
+
+## Contribuir
+
+Las contribuciones son bienvenidas. Lee [CONTRIBUTING.md](CONTRIBUTING.md) y el
+[Código de Conducta](CODE_OF_CONDUCT.md).
+
+## Seguridad
+
+¿Encontraste una vulnerabilidad? Repórtala en privado, mira la [Política de Seguridad](SECURITY.md).
+No abras un issue público.
+
+## Licencia
+
+[BSD-3-Clause](LICENSE) © Hooandee. El binario de ryzenadj que se distribuye conserva su propia
+licencia LGPL-3.0. Las atribuciones de terceros están en [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
## Qué incluye

**README bilingüe.** `README.md` reescrito en español natural (el idioma por defecto del plugin) y un espejo en inglés `README.en.md`, enlazados entre sí arriba. Ambos conservan el aviso de privilegios root, las instrucciones de instalación/verificación y los enlaces a los ficheros de comunidad que ya existían.

Cada README trae:
- Explicación por pestañas (Potencia, Sistema, Ventiladores, Pantalla, Mandos, Ajustes) de qué hace y por qué.
- **Tabla de compatibilidad por equipo** (Steam Deck · ROG Ally · Legion Go · MSI Claw · Otros) con tres estados: funciona / limitado o por defecto / no disponible, y notas al pie explicando cada caso (auto-TDP no en Intel, SMT no en el Claw, límite de carga fijo en Legion, curva gruesa en Go S, etc.). Los datos salen del código real (`device_profiles.py`, backends de TDP/ventiladores/carga).
- Sección de **agradecimientos** (SimpleDeckyTDP, HHD, RyzenAdj, PowerControl, Fantastic/PowerTools, Decky Loader, doc del kernel), con enlace a `THIRD_PARTY_NOTICES.md`.

**Arreglo del pipeline de release.** El release 0.3.0 salió sin `Panel de Control.zip` porque el paso de build provenance (`actions/attest-build-provenance`) falla en repos privados de usuario y abortaba el job antes de subir el asset. Ahora:
- El zip se sube **antes** de la atestación, así la firma nunca puede bloquear el asset.
- La atestación se salta mientras el repo sea privado (`!github.event.repository.private`) y se activa sola al hacerse público.
- Se empaqueta también `README.en.md` en el zip.