### PR TITLE
docs: add demo video to the READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,12 @@ doing.
 
 The interface ships in Spanish by default and falls back to English when your system asks for it.
 
+## Video
+
+In this video I show and explain the plugin in depth:
+
+[![Panel de Control in action](https://img.youtube.com/vi/sDpXFTxG7NQ/maxresdefault.jpg)](https://youtu.be/sDpXFTxG7NQ)
+
 > [!WARNING]
 > This plugin runs with **root privileges** and changes low-level power, thermal, and firmware
 > settings on your device. It talks only to documented kernel interfaces and is designed to fail

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ real de tu equipo arriba, y nunca te mienta sobre lo que de verdad está pasando
 
 La interfaz viene en español por defecto y cae a inglés si tu sistema lo pide.
 
+## Vídeo
+
+En este vídeo enseño y explico el plugin a fondo:
+
+[![Panel de Control en acción](https://img.youtube.com/vi/sDpXFTxG7NQ/maxresdefault.jpg)](https://youtu.be/sDpXFTxG7NQ)
+
 > [!WARNING]
 > Este plugin corre con **privilegios de root** y cambia ajustes de bajo nivel de potencia,
 > temperatura y firmware de tu equipo. Solo habla con interfaces documentadas del kernel y está


### PR DESCRIPTION
Adds the demo video (https://youtu.be/sDpXFTxG7NQ) as a clickable thumbnail near the top of both READMEs. ES + EN kept in sync.