### PR TITLE
docs: fix ryzenadj bundling + provenance wording, sync prerelease zip

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -36,7 +36,7 @@ jobs:
           rm -f dist/*.map
           staging=$(mktemp -d)
           mkdir -p "$staging/$PLUGIN_NAME"
-          cp -rL dist main.py plugin.json package.json README.md LICENSE py_modules assets "$staging/$PLUGIN_NAME"
+          cp -rL dist main.py plugin.json package.json README.md README.en.md LICENSE py_modules assets "$staging/$PLUGIN_NAME"
           (cd "$staging" && zip -r "$GITHUB_WORKSPACE/$PLUGIN_NAME.zip" "$PLUGIN_NAME")
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 

--- a/README.en.md
+++ b/README.en.md
@@ -169,8 +169,8 @@ Once installed, the plugin can update itself from within its settings.
 
 ### Verifying a download (recommended)
 
-Every release zip is signed with build provenance. Confirm it really came from this repository's
-pipeline before installing:
+Releases published once the repository is public are signed with build provenance. When the signature
+is available, you can confirm the zip really came from this repository's pipeline:
 
 ```sh
 gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
@@ -212,8 +212,8 @@ full list with licenses is in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 - **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Reference for the
   per-device strategy, re-applying on resume and on AC/DC changes, and cooperating with the
   controller daemon. We only reference the approach, we don't copy its code.
-- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Bundled as a binary for the generic
-  AMD path when there's no better firmware route.
+- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Invoked as an external process for
+  the generic AMD path when there's no better firmware route; not bundled inside the plugin.
 - **[PowerControl](https://github.com/mengmeet/PowerControl)**. Origin of the Lenovo
   firmware-attributes path that SimpleDeckyTDP inherits.
 - **[Fantastic](https://git.ngram.ca/NG-SD-Plugins/Fantastic)** and **[PowerTools](https://git.ngni.us/NG-SD-Plugins/PowerTools)**.
@@ -234,5 +234,6 @@ open a public issue.
 
 ## License
 
-[BSD-3-Clause](LICENSE) © Hooandee. The bundled ryzenadj binary keeps its own LGPL-3.0 license.
-Third-party attributions are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+[BSD-3-Clause](LICENSE) © Hooandee. Third-party attributions and license details (including ryzenadj,
+which is invoked as an external process and not bundled) are listed in
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Una vez instalado, el plugin puede actualizarse solo desde sus ajustes.
 
 ### Verificar la descarga (recomendado)
 
-Cada zip de release va firmado con build provenance. Antes de instalar, confirma que de verdad salió
-del pipeline de este repositorio:
+Las releases publicadas una vez el repositorio es público se firman con build provenance. Cuando la
+firma esté disponible, puedes confirmar que el zip salió de verdad del pipeline de este repositorio:
 
 ```sh
 gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
@@ -214,8 +214,9 @@ citamos aquí. La lista completa con licencias está en [THIRD_PARTY_NOTICES.md]
 - **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Referencia para la
   estrategia por dispositivo, la reaplicación al despertar y al cambiar de corriente, y la
   cooperación con el demonio de mandos. Solo consultamos el enfoque, no copiamos su código.
-- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Lo incluimos como binario para el
-  camino genérico de AMD cuando no hay una ruta de firmware mejor.
+- **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Lo invocamos como proceso externo
+  para el camino genérico de AMD cuando no hay una ruta de firmware mejor; no se empaqueta dentro del
+  plugin.
 - **[PowerControl](https://github.com/mengmeet/PowerControl)**. Origen de la ruta de
   firmware-attributes de Lenovo que hereda SimpleDeckyTDP.
 - **[Fantastic](https://git.ngram.ca/NG-SD-Plugins/Fantastic)** y **[PowerTools](https://git.ngni.us/NG-SD-Plugins/PowerTools)**.
@@ -237,5 +238,6 @@ No abras un issue público.
 
 ## Licencia
 
-[BSD-3-Clause](LICENSE) © Hooandee. El binario de ryzenadj que se distribuye conserva su propia
-licencia LGPL-3.0. Las atribuciones de terceros están en [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+[BSD-3-Clause](LICENSE) © Hooandee. Las atribuciones de terceros y los detalles de licencia (incluido
+ryzenadj, que se invoca como proceso externo y no se empaqueta) están en
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
Correcciones salidas del /review:
- **ryzenadj**: los README decían que se empaqueta el binario; `THIRD_PARTY_NOTICES.md` (fuente canónica) dice que se invoca como proceso externo y NO se empaqueta. Alineado en ambos idiomas (agradecimientos + licencia).
- **Verificación de descarga**: el texto prometía firma en toda release; ahora aclara que la build provenance aplica a releases publicadas con el repo ya público (las privadas no tienen firma).
- **prerelease.yml**: empaqueta también `README.en.md` (quedó desincronizado con release-please.yml).