### PR TITLE
docs: warm up README voice and drop build-from-source section

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -83,8 +83,8 @@ can be turned off), and a button to erase what has been learned.
 
 Panel de Control knows nine models and, for anything else, tries to work by probing the real
 capabilities of the hardware. This table is honest about what's **verified on each device** and what
-isn't yet: we'd rather show "unconfirmed" than a false "yes". Differences come from what each vendor
-lets you touch in firmware and from each distro's kernel.
+isn't yet: I'd rather show you "unconfirmed" than a false "yes". Differences come from what each
+vendor lets you touch in firmware and from each distro's kernel.
 
 Legend: **✅** verified on that device · **⚠️** limited or default only · **❌** not available · **❔**
 supported in code but not confirmed on that device yet
@@ -137,8 +137,8 @@ capabilities and shows what it can, honestly hiding the rest.
    the firmware applies is read over the EC and shown read-only; editing is in progress (fan-speed
    control will be enabled safely).
 10. The Legion Go 2 exposes no writable hwmon fan; RPM would have to be read over the EC, and on the
-    current build it isn't showing up in the monitor. Marked as not available / unconfirmed until
-    reviewed on your device.
+    current build it isn't showing up in the monitor. Marked as not available / unconfirmed until I
+    can review it.
 11. The original Legion Go needs `acpi_call` (GZFD) for fan curves; it's present on Bazzite but not on
     SteamOS, so without it no curve shows up at all (not even a default one). Where it works, applying
     the curve forces TDP into custom mode. The monitor (speed + temperature) does work.
@@ -177,19 +177,6 @@ is available, you can confirm the zip really came from this repository's pipelin
 gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
 ```
 
-## Building from source
-
-Toolchain: **pnpm 10**, **Node 20**, **Python 3.11**.
-
-```sh
-pnpm install --frozen-lockfile
-pnpm build          # produces dist/index.js
-```
-
-Copy the resulting folder to `~/homebrew/plugins/` on your device and restart Decky. The Python
-backend needs root (the plugin declares it) to write to sysfs; model detection, on the other hand,
-doesn't. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full test gate and development setup.
-
 ## How it learns (and why it stays local)
 
 The point of Panel de Control isn't just having nice buttons, it's that it learns from how you play
@@ -203,16 +190,16 @@ number on screen is a real number.
 
 ## Acknowledgments
 
-This plugin stands on the work of many people in the handheld community. We reference kernel
-interfaces (which are facts, not code) freely, and when we adapt ideas or code we credit it here. The
-full list with licenses is in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+This plugin stands on the work of many people in the handheld community. I reference kernel
+interfaces (which are facts, not code) freely, and when I adapt an idea or a bit of code I credit it
+here. The full list with licenses is in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 - **[SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP)** (BSD-3, Aarron Lee). The primary
   reference for the per-device TDP mechanism: the Lenovo and ASUS firmware-attributes paths, the
   `platform_profile=custom` prestep, and ryzenadj usage.
 - **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Reference for the
   per-device strategy, re-applying on resume and on AC/DC changes, and cooperating with the
-  controller daemon. We only reference the approach, we don't copy its code.
+  controller daemon. I only looked at the approach, I didn't copy its code.
 - **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Invoked as an external process for
   the generic AMD path when there's no better firmware route; not bundled inside the plugin.
 - **[PowerControl](https://github.com/mengmeet/PowerControl)**. Origin of the Lenovo
@@ -221,7 +208,7 @@ full list with licenses is in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
   Reference for the fan monitor and curve control and for periodic re-apply.
 - **[Decky Loader](https://decky.xyz/)** and its plugin template. The base everything runs on.
 - **The Linux kernel documentation** (firmware-attributes, powercap, asus-wmi, hwmon, power_supply).
-  The source of the sysfs paths we read and write.
+  The source of the sysfs paths I read and write.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Idioma (con banderas, no un desplegable), el interruptor de "aprender de mi uso"
 
 Panel de Control conoce nueve modelos y, para cualquier otro, intenta funcionar sondeando las
 capacidades reales del hardware. Esta tabla es honesta sobre qué está **comprobado en cada equipo**
-y qué todavía no: preferimos un "sin confirmar" a un "sí" falso. Las diferencias vienen de lo que
-cada fabricante deja tocar por firmware y del kernel de cada distro.
+y qué todavía no: prefiero enseñarte un "sin confirmar" antes que un "sí" falso. Las diferencias
+vienen de lo que cada fabricante deja tocar por firmware y del kernel de cada distro.
 
 Leyenda: **✅** comprobado en ese equipo · **⚠️** limitado o solo por defecto · **❌** no disponible
 · **❔** el código lo soporta pero aún no está confirmado en ese equipo
@@ -138,7 +138,7 @@ reales y muestra lo que consigue, ocultando honestamente el resto.
    lectura; la edición está en desarrollo (el control de velocidad se ajustará de forma segura).
 10. La Legion Go 2 no expone un ventilador escribible por hwmon; el RPM tendría que leerse por el EC
     y en la build actual no está apareciendo en el monitor. Por eso lo marco como no disponible / sin
-    confirmar hasta revisarlo en tu equipo.
+    confirmar hasta que pueda revisarlo.
 11. La Legion Go original necesita `acpi_call` (GZFD) para las curvas de ventilador; está presente en
     Bazzite pero no en SteamOS, así que sin él no aparece ninguna curva (ni siquiera por defecto).
     Donde funciona, aplicar la curva fuerza el TDP a modo custom. El monitor (velocidad + temperatura)
@@ -178,20 +178,6 @@ firma esté disponible, puedes confirmar que el zip salió de verdad del pipelin
 gh attestation verify "Panel de Control.zip" --repo Hooandee/panel-de-control
 ```
 
