### PR TITLE
perf: run subprocess-backed applies off the event loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 
 import decky
@@ -468,6 +469,11 @@ class Plugin:
 
     # ---- Fan-curve control (global + per-game, persisted) -------------------
     def _reapply_fans(self) -> None:
+        """Push the effective fan curve off the event loop (Steam Deck's software-loop
+        backend spawns a blocking systemctl). No executor / no loop → inline."""
+        self._offload(self._reapply_fans_sync)
+
+    def _reapply_fans_sync(self) -> None:
         """Apply the effective fan profile for the current game (or global).
 
         - auto      -> firmware control.
@@ -847,7 +853,7 @@ class Plugin:
         enabled = bool(enabled)
         self._settings["unlock_battery_max"] = enabled
         self._save()
-        self._reapply_tdp()
+        await self._offload_call(self._reapply_tdp)
         return enabled
 
     def _qam_boost_active(self) -> bool:
@@ -941,7 +947,7 @@ class Plugin:
                     cur, self._gpu_window, self._slack_ticks, floor, active)
                 if nxt != cur:
                     self._tdp_profiles.set_pl1(self._auto_scope(), nxt, appid=self._current_appid)
-                    self._reapply_tdp()
+                    await self._offload_call(self._reapply_tdp)
                     # PL1 changed → drop the now-stale window (samples taken at the
                     # OLD setpoint) so the next reads are homogeneous at the new PL1.
                     self._clear_auto_windows()
@@ -1012,7 +1018,7 @@ class Plugin:
             if cur < floor:  # only raise if actually below the responsive floor
                 self._tdp_profiles.set_pl1(self._auto_scope(), floor,
                                            appid=self._current_appid)
-                self._reapply_tdp()
+                await self._offload_call(self._reapply_tdp)
                 self._clear_auto_windows()  # PL1 changed → window is now stale
         return self._ui_active
 
@@ -1099,6 +1105,46 @@ class Plugin:
         running, else global)."""
         return "game" if self._current_appid else "global"
 
+    # ---- off-loop dispatch --------------------------------------------------
+    # Any subprocess/HTTP-backed apply (gamescopectl, systemctl, ryzenadj, …) MUST
+    # run through one of these so a wedged tool can't stall the event loop that
+    # drives the auto-TDP loop + every QAM RPC. The single-worker executor (created
+    # in _main) serialises applies → no race on shared state (e.g. the color LUT
+    # file). No executor / no loop (unit tests) → run inline (behaviour preserved).
+    def _offload(self, fn):
+        """Fire-and-forget a blocking apply off the event loop. Guards fn on both
+        paths so a raise can't kill the caller nor leak an unretrieved-future log."""
+        def guarded():
+            try:
+                fn()
+            except Exception:  # noqa: BLE001
+                pass
+        ex = getattr(self, "_apply_executor", None)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if ex is None or loop is None:
+            guarded()
+        else:
+            loop.run_in_executor(ex, guarded)
+
+    async def _offload_call(self, fn):
+        """Run a blocking call off the event loop and return its result (awaited)."""
+        ex = getattr(self, "_apply_executor", None)
+        if ex is None:
+            return fn()
+        return await asyncio.get_running_loop().run_in_executor(ex, fn)
+
+    async def _drain_offloaded(self):
+        """Wait for the queued off-loop applies to finish (a no-op runs after them on
+        the single-worker executor). Use before reading back hardware state that a
+        fire-and-forget apply just changed, so the readback isn't stale."""
+        ex = getattr(self, "_apply_executor", None)
+        if ex is None:
+            return
+        await asyncio.get_running_loop().run_in_executor(ex, lambda: None)
+
     def _reapply_tdp(self, on_ac=None):
         self._init()
         lv, _active, ac = self._effective_levels(self._current_appid, on_ac)
@@ -1112,12 +1158,13 @@ class Plugin:
         # stale preview can't leak onto the new context (nor a dangling timer fire).
         self._cancel_color_revert()
         self._color_preview = None
-        self._reapply_tdp(on_ac)
-        self._reapply_fans()
+        # sysfs (fast) → inline; subprocess-backed (tdp-ryzenadj/fans/color) → off-loop.
         self._apply_charge_limit()
         self._apply_cpu()
-        self._reapply_color()
         self._apply_gpu_clock()
+        self._offload(lambda: self._reapply_tdp(on_ac))
+        self._reapply_fans()   # self-offloading
+        self._reapply_color()  # self-offloading
 
     # ---- Battery + charge limit --------------------------------------------
     def _apply_charge_limit(self) -> None:
