### PR TITLE
feat: on-screen value toast for volume and brightness

### DIFF
--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -185,6 +185,10 @@ const es: Record<string, string> = {
   "settings.battmax.desc": "Permite subir el TDP hasta el máximo del equipo también con batería. Más potencia, pero la batería se agota mucho más rápido.",
   "settings.qamboost": "Subir TDP con el menú abierto",
   "settings.qamboost.desc": "Sube el TDP mientras el menú de acceso rápido está abierto para que vaya fluido. El valor mostrado es temporal del menú; dentro del juego se reajusta.",
+  "settings.valueToast": "Mostrar valor al cambiar volumen o brillo",
+  "settings.valueToast.desc": "Muestra el número en pantalla al ajustar con los botones, sin abrir el panel.",
+  "valueToast.volume": "Volumen",
+  "valueToast.brightness": "Brillo",
   "tdp.unsupported": "El control de TDP no está disponible en este dispositivo.",
   "tdp.scope.global": "Global",
   "tdp.inherit": "Heredando del global",
@@ -449,6 +453,10 @@ const en: Record<string, string> = {
   "settings.battmax.desc": "Allow raising TDP to the device maximum on battery too. More performance, but the battery drains much faster.",
   "settings.qamboost": "Raise TDP while the menu is open",
   "settings.qamboost.desc": "Raises TDP while the quick access menu is open so it stays fluid. The value shown is temporary to the menu; in-game it readjusts.",
+  "settings.valueToast": "Show value when changing volume or brightness",
+  "settings.valueToast.desc": "Shows the number on screen when you adjust with the buttons, without opening the panel.",
+  "valueToast.volume": "Volume",
+  "valueToast.brightness": "Brightness",
   "tdp.unsupported": "TDP control isn't available on this device.",
   "tdp.scope.global": "Global",
   "tdp.inherit": "Inheriting from global",
@@ -581,6 +589,11 @@ export const I18nProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const value = useMemo<I18nValue>(() => ({ lang, setLang, t }), [lang, setLang, t]);
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 };
+
+export function translate(key: string, params?: Params): string {
+  const lang = initialLang();
+  return format(DICTS[lang][key] ?? en[key] ?? key, params);
+}
 
 export function useI18n(): I18nValue {
   const ctx = useContext(I18nContext);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { I18nProvider } from "./i18n";
 import { ControlCenter } from "./components/ControlCenter";
 import { startGameWatcher } from "./tdp/gameWatcher";
 import { startEcoAmbient } from "./system/ecoAmbient";
+import { startValueToast } from "./system/valueToast";
 
 export default definePlugin(() => {
   // Persistent current-game watcher: runs at plugin scope (while Steam runs),
@@ -16,6 +17,7 @@ export default definePlugin(() => {
   // Persistent ambient-dim controller for download mode: also runs at plugin scope
   // so the screen keeps dimming/waking while a game downloads with the QAM closed.
   const stopEcoAmbient = startEcoAmbient();
+  const stopValueToast = startValueToast();
 
   return {
     name: "Panel de Control",
@@ -31,6 +33,7 @@ export default definePlugin(() => {
     onDismount() {
       stopGameWatcher();
       stopEcoAmbient();
+      stopValueToast();
     },
   };
 });

--- a/src/sections/AjustesSection.tsx
+++ b/src/sections/AjustesSection.tsx
@@ -7,6 +7,7 @@ import { openCustomizeModal } from "../components/CustomizeModal";
 import { openGlossaryModal } from "../components/GlossaryModal";
 import { openReportModal } from "../components/ReportModal";
 import { getTelemetryEnabled, setTelemetryEnabled, getUnlockBatteryMax, setUnlockBatteryMax, getQamTdpBoost, setQamTdpBoost, resetTelemetry, getVersion, getControllerConflict } from "../api";
+import { isValueToastEnabled, setValueToastEnabled } from "../system/valueToast";
 import { UpdatePanel } from "../updater/UpdatePanel";
 import { ControllerConflictCard } from "../components/ControllerConflictCard";
 import { theme } from "../theme";
@@ -38,6 +39,11 @@ export const AjustesSection: FC = () => {
   const [learn, onToggle] = useToggleSetting(getTelemetryEnabled, setTelemetryEnabled, true);
   const [battMax, onToggleBattMax] = useToggleSetting(getUnlockBatteryMax, setUnlockBatteryMax, false);
   const [qamBoost, onToggleQamBoost] = useToggleSetting(getQamTdpBoost, setQamTdpBoost, false);
+  const [valueToast, setValueToast] = useState(isValueToastEnabled());
+  const onToggleValueToast = (next: boolean) => {
+    setValueToast(next);
+    setValueToastEnabled(next);
+  };
   const [version, setVersion] = useState("");
   useEffect(() => {
     getVersion().then(setVersion).catch(() => {});
@@ -120,6 +126,14 @@ export const AjustesSection: FC = () => {
             bottomSeparator="none"
           />
         )}
+
+        <ToggleField
+          label={t("settings.valueToast")}
+          description={t("settings.valueToast.desc")}
+          checked={valueToast}
+          onChange={onToggleValueToast}
+          bottomSeparator="none"
+        />
 
         {/* Open the full-screen plain-language glossary of terms. */}
         <ButtonItem layout="below" description={t("glossary.button.desc")} onClick={() => openGlossaryModal()}>

--- a/src/system/audio.ts
+++ b/src/system/audio.ts
@@ -1,4 +1,5 @@
 import { ScalarControl } from "./types";
+import { markSelfWrite } from "./selfWrite";
 
 // SteamClient system-volume adapter. Volume is per audio device, so we track the
 // default OUTPUT device: GetDevices() seeds the current level and device id,
@@ -70,6 +71,7 @@ export const systemVolume: ScalarControl = {
   set(fraction) {
     try {
       if (outputDeviceId !== null) {
+        markSelfWrite("volume");
         void SteamClient?.System?.Audio?.SetDeviceVolume?.(outputDeviceId, OUTPUT, fraction);
       }
     } catch {

--- a/src/system/collapseState.ts
+++ b/src/system/collapseState.ts
@@ -1,21 +1,11 @@
-// Per-section collapse state, persisted in localStorage so a card stays collapsed
-// across QAM reopens. Pure UI preference → no backend round-trip. Never throws;
-// if storage is unavailable it just degrades to "always open".
+import { readFlag, writeFlag } from "./pdcStorage";
+
 const KEY = (id: string) => `pdc:collapsed:${id}`;
 
-/** True if the section `id` was left collapsed. Defaults to false (open). */
 export function isCollapsed(id: string): boolean {
-  try {
-    return window.localStorage?.getItem(KEY(id)) === "1";
-  } catch {
-    return false;
-  }
+  return readFlag(KEY(id));
 }
 
 export function setCollapsed(id: string, collapsed: boolean): void {
-  try {
-    window.localStorage?.setItem(KEY(id), collapsed ? "1" : "0");
-  } catch {
-    /* storage unavailable — collapse just won't persist */
-  }
+  writeFlag(KEY(id), collapsed);
 }

--- a/src/system/display.ts
+++ b/src/system/display.ts
@@ -1,4 +1,5 @@
 import { ScalarControl } from "./types";
+import { markSelfWrite } from "./selfWrite";
 
 // SteamClient brightness adapter. Isolated here so the rest of the UI is stable
 // if a device needs a different call. Never throws — degrades to "unavailable"
@@ -26,6 +27,7 @@ export const displayBrightness: ScalarControl = {
   },
   set(fraction) {
     try {
+      markSelfWrite("brightness");
       SteamClient?.System?.Display?.SetBrightness?.(fraction);
     } catch {
       /* ignore */

--- a/src/system/pdcStorage.ts
+++ b/src/system/pdcStorage.ts
@@ -1,0 +1,14 @@
+export function readFlag(key: string, fallback = false): boolean {
+  try {
+    const v = window.localStorage?.getItem(key);
+    return v === null || v === undefined ? fallback : v === "1";
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeFlag(key: string, on: boolean): void {
+  try {
+    window.localStorage?.setItem(key, on ? "1" : "0");
+  } catch {}
+}

--- a/src/system/selfWrite.ts
+++ b/src/system/selfWrite.ts
@@ -1,0 +1,11 @@
+export type ScalarKind = "brightness" | "volume";
+
+const lastWrite: Record<ScalarKind, number | null> = { brightness: null, volume: null };
+
+export function markSelfWrite(kind: ScalarKind): void {
+  lastWrite[kind] = Date.now();
+}
+
+export function lastSelfWrite(kind: ScalarKind): number | null {
+  return lastWrite[kind];
+}

--- a/src/system/valueToast.tsx
+++ b/src/system/valueToast.tsx
@@ -1,0 +1,134 @@
+import { toaster } from "@decky/api";
+import { IconType } from "react-icons";
+import { LuSun, LuVolume2 } from "react-icons/lu";
+
+import { translate } from "../i18n";
+import { theme } from "../theme";
+import { toPercent } from "./logic";
+import { displayBrightness } from "./display";
+import { systemVolume } from "./audio";
+import { ScalarControl } from "./types";
+import { ScalarKind, lastSelfWrite } from "./selfWrite";
+import { readFlag, writeFlag } from "./pdcStorage";
+import { shouldSuppress } from "./valueToastLogic";
+
+const KEY = "pdc:valueToast:enabled";
+const DEBOUNCE_MS = 900;
+const SELF_WINDOW_MS = 1500;
+const SILENT_ETYPE = 17;
+
+interface Channel {
+  kind: ScalarKind;
+  ctrl: ScalarControl;
+  labelKey: string;
+  color: string;
+  Icon: IconType;
+}
+
+const CHANNELS: Channel[] = [
+  { kind: "volume", ctrl: systemVolume, labelKey: "valueToast.volume", color: theme.color.accent, Icon: LuVolume2 },
+  { kind: "brightness", ctrl: displayBrightness, labelKey: "valueToast.brightness", color: theme.color.brightness, Icon: LuSun },
+];
+
+let enabled = false;
+let alive = false;
+let subscribed = false;
+const unsubs: Array<() => void> = [];
+const timers: Partial<Record<ScalarKind, ReturnType<typeof setTimeout>>> = {};
+const lastFraction: Partial<Record<ScalarKind, number>> = {};
+const seeded: Partial<Record<ScalarKind, boolean>> = {};
+const lastToast: Partial<Record<ScalarKind, ReturnType<typeof toaster.toast>>> = {};
+
+function emitToast(ch: Channel, fraction: number): void {
+  const { Icon } = ch;
+  const prev = lastToast[ch.kind];
+  if (prev) {
+    try {
+      prev.dismiss();
+    } catch {}
+  }
+  lastToast[ch.kind] = toaster.toast({
+    title: translate(ch.labelKey),
+    body: (
+      <span style={{ fontSize: 18, fontWeight: 700, color: theme.color.textPrimary }}>
+        {toPercent(fraction)}%
+      </span>
+    ),
+    icon: <Icon size={22} color={ch.color} />,
+    duration: 1500,
+    eType: SILENT_ETYPE,
+    playSound: false,
+    showNewIndicator: false,
+  });
+}
+
+function onChange(ch: Channel, fraction: number): void {
+  if (!seeded[ch.kind]) {
+    seeded[ch.kind] = true;
+    lastFraction[ch.kind] = fraction;
+    return;
+  }
+  const changed = lastFraction[ch.kind] !== fraction;
+  lastFraction[ch.kind] = fraction;
+  if (!enabled) return;
+  if (!changed) return;
+  if (shouldSuppress(lastSelfWrite(ch.kind), Date.now(), SELF_WINDOW_MS)) return;
+  const existing = timers[ch.kind];
+  if (existing) clearTimeout(existing);
+  timers[ch.kind] = setTimeout(() => {
+    delete timers[ch.kind];
+    emitToast(ch, fraction);
+  }, DEBOUNCE_MS);
+}
+
+function subscribeAll(): void {
+  if (subscribed) return;
+  subscribed = true;
+  for (const ch of CHANNELS) {
+    seeded[ch.kind] = false;
+    const unsub = ch.ctrl.subscribe((fraction) => onChange(ch, fraction));
+    if (unsub) unsubs.push(unsub);
+  }
+}
+
+function clearTimers(): void {
+  for (const k of Object.keys(timers) as ScalarKind[]) {
+    clearTimeout(timers[k]);
+    delete timers[k];
+  }
+}
+
+function teardown(): void {
+  for (const u of unsubs.splice(0)) {
+    try {
+      u();
+    } catch {}
+  }
+  clearTimers();
+}
+
+export function isValueToastEnabled(): boolean {
+  return readFlag(KEY);
+}
+
+export function setValueToastEnabled(on: boolean): void {
+  writeFlag(KEY, on);
+  enabled = on;
+  if (on) {
+    if (alive) subscribeAll();
+  } else {
+    clearTimers();
+  }
+}
+
+export function startValueToast(): () => void {
+  alive = true;
+  enabled = isValueToastEnabled();
+  if (enabled) subscribeAll();
+  return () => {
+    alive = false;
+    enabled = false;
+    teardown();
+    subscribed = false;
+  };
+}

--- a/src/system/valueToastLogic.test.ts
+++ b/src/system/valueToastLogic.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSuppress } from "./valueToastLogic";
+
+describe("shouldSuppress", () => {
+  it("does not suppress when there was no self-write", () => {
+    expect(shouldSuppress(null, 1000, 1500)).toBe(false);
+  });
+
+  it("suppresses an echo shortly after a self-write", () => {
+    expect(shouldSuppress(1000, 1500, 1500)).toBe(true);
+  });
+
+  it("does not suppress once the window has fully passed", () => {
+    expect(shouldSuppress(1000, 3000, 1500)).toBe(false);
+  });
+
+  it("does not suppress exactly at the window boundary", () => {
+    expect(shouldSuppress(1000, 2500, 1500)).toBe(false);
+  });
+
+  it("suppresses just inside the window boundary", () => {
+    expect(shouldSuppress(1000, 2499, 1500)).toBe(true);
+  });
+});

--- a/src/system/valueToastLogic.ts
+++ b/src/system/valueToastLogic.ts
@@ -1,0 +1,8 @@
+export function shouldSuppress(
+  lastSelfWriteMs: number | null,
+  nowMs: number,
+  windowMs: number,
+): boolean {
+  if (lastSelfWriteMs === null) return false;
+  return nowMs - lastSelfWriteMs < windowMs;
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -21,6 +21,7 @@ const color = {
   // Warm/bright orange for the transient HW-boost segment on the power arc — a
   // hotter tone than `warn` so it reads as "extra on top", not a warning.
   boost: "#ff8a3d",
+  brightness: "#f5c542",
 } as const;
 
 const radius = { sm: 8, md: 14, lg: 20 } as const;


### PR DESCRIPTION
## 🇪🇸 Español

**Qué hace**

Añade un ajuste **opcional** (desactivado por defecto) que, al cambiar el **volumen** o el **brillo** con los botones físicos, muestra el **valor exacto** en una notificación en pantalla — visible **sin abrir el panel**.

**Detalles**

- Toggle en **Ajustes**: «Mostrar valor al cambiar volumen o brillo».
- Notificación con icono (altavoz / sol), etiqueta y el número; **azul** para volumen, **amarillo** para brillo.
- **Silenciosa** (usa un tipo de notificación de Steam sin sonido; `playSound` no es suficiente en algunas versiones).
- **Un solo aviso por gesto** (debounce de 900 ms que puentea el retardo inicial de auto-repetición del botón) y nunca se apila.
- **No aparece** cuando el cambio lo origina el propio plugin (slider de Sistema o atenuado del Modo Descarga).
- **100 % frontend**, sin backend. La preferencia se guarda en `localStorage` mediante un helper compartido (`pdcStorage`), que también adopta `collapseState`.

**Limitación conocida (aceptada)**

El brillo automático (sensor de luz) llega por el mismo evento que una pulsación manual y no se puede distinguir, así que también dispara el aviso. Es honesto (el brillo cambió) y se puede evitar desactivando el brillo automático o el propio toggle.

---

## 🇬🇧 English

**What it does**

Adds an **opt-in** setting (off by default) that shows the **exact value** on screen when you change **volume** or **brightness** with the hardware buttons — visible **without opening the panel**.

**Details**

- Toggle in **Settings**: “Show value when changing volume or brightness”.
- Notification with icon (speaker / sun), label and the number; **blue** for volume, **yellow** for brightness.
- **Silent** (uses a soundless Steam notification type; `playSound` alone isn't honored on some builds).
- **One toast per gesture** (900 ms debounce that bridges the button's initial auto-repeat delay), never stacked.
- **Suppressed** when the change comes from the plugin itself (System slider or download-mode dimming).
- **Frontend-only**, no backend. The preference is stored in `localStorage` via a shared `pdcStorage` helper (also adopted by `collapseState`).

**Known limitation (accepted)**

Automatic brightness (ambient sensor) arrives through the same event as a manual press and can't be told apart, so it also triggers the toast. It's honest (brightness did change) and can be avoided by turning off adaptive brightness or the toggle itself.

---

**Testing / Pruebas**

- `typecheck` · **178 vitest** · `build` — green.
- Validated on Steam Deck OLED, MSI Claw (Intel) and Legion Go 2.