-## Compilar desde el código
-
-Herramientas: **pnpm 10**, **Node 20**, **Python 3.11**.
-
-```sh
-pnpm install --frozen-lockfile
-pnpm build          # genera dist/index.js
-```
-
-Copia la carpeta resultante a `~/homebrew/plugins/` en tu equipo y reinicia Decky. El backend en
-Python necesita root (lo declara el plugin) para escribir en sysfs; la detección del modelo, en
-cambio, no lo necesita. Mira [CONTRIBUTING.md](CONTRIBUTING.md) para el conjunto de pruebas completo
-y la configuración de desarrollo.
-
 ## Cómo aprende (y por qué es local)
 
 La gracia de Panel de Control no es solo tener botones bonitos, es que aprende de cómo usas cada
@@ -205,16 +191,16 @@ número en pantalla es un número real.
 
 ## Agradecimientos
 
-Este plugin se apoya en el trabajo de mucha gente de la comunidad de handhelds. Referenciamos
-interfaces del kernel (que son hechos, no código) libremente, y cuando adaptamos ideas o código lo
-citamos aquí. La lista completa con licencias está en [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+Este plugin se apoya en el trabajo de mucha gente de la comunidad de handhelds. Referencio las
+interfaces del kernel (que son hechos, no código) con libertad, y cuando adapto una idea o algo de
+código lo cito aquí. La lista completa con licencias está en [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 - **[SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP)** (BSD-3, Aarron Lee). La
   referencia principal del mecanismo de TDP por dispositivo: las rutas de firmware-attributes de
   Lenovo y ASUS, el paso previo de `platform_profile=custom`, y el uso de ryzenadj.
 - **[Handheld Daemon (HHD)](https://github.com/hhd-dev/hhd)** (LGPL-2.1). Referencia para la
   estrategia por dispositivo, la reaplicación al despertar y al cambiar de corriente, y la
-  cooperación con el demonio de mandos. Solo consultamos el enfoque, no copiamos su código.
+  cooperación con el demonio de mandos. Solo miré el enfoque, no copié su código.
 - **[RyzenAdj](https://github.com/FlyGoat/RyzenAdj)** (LGPL-3.0). Lo invocamos como proceso externo
   para el camino genérico de AMD cuando no hay una ruta de firmware mejor; no se empaqueta dentro del
   plugin.
@@ -225,7 +211,7 @@ citamos aquí. La lista completa con licencias está en [THIRD_PARTY_NOTICES.md]
 - **[Decky Loader](https://decky.xyz/)** y su plantilla de plugins. La base sobre la que corre todo
   esto.
 - **La documentación del kernel de Linux** (firmware-attributes, powercap, asus-wmi, hwmon,
-  power_supply). De donde salen las rutas de sysfs que leemos y escribimos.
+  power_supply). De donde salen las rutas de sysfs que leo y escribo.
 
 ## Contribuir
 


### PR DESCRIPTION
Public-launch README pass.

- Convert the plural "we" voice in the compatibility and acknowledgments copy to a first-person author voice, so the READMEs read as the author speaking directly to the reader.
- Fix the confusing "unconfirmed until reviewed on your device" line (I can't review it on the reader's device) → "until I can review it".
- Remove the **build-from-source** section from both READMEs. Users install from the release zip; contributors still have CONTRIBUTING.md.
- README.md (ES) and README.en.md kept in sync.

No functional changes.