### PR TITLE
docs: honest per-device compatibility table (correct fan rows)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,53 +82,77 @@ can be turned off), and a button to erase what has been learned.
 ## Per-device compatibility
 
 Panel de Control knows nine models and, for anything else, tries to work by probing the real
-capabilities of the hardware. This table sums up what you'll find in each family. Differences usually
-come from what the vendor lets you touch in firmware, not from the plugin.
+capabilities of the hardware. This table is honest about what's **verified on each device** and what
+isn't yet: we'd rather show "unconfirmed" than a false "yes". Differences come from what each vendor
+lets you touch in firmware and from each distro's kernel.
 
-Legend: **●** works · **◐** limited, read-only or default values · **○** not available
+Legend: **✅** verified on that device · **⚠️** limited or default only · **❌** not available · **❔**
+supported in code but not confirmed on that device yet
 
-| Feature | Steam Deck | ROG Ally | Legion Go | MSI Claw 8 AI+ | Other devices |
-|---|:---:|:---:|:---:|:---:|:---:|
-| TDP limit | ● | ● | ● | ● | ◐ |
-| Advanced modes (SPPT/FPPT) | ○ | ● | ● | ○ | ○ |
-| Auto-TDP by GPU load | ● [¹](#notes) | ● | ● | ○ [²](#notes) | ◐ |
-| GPU clock | ● | ● | ● | ● | ◐ |
-| Battery: state, health, cycles | ● | ● | ● | ● | ● |
-| Charge limit | ● | ● | ◐ [³](#notes) | ◐ | ◐ |
-| CPU: turbo boost | ● | ● | ● | ● | ◐ |
-| CPU: multithreading (SMT) | ● | ● | ● | ○ [⁴](#notes) | ◐ |
-| CPU: active cores | ● | ● | ● | ● | ● |
-| Brightness and volume | ● | ● | ● | ● | ● |
-| Download Mode | ● | ● | ● | ● | ● |
-| Fan monitor | ● | ● | ● | ● | ● |
-| Fan curves | ● | ● | ◐ [⁵](#notes) | ● | ◐ |
-| Learned per-game curves | ● | ● | ◐ [⁵](#notes) | ● | ◐ |
-| Color calibration | ● | ● | ● | ● [⁶](#notes) | ● |
-| "OLED look" preset | ◐ [⁷](#notes) | ● | ◐ [⁷](#notes) | ● | ● |
-| Controller remap (beta) | ◐ | ◐ | ◐ | ◐ | ○ |
-| RGB lighting (via Colores) | ○ [⁸](#notes) | ● | ● | ● | ◐ |
+| Feature | Steam Deck LCD | Steam Deck OLED | ROG Ally | ROG Ally X | ROG Xbox Ally X | Legion Go | Legion Go S | Legion Go 2 | MSI Claw 8 AI+ |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| TDP limit | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| Advanced modes (SPPT/FPPT) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [¹](#notes) |
+| Auto-TDP by GPU load | ✅ [²](#notes) | ✅ [²](#notes) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [³](#notes) |
+| GPU clock | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) |
+| Battery: state and health | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Battery cycle count | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ✅ | ❔ | ✅ | ❌ [⁵](#notes) |
+| Charge limit | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notes) | ❔ | ⚠️ [⁷](#notes) | ❔ |
+| CPU: turbo boost | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| CPU: multithreading (SMT) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [⁸](#notes) |
+| CPU: active cores | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| Brightness and volume | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Download Mode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Temperature monitor | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ✅ [⁹](#notes) |
+| Fan RPM monitor | ❔ | ❔ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Fan curves | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notes) | ⚠️ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Learned per-game curves | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notes) | ❌ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Color calibration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ [¹³](#notes) |
+| "OLED look" preset | ✅ | ❌ [¹⁴](#notes) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁴](#notes) | ✅ |
+| Controller remap (beta) | ❔ | ❔ | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ❔ | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) |
+| RGB lighting (via Colores) | ❌ [¹⁶](#notes) | ❌ [¹⁶](#notes) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-Each family covers: **Steam Deck** (LCD and OLED), **ROG Ally** (Ally 2023, Ally X, Xbox Ally X),
-**Legion Go** (Go, Go S, Go 2). Every other handheld falls under "Other devices", where the plugin
-marks itself as experimental and works with whatever it can probe.
+Any other handheld falls under an **experimental generic** profile: the plugin probes the real
+capabilities and shows what it can, honestly hiding the rest.
 
 ### Notes
 
-1. On the Steam Deck the GPU-load reading is instantaneous and very noisy; auto-TDP averages it
+1. The Claw controls TDP through `intel-rapl`, which only exposes the base limit (PL1); there are no
+   separate boost rails to tune.
+2. On the Steam Deck the GPU-load reading is instantaneous and very noisy; auto-TDP averages it
    before deciding.
-2. Power profiling on Intel (RAPL / i915) isn't implemented yet, so GPU-based auto-TDP isn't
-   available on the Claw. The rest of the TDP control is.
-3. On Legion, the charge limit is a "conservation mode" toggle with a firmware-fixed percentage, not
-   an adjustable value. On the Claw it depends on what each unit exposes.
-4. The Claw's Intel Core Ultra has no hyperthreading, so there's no multithreading to enable or
+3. Power profiling on Intel (RAPL / i915) isn't implemented yet, so GPU-based auto-TDP isn't
+   available on the Claw. The rest of the TDP control works.
+4. GPU-clock writing is implemented per device, but it hasn't been confirmed with a live change on
+   any machine yet. Marked as unconfirmed until validated.
+5. The cycle counter is only populated by Lenovo firmware; on ASUS, Steam Deck and MSI the node
+   reports a fake 0, so it's hidden instead of showing an invented zero.
+6. The original Legion Go (83E1) doesn't expose `conservation_mode`, so it offers no charge limit.
+7. On Legion the charge limit is a "conservation mode" toggle with a firmware-fixed percentage, not
+   an adjustable value.
+8. The Claw's Intel Core Ultra has no hyperthreading, so there's no multithreading to enable or
    disable.
-5. Legion Go 2 has a full curve; Legion Go S only coarse modes (quiet, balanced, performance); the
-   original Legion Go is limited depending on the OS.
-6. On Intel the color is only applied while the compositor is active, so that path is forced and the
-   small cost is disclosed.
-7. The "OLED look" preset is hidden on panels that are already OLED (Steam Deck OLED, Legion Go 2)
-   since it makes no sense there.
-8. The Steam Deck has no RGB lighting, so this card doesn't appear.
+9. On the MSI Claw the fan chip (`msi_wmi_platform`) is read-only on its current kernel, so there are
+   no curves and the editor is hidden. `coretemp` provides temperatures but exposes no fan RPM, which
+   is why the monitor shows no fans on the Claw.
+10. The Legion Go 2 exposes no writable hwmon fan; RPM would have to be read over the EC, and on the
+    current build it isn't showing up in the monitor. Marked as not available / unconfirmed until
+    reviewed on your device.
+11. The original Legion Go controls the fan via `acpi_call` (GZFD), which exists on Bazzite but not on
+    SteamOS; applying the curve also forces TDP into custom mode.
+12. The Legion Go S only allows coarse fan modes (quiet, balanced, performance), not a freeform curve,
+    so it can't apply a learned curve either.
+13. On Intel the color is only applied while the compositor is active, so that path is forced and the
+    small cost is disclosed.
+14. The "OLED look" preset is hidden on panels that are already OLED (Steam Deck OLED, Legion Go 2)
+    since it makes no sense there.
+15. Remapping cooperates with the system daemon (HHD on Bazzite, InputPlumber on SteamOS). It's early,
+    and on Legion some back buttons aren't detected well yet.
+16. The Steam Deck has no RGB lighting, so this card doesn't appear.
+
+> Cells marked **❔** are the ones I haven't confirmed on that specific device. If you have the
+> hardware in front of you and see something works (or doesn't), tell me and I'll fix it: this table
+> should reflect reality, not what the code tries to do.
 
 ## Installation
 

--- a/README.en.md
+++ b/README.en.md
@@ -95,18 +95,18 @@ supported in code but not confirmed on that device yet
 | Advanced modes (SPPT/FPPT) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [¹](#notes) |
 | Auto-TDP by GPU load | ✅ [²](#notes) | ✅ [²](#notes) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [³](#notes) |
 | GPU clock | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) | ❔ [⁴](#notes) |
-| Battery: state and health | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Battery: state and health | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | Battery cycle count | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ❌ [⁵](#notes) | ✅ | ❔ | ✅ | ❌ [⁵](#notes) |
-| Charge limit | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notes) | ❔ | ⚠️ [⁷](#notes) | ❔ |
+| Charge limit | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notes) | ❔ | ⚠️ [⁷](#notes) | ✅ |
 | CPU: turbo boost | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | CPU: multithreading (SMT) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [⁸](#notes) |
 | CPU: active cores | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
-| Brightness and volume | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Brightness and volume | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | Download Mode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
-| Temperature monitor | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ✅ [⁹](#notes) |
-| Fan RPM monitor | ❔ | ❔ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ [¹⁰](#notes) | ❌ [⁹](#notes) |
-| Fan curves | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notes) | ⚠️ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
-| Learned per-game curves | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notes) | ❌ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Temperature monitor | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ [⁹](#notes) |
+| Fan RPM monitor | ❔ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Fan curves | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹¹](#notes) | ⚠️ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
+| Learned per-game curves | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹¹](#notes) | ❌ [¹²](#notes) | ❔ [¹⁰](#notes) | ❌ [⁹](#notes) |
 | Color calibration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ [¹³](#notes) |
 | "OLED look" preset | ✅ | ❌ [¹⁴](#notes) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁴](#notes) | ✅ |
 | Controller remap (beta) | ❔ | ❔ | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) | ❔ | ⚠️ [¹⁵](#notes) | ⚠️ [¹⁵](#notes) |
@@ -138,8 +138,9 @@ capabilities and shows what it can, honestly hiding the rest.
 10. The Legion Go 2 exposes no writable hwmon fan; RPM would have to be read over the EC, and on the
     current build it isn't showing up in the monitor. Marked as not available / unconfirmed until
     reviewed on your device.
-11. The original Legion Go controls the fan via `acpi_call` (GZFD), which exists on Bazzite but not on
-    SteamOS; applying the curve also forces TDP into custom mode.
+11. The original Legion Go needs `acpi_call` (GZFD) for fan curves; it's present on Bazzite but not on
+    SteamOS, so without it no curve shows up at all (not even a default one). Where it works, applying
+    the curve forces TDP into custom mode. The monitor (speed + temperature) does work.
 12. The Legion Go S only allows coarse fan modes (quiet, balanced, performance), not a freeform curve,
     so it can't apply a learned curve either.
 13. On Intel the color is only applied while the compositor is active, so that path is forced and the

--- a/README.md
+++ b/README.md
@@ -95,18 +95,18 @@ Leyenda: **✅** comprobado en ese equipo · **⚠️** limitado o solo por defe
 | Modos avanzados (SPPT/FPPT) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [¹](#notas) |
 | Auto-TDP por carga de GPU | ✅ [²](#notas) | ✅ [²](#notas) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [³](#notas) |
 | Frecuencia de GPU | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) |
-| Batería: estado y salud | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Batería: estado y salud | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | Ciclos de batería | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ✅ | ❔ | ✅ | ❌ [⁵](#notas) |
-| Límite de carga | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notas) | ❔ | ⚠️ [⁷](#notas) | ❔ |
+| Límite de carga | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notas) | ❔ | ⚠️ [⁷](#notas) | ✅ |
 | CPU: turbo boost | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | CPU: multihilo (SMT) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [⁸](#notas) |
 | CPU: núcleos activos | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
-| Brillo y volumen | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Brillo y volumen | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
 | Modo Descarga | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
-| Monitor de temperaturas | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ✅ [⁹](#notas) |
-| Monitor de RPM de ventilador | ❔ | ❔ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ [¹⁰](#notas) | ❌ [⁹](#notas) |
-| Curvas de ventilador | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notas) | ⚠️ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
-| Curvas aprendidas por juego | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notas) | ❌ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Monitor de temperaturas | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ [⁹](#notas) |
+| Monitor de RPM de ventilador | ❔ | ❔ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Curvas de ventilador | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹¹](#notas) | ⚠️ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Curvas aprendidas por juego | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹¹](#notas) | ❌ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
 | Calibración de color | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ [¹³](#notas) |
 | Preset "Aspecto OLED" | ✅ | ❌ [¹⁴](#notas) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁴](#notas) | ✅ |
 | Remapeo de mandos (beta) | ❔ | ❔ | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ❔ | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) |
@@ -138,8 +138,10 @@ reales y muestra lo que consigue, ocultando honestamente el resto.
 10. La Legion Go 2 no expone un ventilador escribible por hwmon; el RPM tendría que leerse por el EC
     y en la build actual no está apareciendo en el monitor. Por eso lo marco como no disponible / sin
     confirmar hasta revisarlo en tu equipo.
-11. La Legion Go original controla el ventilador vía `acpi_call` (GZFD), que existe en Bazzite pero
-    no en SteamOS; además aplicar la curva fuerza el TDP a modo custom.
+11. La Legion Go original necesita `acpi_call` (GZFD) para las curvas de ventilador; está presente en
+    Bazzite pero no en SteamOS, así que sin él no aparece ninguna curva (ni siquiera por defecto).
+    Donde funciona, aplicar la curva fuerza el TDP a modo custom. El monitor (velocidad + temperatura)
+    sí funciona.
 12. La Legion Go S solo permite modos gruesos de ventilador (silencioso, equilibrado, rendimiento),
     no una curva libre, así que tampoco puede aplicar una curva aprendida.
 13. En Intel el color solo se aplica mientras el compositor está activo, así que se fuerza esa ruta y

--- a/README.md
+++ b/README.md
@@ -82,53 +82,77 @@ Idioma (con banderas, no un desplegable), el interruptor de "aprender de mi uso"
 ## Compatibilidad por equipo
 
 Panel de Control conoce nueve modelos y, para cualquier otro, intenta funcionar sondeando las
-capacidades reales del hardware. Esta tabla resume qué encontrarás en cada familia. Las diferencias
-suelen venir de lo que el fabricante deja tocar por firmware, no del plugin.
+capacidades reales del hardware. Esta tabla es honesta sobre qué está **comprobado en cada equipo**
+y qué todavía no: preferimos un "sin confirmar" a un "sí" falso. Las diferencias vienen de lo que
+cada fabricante deja tocar por firmware y del kernel de cada distro.
 
-Leyenda: **●** funciona · **◐** limitado, solo lectura o valores por defecto · **○** no disponible
+Leyenda: **✅** comprobado en ese equipo · **⚠️** limitado o solo por defecto · **❌** no disponible
+· **❔** el código lo soporta pero aún no está confirmado en ese equipo
 
-| Característica | Steam Deck | ROG Ally | Legion Go | MSI Claw 8 AI+ | Otros equipos |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Límite de TDP | ● | ● | ● | ● | ◐ |
-| Modos avanzados (SPPT/FPPT) | ○ | ● | ● | ○ | ○ |
-| Auto-TDP por carga de GPU | ● [¹](#notas) | ● | ● | ○ [²](#notas) | ◐ |
-| Frecuencia de GPU | ● | ● | ● | ● | ◐ |
-| Batería: estado, salud, ciclos | ● | ● | ● | ● | ● |
-| Límite de carga | ● | ● | ◐ [³](#notas) | ◐ | ◐ |
-| CPU: turbo boost | ● | ● | ● | ● | ◐ |
-| CPU: multihilo (SMT) | ● | ● | ● | ○ [⁴](#notas) | ◐ |
-| CPU: núcleos activos | ● | ● | ● | ● | ● |
-| Brillo y volumen | ● | ● | ● | ● | ● |
-| Modo Descarga | ● | ● | ● | ● | ● |
-| Monitor de ventiladores | ● | ● | ● | ● | ● |
-| Curvas de ventilador | ● | ● | ◐ [⁵](#notas) | ● | ◐ |
-| Curvas aprendidas por juego | ● | ● | ◐ [⁵](#notas) | ● | ◐ |
-| Calibración de color | ● | ● | ● | ● [⁶](#notas) | ● |
-| Preset "Aspecto OLED" | ◐ [⁷](#notas) | ● | ◐ [⁷](#notas) | ● | ● |
-| Remapeo de mandos (beta) | ◐ | ◐ | ◐ | ◐ | ○ |
-| Iluminación RGB (vía Colores) | ○ [⁸](#notas) | ● | ● | ● | ◐ |
+| Característica | Steam Deck LCD | Steam Deck OLED | ROG Ally | ROG Ally X | ROG Xbox Ally X | Legion Go | Legion Go S | Legion Go 2 | MSI Claw 8 AI+ |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Límite de TDP | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| Modos avanzados (SPPT/FPPT) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [¹](#notas) |
+| Auto-TDP por carga de GPU | ✅ [²](#notas) | ✅ [²](#notas) | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [³](#notas) |
+| Frecuencia de GPU | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) | ❔ [⁴](#notas) |
+| Batería: estado y salud | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Ciclos de batería | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ❌ [⁵](#notas) | ✅ | ❔ | ✅ | ❌ [⁵](#notas) |
+| Límite de carga | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [⁶](#notas) | ❔ | ⚠️ [⁷](#notas) | ❔ |
+| CPU: turbo boost | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| CPU: multihilo (SMT) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❌ [⁸](#notas) |
+| CPU: núcleos activos | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ |
+| Brillo y volumen | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Modo Descarga | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ❔ |
+| Monitor de temperaturas | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ❔ | ✅ | ✅ [⁹](#notas) |
+| Monitor de RPM de ventilador | ❔ | ❔ | ✅ | ✅ | ✅ | ❔ | ❔ | ❌ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Curvas de ventilador | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notas) | ⚠️ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Curvas aprendidas por juego | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ [¹¹](#notas) | ❌ [¹²](#notas) | ❔ [¹⁰](#notas) | ❌ [⁹](#notas) |
+| Calibración de color | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❔ | ✅ | ✅ [¹³](#notas) |
+| Preset "Aspecto OLED" | ✅ | ❌ [¹⁴](#notas) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ [¹⁴](#notas) | ✅ |
+| Remapeo de mandos (beta) | ❔ | ❔ | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) | ❔ | ⚠️ [¹⁵](#notas) | ⚠️ [¹⁵](#notas) |
+| Iluminación RGB (vía Colores) | ❌ [¹⁶](#notas) | ❌ [¹⁶](#notas) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-Cada familia agrupa: **Steam Deck** (LCD y OLED), **ROG Ally** (Ally 2023, Ally X, Xbox Ally X),
-**Legion Go** (Go, Go S, Go 2). El resto de portátiles caen en "Otros equipos", donde el plugin se
-marca como experimental y funciona con lo que consiga sondear.
+Cualquier otro portátil cae en un perfil **genérico experimental**: el plugin sondea las capacidades
+reales y muestra lo que consigue, ocultando honestamente el resto.
 
 ### Notas
 
-1. En Steam Deck la lectura de carga de GPU es instantánea y muy ruidosa; el auto-TDP la promedia
+1. El Claw controla el TDP por `intel-rapl`, que solo expone el límite base (PL1); no hay raíles de
+   boost separados que ajustar.
+2. En Steam Deck la lectura de carga de GPU es instantánea y muy ruidosa; el auto-TDP la promedia
    antes de decidir.
-2. El perfilado de consumo en Intel (RAPL / i915) todavía no está implementado, así que el auto-TDP
-   por GPU no está disponible en el Claw. El resto del control de TDP sí.
-3. En Legion el límite de carga es un interruptor de "modo conservación" con un porcentaje fijo por
-   firmware, no un valor ajustable. En el Claw depende de lo que exponga cada unidad.
-4. El Intel Core Ultra del Claw no tiene hyperthreading, así que no hay multihilo que activar o
+3. El perfilado de consumo en Intel (RAPL / i915) todavía no está implementado, así que el auto-TDP
+   por GPU no está disponible en el Claw. El resto del control de TDP sí funciona.
+4. La escritura de frecuencia de GPU está implementada por dispositivo, pero aún no se ha confirmado
+   con un cambio en vivo en ningún equipo. Marcado como sin confirmar hasta validarlo.
+5. El contador de ciclos solo lo rellena el firmware de Lenovo; en ASUS, Steam Deck y MSI el nodo da
+   un 0 falso, así que se oculta en vez de mostrar un cero inventado.
+6. La Legion Go original (83E1) no expone `conservation_mode`, así que no ofrece límite de carga.
+7. En Legion el límite de carga es un interruptor de "modo conservación" con un porcentaje fijo por
+   firmware, no un valor ajustable.
+8. El Intel Core Ultra del Claw no tiene hyperthreading, así que no hay multihilo que activar o
    desactivar.
-5. Legion Go 2 tiene curva completa; Legion Go S solo modos gruesos (silencioso, equilibrado,
-   rendimiento); el Legion Go original queda limitado según el sistema.
-6. En Intel el color solo se aplica mientras el compositor está activo, así que se fuerza esa ruta y
-   se avisa del pequeño coste.
-7. El preset "Aspecto OLED" se oculta en los paneles que ya son OLED (Steam Deck OLED, Legion Go 2)
-   porque no tiene sentido allí.
-8. La Steam Deck no lleva iluminación RGB, así que esta tarjeta no aparece.
+9. En el MSI Claw el chip de ventilador (`msi_wmi_platform`) es de solo lectura en su kernel actual,
+   así que no hay curvas y el editor se oculta. El `coretemp` da temperaturas pero no expone RPM de
+   ventilador, por eso el monitor no muestra ventiladores en el Claw.
+10. La Legion Go 2 no expone un ventilador escribible por hwmon; el RPM tendría que leerse por el EC
+    y en la build actual no está apareciendo en el monitor. Por eso lo marco como no disponible / sin
+    confirmar hasta revisarlo en tu equipo.
+11. La Legion Go original controla el ventilador vía `acpi_call` (GZFD), que existe en Bazzite pero
+    no en SteamOS; además aplicar la curva fuerza el TDP a modo custom.
+12. La Legion Go S solo permite modos gruesos de ventilador (silencioso, equilibrado, rendimiento),
+    no una curva libre, así que tampoco puede aplicar una curva aprendida.
+13. En Intel el color solo se aplica mientras el compositor está activo, así que se fuerza esa ruta y
+    se avisa del pequeño coste.
+14. El preset "Aspecto OLED" se oculta en los paneles que ya son OLED (Steam Deck OLED, Legion Go 2)
+    porque no tiene sentido allí.
+15. El remapeo coopera con el demonio del sistema (HHD en Bazzite, InputPlumber en SteamOS). Está en
+    fase temprana y en Legion algunos botones traseros aún no se detectan bien.
+16. La Steam Deck no lleva iluminación RGB, así que esta tarjeta no aparece.
+
+> Las celdas marcadas **❔** son las que aún no he confirmado en ese equipo concreto. Si tienes el
+> hardware delante y ves que algo va (o no va), dímelo y lo corrijo: la idea es que esta tabla
+> refleje la realidad, no lo que el código intenta hacer.
 
 ## Instalación
 


### PR DESCRIPTION
Rehace la tabla de compatibilidad con **una columna por modelo** (9 equipos) y una leyenda de cuatro estados (comprobado / limitado / no disponible / sin confirmar).

Corrige las filas de ventiladores que estaban inferidas de las clases de backend en vez del comportamiento real:
- **MSI Claw**: sin curvas y su monitor no muestra RPM de ventilador (chip `msi_wmi_platform` de solo lectura; `coretemp` solo da temperaturas). Confirmado por el usuario.
- **Legion Go 2**: el monitor no está mostrando RPM (no hay ventilador escribible por hwmon; el RPM iría por EC). Confirmado por el usuario.
- Se separa el monitor en **temperaturas** vs **RPM**.
- Las celdas no validadas se marcan **sin confirmar** en vez de afirmar soporte falso.

Pendiente antes de mergear: el usuario confirma las celdas ❔ que tiene delante.