### PR TITLE
fix: keep panel color working when gamescope socket appears after load

### DIFF
--- a/py_modules/display/gamescope.py
+++ b/py_modules/display/gamescope.py
@@ -11,10 +11,12 @@ import glob
 import os
 import subprocess
 import tempfile
+import time
 
 from display.const import NATIVE as _NATIVE
 
 _LUT_SIZE = 17  # 17^3 grid — smooth enough for color, cheap to generate/apply
+_PROBE_RETRY_S = 5.0  # min interval between probes of a present-but-unresponsive socket
 
 # Rec.709 luma weights (saturation pivots around perceived brightness).
 _LR, _LG, _LB = 0.2126, 0.7152, 0.0722
@@ -71,7 +73,9 @@ def _run(args, env):
         # WAYLAND_DISPLAY). Same spawn hygiene as the controller/fan backends.
         from controllers.detect import clean_env, resolve_bin
         argv = [resolve_bin(args[0]), *args[1:]]
-        p = subprocess.run(argv, capture_output=True, text=True, timeout=5,
+        # Short timeout: this runs on the event loop, so it must fail fast rather than
+        # stall it if gamescope is wedged (the calls themselves complete in ms).
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=2,
                            env={**clean_env(), **env})
         return p.returncode, (p.stdout or "")
     except (OSError, subprocess.SubprocessError):
@@ -84,7 +88,7 @@ class GamescopeColorBackend:
     `runner(args, env) -> (rc, stdout)` is injected for testing."""
 
     def __init__(self, runner=_run, socket_glob="/run/user/*/gamescope-*", lut_path=None,
-                 force_composite=False):
+                 force_composite=False, clock=time.monotonic):
         self._run = runner
         # On Intel/Xe the color LUT is only applied while gamescope COMPOSITES (it's
         # not carried by the HW DRM color pipeline as on AMD), so a look is invisible
@@ -93,8 +97,13 @@ class GamescopeColorBackend:
         # small power cost (composition every frame). AMD leaves this False.
         self._force_composite = force_composite
         self._lut_path = lut_path or os.path.join(tempfile.gettempdir(), "pdc_look.cube")
-        self._runtime, self._wayland = self._discover(socket_glob)
-        self._supported = self._runtime is not None and self._probe()
+        # The socket may not exist yet when the plugin loads, so probe on demand.
+        self._socket_glob = socket_glob
+        self._clock = clock
+        self._last_probe = None
+        self._runtime = self._wayland = None
+        self._supported = False
+        self._ensure_supported()
         # Whether a non-native look may be loaded — lets apply() skip rebuilding the
         # identity LUT on the common (untouched-color) path, yet still clear a look
         # exactly once when returning to native. Starts True: a prior plugin process
@@ -116,9 +125,25 @@ class GamescopeColorBackend:
         rc, _ = self._ctl("version")
         return rc == 0
 
+    def _ensure_supported(self):
+        """Discover the socket + probe on demand, caching the first success."""
+        if self._supported:
+            return True
+        self._runtime, self._wayland = self._discover(self._socket_glob)
+        if self._runtime is None:
+            return False
+        # Rate-limit the probe: it spawns a subprocess and is read on the event loop,
+        # so a present-but-unresponsive socket must not re-probe on every access.
+        now = self._clock()
+        if self._last_probe is not None and now - self._last_probe < _PROBE_RETRY_S:
+            return False
+        self._last_probe = now
+        self._supported = self._probe()
+        return self._supported
+
     @property
     def supported(self):
-        return self._supported
+        return self._ensure_supported()
 
     @property
     def force_composite(self):
@@ -132,7 +157,7 @@ class GamescopeColorBackend:
         non-native is currently applied (no wasted rebuild on the untouched path).
         On force_composite devices, toggles gamescope composition so the look is
         visible in-game (on for a look, off at native). Never raises."""