@@ -1331,6 +1378,11 @@ class Plugin:
 
     # ---- Pantalla (panel color via gamescope) -------------------------------
     def _reapply_color(self) -> None:
+        """Push the color apply off the event loop (gamescopectl can stall on a wedged
+        compositor). No executor / no loop → inline."""
+        self._offload(self._reapply_color_sync)
+
+    def _reapply_color_sync(self) -> None:
         """Push the effective color (per-game saturation + global calibration, with
         any live preview overlaid) to gamescope. No-op when unsupported. Guarded."""
         try:
@@ -1370,7 +1422,7 @@ class Plugin:
 
     async def get_color_state(self) -> dict:
         self._init()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     async def set_saturation(self, value: int, scope: str, appid=None) -> dict:
         # Saturation can't make the screen illegible (0 = grayscale) → save directly,
@@ -1378,7 +1430,7 @@ class Plugin:
         self._init()
         self._color.set_saturation(scope, int(value), appid=appid)
         self._reapply_color()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     async def preview_calibration(self, temperature: int, contrast: int) -> dict:
         """Apply calibration LIVE without saving, and arm the auto-revert timer. The
@@ -1387,7 +1439,7 @@ class Plugin:
         self._color_preview = {"temperature": int(temperature), "contrast": int(contrast)}
         self._reapply_color()
         self._arm_color_revert()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     async def set_calibration(self, temperature: int, contrast: int) -> dict:
         """Confirm (save) the calibration: persist, cancel the auto-revert, apply."""
@@ -1396,7 +1448,7 @@ class Plugin:
         self._color_preview = None
         self._color.set_calibration(temperature=int(temperature), contrast=int(contrast))
         self._reapply_color()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     def _arm_color_revert(self) -> None:
         self._cancel_color_revert()
@@ -1434,7 +1486,7 @@ class Plugin:
         if look is not None:
             self._color.apply_preset(look)
             self._reapply_color()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     async def reset_color(self) -> dict:
         self._init()
@@ -1442,7 +1494,7 @@ class Plugin:
         self._color_preview = None
         self._color.reset()
         self._reapply_color()
-        return self._color_state()
+        return await self._offload_call(self._color_state)
 
     async def get_tdp_state(self) -> dict:
         self._init()
@@ -1499,7 +1551,7 @@ class Plugin:
         limits = self._limits()
         clamped = limits.clamp(watts, read_on_ac())
         self._tdp_profiles.set_pl1(resolved, clamped, appid=appid)
-        res = self._reapply_tdp()
+        res = await self._offload_call(self._reapply_tdp)
         return {"requested_w": res.requested_w, "applied_w": res.applied_w,
                 "ok": res.ok, "detail": res.detail}
 
@@ -1511,7 +1563,7 @@ class Plugin:
                     "detail": f"unknown scope: {scope}"}
         self._clear_eco()
         self._tdp_profiles.set_offsets(resolved, off2, off3, appid=appid)
-        res = self._reapply_tdp()
+        res = await self._offload_call(self._reapply_tdp)
         # requested_w/applied_w reflect resulting sustained pl1 (readback), not the offsets
         return {"requested_w": res.requested_w, "applied_w": res.applied_w,
                 "ok": res.ok, "detail": res.detail}
@@ -1522,7 +1574,7 @@ class Plugin:
         if resolved is not None:  # invalid scope → no-op (never from the UI)
             self._clear_eco()
             self._tdp_profiles.set_auto(resolved, appid=appid)
-            self._reapply_tdp()
+            await self._offload_call(self._reapply_tdp)
         # Always return the full new state so the UI updates badge + sliders in ONE
         # round-trip (no separate get_tdp_state) — immediate, and a consistent
         # TdpState shape (the frontend does setTdp with it).
@@ -1546,6 +1598,9 @@ class Plugin:
         # effective fan curve, including the adaptive learned curve when that mode is on.
         self._maybe_drive_adaptive_fan_curve()  # track + drive if adaptive with enough data
         self._reapply_all()
+        # The TDP re-apply is off-loop; wait for it so the returned state's hardware
+        # readback (applied_w) reflects the new game, not the previous setpoint.
+        await self._drain_offloaded()
         return await self.get_tdp_state()
 
     def _restore_fans_safe(self) -> None:
@@ -1568,6 +1623,10 @@ class Plugin:
     # ---- lifecycle ----------------------------------------------------------
     async def _main(self) -> None:
         self._init()
+        # Single-worker executor for subprocess-backed applies (gamescopectl /
+        # systemctl / ryzenadj) → keeps them off the event loop AND serialised.
+        # Created here (not _init) so unit tests that never call _main run inline.
+        self._apply_executor = ThreadPoolExecutor(max_workers=1)
         decky.logger.info(
             "Panel de Control v%s loaded (euid=%s)", read_version(), os.geteuid()
         )
@@ -1587,19 +1646,29 @@ class Plugin:
 
     async def _unload(self) -> None:
         # Restore fans to firmware auto FIRST — before stopping other loops —
-        # so the hardware is never left with a stale manual curve.
-        self._restore_fans_safe()
+        # so the hardware is never left with a stale manual curve. The restores
+        # spawn subprocesses (systemctl / gamescopectl) → run them off the loop and
+        # await, then shut the executor down.
+        await self._offload_call(self._restore_fans_safe)
         self._cancel_color_revert()
-        self._restore_color_safe()
+        await self._offload_call(self._restore_color_safe)
         self._stop_auto_loop()
         if getattr(self, "_sampler", None) is not None:
             self._sampler.stop()
         if getattr(self, "_lifecycle", None) is not None:
             self._lifecycle.stop()
+        self._shutdown_apply_executor()
         decky.logger.info("Panel de Control unloaded")
 
+    def _shutdown_apply_executor(self) -> None:
+        ex = getattr(self, "_apply_executor", None)
+        if ex is not None:
+            ex.shutdown(wait=False)
+            self._apply_executor = None
+
     async def _uninstall(self) -> None:
-        self._restore_fans_safe()
-        self._restore_color_safe()
+        await self._offload_call(self._restore_fans_safe)
+        await self._offload_call(self._restore_color_safe)
+        self._shutdown_apply_executor()
         fan_expose.remove_conf()  # drop the modprobe.d option we added (guarded)
         decky.logger.info("Panel de Control uninstalled")

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -1,0 +1,206 @@
+"""Guardrail: subprocess-backed applies (color / fans / TDP-ryzenadj) must run OFF
+the event loop, so a wedged gamescope/systemctl/ryzenadj can't stall the auto-TDP
+loop or any QAM RPC. See the off-load chokepoint helpers in main.Plugin.
+
+The chokepoints run INLINE when no executor is installed (the state in every other
+test → existing behaviour preserved). These tests install an executor to prove the
+production dispatch actually goes off-loop.
+"""
+import asyncio
+import concurrent.futures
+import importlib
+import sys
+import threading
+import types
+
+
+class _RecordingExecutor(concurrent.futures.Executor):
+    """Real Executor that records submissions and runs them inline (deterministic)."""
+
+    def __init__(self):
+        self.count = 0
+
+    def submit(self, fn, *a, **k):
+        self.count += 1
+        f = concurrent.futures.Future()
+        try:
+            f.set_result(fn(*a, **k))
+        except Exception as e:  # noqa: BLE001
+            f.set_exception(e)
+        return f
+
+
+class _FakeColorBackend:
+    def __init__(self):
+        self.supported = True
+        self.force_composite = False
+        self.applied = []
+        self.applied_threads = []
+
+    def apply(self, state):
+        self.applied.append(dict(state))
+        self.applied_threads.append(threading.get_ident())
+        return True
+
+
+def _make_plugin(tmp_path, monkeypatch):
+    fake_decky = types.ModuleType("decky")
+    fake_decky.DECKY_PLUGIN_SETTINGS_DIR = str(tmp_path)
+    fake_decky.DECKY_USER = "deck"
+    fake_decky.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
+    )
+    monkeypatch.setitem(sys.modules, "decky", fake_decky)
+
+    import tdp.factory as factory
+    from tdp.types import TdpLimits, TdpResult
+
+    class _FakeBackend:
+        supported = True
+        supports_levels = True
+        name = "fake"
+
+        def get_limits(self):
+            return TdpLimits(min_w=5, default_w=15, max_w=20, max_ac_w=20)
+
+        def level_limits(self):
+            return {}
+
+        def set_tdp(self, w, ac):
+            return TdpResult(w, w, True, "")
+
+        def set_levels(self, pl1, pl2, pl3, ac):
+            return TdpResult(pl1, pl1, True, "")
+
+        def read_applied(self):
+            return 15
+
+    monkeypatch.setattr(factory, "select_backend", lambda device, **kw: _FakeBackend())
+    import lifecycle
+    monkeypatch.setattr(lifecycle, "read_on_ac", lambda root="/": True)
+    main = importlib.reload(importlib.import_module("main"))
+    monkeypatch.setattr(main, "read_on_ac", lambda root="/": True, raising=False)
+    color = _FakeColorBackend()
+    monkeypatch.setattr(main, "GamescopeColorBackend", lambda *a, **k: color)
+    p = main.Plugin()
+    p._init()
+    return p, color
+
+
+# ---- chokepoint helpers -------------------------------------------------------
+
+def test_offload_call_runs_inline_and_returns_result_without_executor(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    assert asyncio.run(p._offload_call(lambda: 42)) == 42
+
+
+def test_offload_runs_inline_without_executor(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    seen = []
+    p._offload(lambda: seen.append(1))  # no executor, no loop → inline
+    assert seen == [1]
+
+
+def test_offload_call_dispatches_through_executor(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    rec = _RecordingExecutor()
+    p._apply_executor = rec
+
+    async def _run():
+        return await p._offload_call(lambda: 7)
+
+    assert asyncio.run(_run()) == 7
+    assert rec.count == 1  # went THROUGH the executor, not the inline branch
+
+
+def test_offload_runs_off_the_loop_thread(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = ex
+    main_tid = threading.get_ident()
+
+    async def _run():
+        return await p._offload_call(threading.get_ident)
+
+    ran_on = asyncio.run(_run())
+    ex.shutdown()
+    assert ran_on != main_tid  # executed off the event-loop thread
+
+
+# ---- reapply paths dispatch off-loop -----------------------------------------
+
+def test_reapply_all_offloads_tdp_fans_and_color(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    rec = _RecordingExecutor()
+    p._apply_executor = rec
+
+    async def _run():
+        p._reapply_all()  # sync, but under a running loop
+
+    asyncio.run(_run())
+    # tdp + fans + color offloaded; charge/cpu/gpu-clock stay inline (sysfs).
+    assert rec.count == 3
+
+
+def test_set_saturation_applies_color_off_loop(tmp_path, monkeypatch):
+    p, color = _make_plugin(tmp_path, monkeypatch)
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = ex
+    main_tid = threading.get_ident()
+    st = asyncio.run(p.set_saturation(150, "global", None))
+    ex.shutdown()
+    assert st["saturation"] == 150
+    assert color.applied[-1]["saturation"] == 150       # still reached the hardware
+    assert color.applied_threads[-1] != main_tid        # off the loop thread
+
+
+def test_set_tdp_watts_keeps_result_contract_when_offloaded(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    rec = _RecordingExecutor()
+    p._apply_executor = rec
+    res = asyncio.run(p.set_tdp_watts(18, "global"))
+    assert res["ok"] is True and res["applied_w"] is not None
+    assert rec.count >= 1  # the TDP write went through the executor
+
+
+class _SlowBackend:
+    """TDP backend whose set_levels lags — so a readback that races an offloaded
+    apply is deterministic (reads the stale value if not awaited)."""
+
+    supported = True
+    supports_levels = True
+    name = "slow"
+
+    def __init__(self):
+        self._applied = 0
+
+    def get_limits(self):
+        from tdp.types import TdpLimits
+        return TdpLimits(min_w=5, default_w=15, max_w=40, max_ac_w=40)
+
+    def level_limits(self):
+        return {}
+
+    def set_levels(self, pl1, pl2, pl3, ac):
+        import time
+        from tdp.types import TdpResult
+        time.sleep(0.05)
+        self._applied = pl1
+        return TdpResult(pl1, pl1, True, "")
+
+    def read_applied(self):
+        return self._applied
+
+
+def test_set_current_game_state_reflects_the_offloaded_apply(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    p._tdp_backend = _SlowBackend()
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = ex
+    asyncio.run(p.create_game_profile("42"))
+    asyncio.run(p.set_tdp_watts(25, "game", "42"))  # awaited → really applied
+    p._tdp_backend._applied = 999                   # stale hardware readback
+    st = asyncio.run(p.set_current_game("42"))       # re-applies (slow, off-loop)
+    ex.shutdown()
+    # The returned state must reflect the completed apply, not the stale 999.
+    assert st["applied_w"] == 25

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -192,6 +192,64 @@ class _SlowBackend:
         return self._applied
 
 
+class _FakeFan:
+    """Fan backend that records the thread each hardware write runs on. On the Steam
+    Deck this write is a blocking systemctl, so it MUST run off the loop thread."""
+
+    def __init__(self):
+        self.supported = True
+        self.mode_based = False
+        self.write_threads = []
+
+    def read_state(self):
+        return {"supported": True, "source": "fake", "pwm_max": 255,
+                "mode_based": False, "mode": None}
+
+    def apply_curve_all(self, points):
+        self.write_threads.append(threading.get_ident())
+
+    def set_auto(self, _mode):
+        self.write_threads.append(threading.get_ident())
+
+    def apply_preset(self, preset):
+        self.write_threads.append(threading.get_ident())
+
+    def restore_auto(self):
+        self.write_threads.append(threading.get_ident())
+
+
+def test_apply_rpcs_keep_subprocess_backends_off_the_loop_thread(tmp_path, monkeypatch):
+    """Tripwire: every user apply path (color + fan RPCs, game change) must run the
+    subprocess-spawning backends OFF the event-loop thread. Catches a future change
+    that adds a blocking apply on the loop or drops the off-load — for any device."""
+    p, color = _make_plugin(tmp_path, monkeypatch)
+    fan = _FakeFan()
+    p._fan_ctrl = fan
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = ex
+
+    async def drive():
+        loop_tid = threading.get_ident()
+        await p.set_saturation(150, "global", None)
+        await p.set_calibration(-20, 15)
+        await p.preview_calibration(-10, 10)
+        await p.reset_color()
+        await p.set_fan_preset("balanced", "global", None)
+        await p.set_fan_curve_points([[40, 30], [60, 50], [80, 90]], "global", None)
+        await p.set_fan_auto("global", None)
+        await p.create_game_profile("7")
+        await p.set_current_game("7")
+        await p._drain_offloaded()  # let fire-and-forget applies land
+        return loop_tid
+
+    loop_tid = asyncio.run(drive())
+    ex.shutdown()
+    assert color.applied_threads, "color apply never ran"
+    assert fan.write_threads, "fan apply never ran"
+    assert loop_tid not in color.applied_threads   # gamescopectl off the loop
+    assert loop_tid not in fan.write_threads        # (Deck) systemctl off the loop
+
+
 def test_set_current_game_state_reflects_the_offloaded_apply(tmp_path, monkeypatch):
     p, _ = _make_plugin(tmp_path, monkeypatch)
     p._tdp_backend = _SlowBackend()


### PR DESCRIPTION
## What

The re-apply path (LifecycleManager callback, game change, eco, AC/DC) and several RPCs invoked blocking subprocesses **synchronously on the asyncio event loop**:

- `gamescopectl` (panel color) — up to ~3 calls, 2s timeout each
- `systemctl` start/stop (Steam Deck software-loop fan backend) — 10s timeout ×2
- `ryzenadj` (generic-device TDP fallback) — 5s timeout

That loop also drives the auto-TDP control loop and every QAM RPC, so a wedged tool could stall the whole panel. A prior fix hardened only the color-socket probe; this generalises the pattern.

## How

Two chokepoint helpers on `Plugin` — the single sanctioned way to run blocking work from a loop-reachable path:

- `_offload(fn)` — fire-and-forget void applies (self-offloading `_reapply_color`/`_reapply_fans`, and the generic `_reapply_tdp` inside `_reapply_all`); guarded on both paths.
- `_offload_call(fn)` — awaited, returns the result (the TDP RPCs that consume it, the `.supported` color-state read, the unload restores).

Both run on a single-worker `ThreadPoolExecutor` (created on load, torn down on unload) so applies stay **serialised** — no race on the shared color LUT temp file. Fast sysfs writes (charge limit, CPU, GPU clock; firmware-attr/RAPL TDP) stay inline. `set_current_game` drains the queued apply before reading TDP state back, so `applied_w` reflects the new game and never a stale value.

With no executor (unit tests) both helpers run inline, so existing behaviour is preserved exactly.

## Tests

New guardrail `tests/test_event_loop_offload.py` injects a recording / real single-worker executor and asserts color/fan/TDP work is dispatched **through** it (off the loop thread) — a future refactor back onto the loop turns CI red. Full suite green (664 pytest / 160 vitest / typecheck / ruff / build).

Installed and loaded clean on all six reachable handhelds (Steam Deck OLED, MSI Claw, Legion Go S, ROG Ally, ROG Xbox Ally X, Legion Go); light on-device sweep passed.