### PR TITLE
chore: add CODEOWNERS so PRs require the owner's review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every change requires review from the repository owner.
+* @Hooandee


### PR DESCRIPTION
Adds a CODEOWNERS file (`* @Hooandee`) so branch protection can require an approving review from the repository owner on every PR.