-        if not self._supported:
+        if not self._ensure_supported():
             return False
         native = is_native(state)
         if native and not self._applied_non_native:

--- a/tests/test_color_gamescope.py
+++ b/tests/test_color_gamescope.py
@@ -1,4 +1,10 @@
-from display.gamescope import GamescopeColorBackend, build_cube, is_native, transform
+from display.gamescope import (
+    _PROBE_RETRY_S,
+    GamescopeColorBackend,
+    build_cube,
+    is_native,
+    transform,
+)
 
 NATIVE = {"saturation": 100, "temperature": 0, "contrast": 0}
 
@@ -109,6 +115,41 @@ def test_backend_unsupported_when_no_socket(tmp_path):
                               socket_glob=str(tmp_path / "run/user/*/gamescope-*"))
     assert b.supported is False
     assert b.apply({**NATIVE, "saturation": 150}) is False
+
+
+def test_backend_self_heals_when_socket_appears_after_init(tmp_path):
+    # A socket that appears after construction must still be picked up.
+    run = tmp_path / "run"
+    run.mkdir()
+    r = FakeRunner(ok=True)
+    b = GamescopeColorBackend(runner=r,
+                              socket_glob=str(tmp_path / "run/user/*/gamescope-*"),
+                              lut_path=str(tmp_path / "look.cube"))
+    assert b.supported is False            # no socket yet at construction
+    sock = run / "user" / "1000" / "gamescope-0"
+    sock.parent.mkdir(parents=True)
+    sock.write_text("")
+    assert b.supported is True             # gamescope came up → re-discovered + probed
+    assert b.apply({**NATIVE, "saturation": 150}) is True
+
+
+def test_backend_rate_limits_probe_of_unresponsive_socket(tmp_path):
+    # A socket that exists but doesn't answer must not re-spawn the probe on every read.
+    sock = tmp_path / "run" / "user" / "1000" / "gamescope-0"
+    sock.parent.mkdir(parents=True)
+    sock.write_text("")
+    r = FakeRunner(ok=False)
+    t = [100.0]
+    b = GamescopeColorBackend(runner=r, socket_glob=str(tmp_path / "run/user/*/gamescope-*"),
+                              lut_path=str(tmp_path / "look.cube"), clock=lambda: t[0])
+
+    def probes():
+        return len([c for c in r.calls if c[0][:2] == ["gamescopectl", "version"]])
+
+    assert b.supported is False and probes() == 1   # probed once at construction
+    assert b.supported is False and probes() == 1   # within backoff → no re-probe
+    t[0] += _PROBE_RETRY_S + 1
+    assert b.supported is False and probes() == 2   # past the interval → re-probes
 
 
 def test_backend_apply_writes_cube_and_calls_set_look(tmp_path):


### PR DESCRIPTION
## Problem

On some devices the Pantalla (color) tab showed "color control isn't available on this system version" and the controls were gone. Root cause: the color backend discovered gamescope's Wayland socket and probed it **once at construction**. When the plugin loads before that socket exists (a boot-order race that a system update can shift), support latched off for the whole session and the tab stayed hidden — even though the mechanism itself still works fine.

## Fix

- Discover + probe **on demand** (`_ensure_supported`), caching the first success, so a socket that appears after load is picked up instead of latching the tab off.
- **Rate-limit** re-probing a present-but-unresponsive socket (min 5 s between probes) so the blocking `gamescopectl` subprocess can't run on every read on the event loop.
- No change to the color-apply mechanism or to any other device: where the socket is already present, behaviour is unchanged (probe once, cache, done).

## Verification

- New unit tests: self-heal when the socket appears after construction, and probe rate-limiting for an unresponsive socket.
- Full backend suite green (656 pytest), ruff clean. Frontend untouched.
- Validated on-device on the affected handheld: socket present → supported, `set_look` applies color; and the self-heal proven end-to-end against the live `gamescopectl` (no socket → unsupported; socket appears → re-discovers → applies).