### PR TITLE
feat: capture the controller daemon journal in bug reports

### DIFF
--- a/main.py
+++ b/main.py
@@ -323,7 +323,12 @@ class Plugin:
         kernel = await loop.run_in_executor(
             None,
             lambda: report_collector.kernel_logs(
-                self._run_capture, home=home, hostname=hostname
+                self._run_capture,
+                extra=report_collector.controller_daemon_cmds(
+                    self._controller_backend.manager
+                ),
+                home=home,
+                hostname=hostname,
             ),
         )
         return report_collector.build_bundle(

--- a/py_modules/report/collector.py
+++ b/py_modules/report/collector.py
@@ -142,11 +142,35 @@ _KERNEL_CMDS = {
 }
 
 
-def kernel_logs(run, *, cap: int = 40_000, home: str | None = None, hostname: str | None = None) -> dict:
-    """Tail of dmesg (errors/warnings) + the plugin_loader journal, via run(cmd)->
-    str|None. Redacted and size-capped. Never raises."""
+# The controller daemon (HHD on Bazzite, InputPlumber on SteamOS) owns the gamepad
+# and its own resume/re-grab. Controller failures land in ITS journal, not the
+# plugin log — so a controller report should carry it. Keyed by the manager string
+# reported by controllers.detect (values, not imported, to keep this standalone).
+_CONTROLLER_UNITS = {"hhd": "hhd.service", "inputplumber": "inputplumber.service"}
+
+
+def controller_daemon_cmds(manager: str | None) -> dict:
+    """Extra kernel_logs command for the active controller daemon's journal, or an
+    empty dict when no daemon runs the controller (nothing to capture)."""
+    unit = _CONTROLLER_UNITS.get(manager or "")
+    if not unit:
+        return {}
+    return {"controller": ["/usr/bin/journalctl", "-b", "-u", unit, "-n", "300", "--no-pager"]}
+
+
+def kernel_logs(
+    run,
+    *,
+    cap: int = 40_000,
+    extra: dict | None = None,
+    home: str | None = None,
+    hostname: str | None = None,
+) -> dict:
+    """Tail of dmesg (errors/warnings) + the plugin_loader journal, plus any `extra`
+    {key: cmd} commands (e.g. the controller daemon journal), via run(cmd)->str|None.
+    Redacted and size-capped. Never raises."""
     out = {}
-    for key, cmd in _KERNEL_CMDS.items():
+    for key, cmd in {**_KERNEL_CMDS, **(extra or {})}.items():
         try:
             text = run(cmd)
         except Exception:  # noqa: BLE001

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -4,6 +4,7 @@ from report.collector import (
     SCHEMA,
     build_bundle,
     capabilities_from,
+    controller_daemon_cmds,
     kernel_logs,
     redact_obj,
     redact_text,
@@ -25,6 +26,28 @@ def test_kernel_logs_runner_raising_is_null():
         raise OSError("boom")
     out = kernel_logs(run)
     assert out["dmesg"] is None and out["journal"] is None
+
+
+def test_controller_daemon_cmds_hhd():
+    cmd = controller_daemon_cmds("hhd")["controller"]
+    assert "journalctl" in cmd[0] and "hhd.service" in cmd
+
+
+def test_controller_daemon_cmds_inputplumber():
+    cmd = controller_daemon_cmds("inputplumber")["controller"]
+    assert "inputplumber.service" in cmd
+
+
+def test_controller_daemon_cmds_none_is_empty():
+    assert controller_daemon_cmds("none") == {}
+    assert controller_daemon_cmds(None) == {}
+
+
+def test_kernel_logs_captures_extra_controller_journal():
+    def run(cmd):
+        return "HHD woke up /home/deck/x" if "hhd.service" in cmd else None
+    out = kernel_logs(run, extra=controller_daemon_cmds("hhd"))
+    assert "~/x" in out["controller"] and "/home/deck" not in out["controller"]
 
 
 def test_build_bundle_includes_kernel():


### PR DESCRIPTION
## Qué

Los reportes de problemas ahora incluyen el journal del daemon de mandos activo (`hhd.service` en Bazzite / `inputplumber.service` en SteamOS) dentro del bloque `kernel` del bundle.

## Por qué

Los fallos de mando (paletas que dejan de responder tras suspender, carreras de re-grab) caen en el journal del propio daemon, no en el log del plugin. Sin ese journal, un reporte de categoría `controllers` no es diagnosticable sin acceso físico al equipo (fue justo lo que pasó con PDC-GPBT / #50: hubo que sacar la traza a mano en el equipo).

Con el cambio, el bundle trae directamente la traza de resume del daemon (`System woke up from sleep` → `Launching emulated controller` → `Re-initializing controller`, y los errores tipo `No such device` / `controller not found, waiting`).

## Cómo

- `collector.controller_daemon_cmds(manager)`: mapea el manager detectado a su unidad de systemd (vacío si no hay daemon).
- `collector.kernel_logs(..., extra=...)`: fusiona comandos extra con los de siempre (dmesg + journal de plugin_loader), mismo redactado + tope de tamaño.
- `main._collect_report_bundle`: pasa el journal del daemon según `self._controller_backend.manager`.

Solo se captura cuando hay daemon (equipos sin uno → sin coste extra).

## Notas

- No es un arreglo del bug de #50 (eso es una carrera de re-grab de HHD en el resume, upstream — HHD ya re-inicializa el mando solo al despertar; no procede un re-assert nuestro). Esto es la mejora de diagnóstico para poder triar estos reportes.

## Gate

- 770 pytest verde · ruff limpio.
- 4 tests nuevos (mapeo por daemon + captura extra redactada).
- Validado on-device (ROG Ally, Bazzite): el comando exacto devuelve la traza de resume de HHD.