### PR TITLE
fix: stop download mode from fighting manual screen brightness

### DIFF
--- a/src/system/eco.test.ts
+++ b/src/system/eco.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { ecoBrightness } from "./eco";
+import { activityDebounceMs, ecoBrightness, isDimEcho, isFloorEcho } from "./eco";
 
 describe("ecoBrightness", () => {
   it("is the wake level when active, the floor when idle", () => {
     expect(ecoBrightness(true, 45, 0)).toBe(45);
     expect(ecoBrightness(false, 45, 0)).toBe(0);
+  });
+});
+
+describe("isDimEcho", () => {
+  it("is false when nothing has been driven yet", () => {
+    expect(isDimEcho(44, null, 0)).toBe(false);
+  });
+
+  it("recognises our own recent write echoing back", () => {
+    expect(isDimEcho(44, 44, 100)).toBe(true);
+  });
+
+  it("tolerates panel quantisation within a couple percent", () => {
+    expect(isDimEcho(43, 44, 100)).toBe(true);
+    expect(isDimEcho(47, 44, 100)).toBe(false);
+  });
+
+  it("treats a value far from our last write as external (the user)", () => {
+    expect(isDimEcho(20, 44, 100)).toBe(false);
+  });
+
+  it("stops claiming an echo once the window passes (a later change is the user)", () => {
+    expect(isDimEcho(44, 44, 5000)).toBe(false);
+  });
+});
+
+describe("isFloorEcho", () => {
+  it("recognises an echo sitting at the idle floor (our own dim, never the user)", () => {
+    expect(isFloorEcho(12, 12)).toBe(true);
+    expect(isFloorEcho(13, 12)).toBe(true); // panel quantisation
+  });
+
+  it("is false for a real wake level well above the floor", () => {
+    expect(isFloorEcho(44, 12)).toBe(false);
+  });
+});
+
+describe("activityDebounceMs", () => {
+  it("wakes fast but debounces idle to swallow flapping", () => {
+    expect(activityDebounceMs(true)).toBeLessThan(activityDebounceMs(false));
   });
 });

--- a/src/system/eco.ts
+++ b/src/system/eco.ts
@@ -1,7 +1,27 @@
-// Pure helper for download mode's ambient dim. No React/SteamClient.
+// Pure helpers for download mode's ambient dim.
 
-/** Screen brightness (%) for the ambient dim: wake level when the user is active,
- *  the low floor when idle. */
 export function ecoBrightness(active: boolean, wakePct: number, floorPct: number): number {
   return active ? wakePct : floorPct;
+}
+
+// True when a brightness echo is our own recent write, not a user change.
+export function isDimEcho(
+  echo: number,
+  lastDriven: number | null,
+  msSinceDrive: number,
+  windowMs = 2000,
+  tol = 2,
+): boolean {
+  if (lastDriven === null) return false;
+  return Math.abs(echo - lastDriven) <= tol && msSinceDrive <= windowMs;
+}
+
+// A change at the idle floor is our dim, never a wake level to adopt.
+export function isFloorEcho(echo: number, floorPct: number, tol = 2): boolean {
+  return Math.abs(echo - floorPct) <= tol;
+}
+
+// Wake fast, hold on idle so activity flapping doesn't flicker the screen.
+export function activityDebounceMs(active: boolean): number {
+  return active ? 150 : 800;
 }

--- a/src/system/ecoAmbient.ts
+++ b/src/system/ecoAmbient.ts
@@ -1,32 +1,50 @@
 import { getEcoState } from "../api";
 import { subscribeActive } from "./activity";
 import { displayBrightness } from "./display";
-import { fromPercent } from "./logic";
-import { ecoBrightness } from "./eco";
+import { fromPercent, toPercent } from "./logic";
+import { activityDebounceMs, ecoBrightness, isDimEcho, isFloorEcho } from "./eco";
 
-// Idle brightness floor while download mode dims the screen. Minimum by default
-// (max saving for an unattended download); tune if a fully-dark panel
-// reads as "off".
-const ECO_FLOOR_PCT = 0;
-// Backstop reconcile cadence — runs ONLY while eco is on, to catch a backend-side
-// clear (a manual power change that turned eco off without going through the card).
+// Download-mode ambient dim. Runs at plugin scope so it works with the QAM closed.
+const ECO_FLOOR_PCT = 12;
 const POLL_MS = 3000;
 
-// Singleton state — this controller runs once at plugin scope (definePlugin), not
-// tied to the QAM being open, so the ambient dim works while a game downloads with
-// the panel closed. Event-driven (activity transitions) + a backstop poll that runs
-// only while enabled; NO render loop.
 let enabled = false;
 let wakePct = 40;
 let alive = false;
+let activeState = true;
 let unsubActivity: (() => void) | null = null;
+let unsubBrightness: (() => void) | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
-// Bumped on every explicit toggle (hint). An async getEcoState() started before a
-// toggle must not reconcile with its now-stale result and undo the user's action.
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let lastDriven: number | null = null; // last value we drove, to spot our own echoes
+let lastDriveAt = 0;
 let epoch = 0;
 
 function drive(active: boolean): void {
-  if (enabled) displayBrightness.set(fromPercent(ecoBrightness(active, wakePct, ECO_FLOOR_PCT)));
+  if (!enabled) return;
+  lastDriven = ecoBrightness(active, wakePct, ECO_FLOOR_PCT);
+  lastDriveAt = Date.now();
+  displayBrightness.set(fromPercent(lastDriven));
+}
+
+function onActivity(active: boolean): void {
+  if (debounceTimer !== null) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    if (active !== activeState) {
+      activeState = active;
+      drive(active);
+    }
+  }, activityDebounceMs(active));
+}
+
+// Adopt a user brightness change as the new wake level; skip our own echoes and the floor.
+function onBrightness(fraction: number): void {
+  if (!enabled) return;
+  const echo = toPercent(fraction);
+  if (isDimEcho(echo, lastDriven, Date.now() - lastDriveAt)) return;
+  if (isFloorEcho(echo, ECO_FLOOR_PCT)) return;
+  wakePct = echo;
 }
 
 function startPoll(): void {
@@ -35,11 +53,9 @@ function startPoll(): void {
     const e = epoch;
     getEcoState()
       .then((s) => {
-        if (e === epoch) reconcile(s.enabled, s.wake_brightness); // ignore if a toggle raced
+        if (e === epoch) reconcile(s.enabled, s.wake_brightness);
       })
-      .catch(() => {
-        /* backend busy — retry next tick */
-      });
+      .catch(() => {});
   }, POLL_MS);
 }
 
@@ -50,33 +66,43 @@ function stopPoll(): void {
   }
 }
 
-/** Reconcile to the desired eco state (from a toggle hint, startup, or backstop poll). */
+function teardown(): void {
+  if (unsubActivity) {
+    unsubActivity();
+    unsubActivity = null;
+  }
+  if (unsubBrightness) {
+    unsubBrightness();
+    unsubBrightness = null;
+  }
+  if (debounceTimer !== null) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  stopPoll();
+}
+
 function reconcile(on: boolean, wake: number): void {
-  wakePct = wake;
   if (on && !enabled) {
+    wakePct = wake; // snapshot only on enable; while on, wakePct tracks the user
     enabled = true;
-    unsubActivity = subscribeActive((active) => drive(active));
-    drive(true); // user just enabled it → start at the wake level
+    activeState = true;
+    drive(true); // before subscribing, so the on-register echo is recognised as ours
+    unsubActivity = subscribeActive(onActivity);
+    unsubBrightness = displayBrightness.subscribe(onBrightness);
     startPoll();
   } else if (!on && enabled) {
     enabled = false;
-    if (unsubActivity) {
-      unsubActivity();
-      unsubActivity = null;
-    }
-    stopPoll();
-    displayBrightness.set(fromPercent(wakePct)); // restore the pre-eco brightness
+    teardown();
+    displayBrightness.set(fromPercent(wakePct));
   }
-  // already-on: wake level is snapshotted at enable — nothing to re-drive.
 }
 
-/** Instant response when the user toggles download mode from the card. */
 export function setEcoActiveHint(on: boolean, wake: number): void {
-  epoch += 1; // invalidate any in-flight poll result
+  epoch += 1;
   reconcile(on, wake);
 }
 
-/** Start the persistent ambient-dim controller. Call once in definePlugin. */
 export function startEcoAmbient(): () => void {
   alive = true;
   const e = epoch;
@@ -84,16 +110,11 @@ export function startEcoAmbient(): () => void {
     .then((s) => {
       if (alive && e === epoch) reconcile(s.enabled, s.wake_brightness);
     })
-    .catch(() => {
-      /* backend not ready — a later toggle hint will engage it */
-    });
+    .catch(() => {});
   return () => {
     alive = false;
-    stopPoll();
-    if (unsubActivity) {
-      unsubActivity();
-      unsubActivity = null;
-    }
+    if (enabled) displayBrightness.set(fromPercent(wakePct)); // don't leave the panel dim
     enabled = false;
+    teardown();
   };
 }


### PR DESCRIPTION
Reporte **PDC-B4RX** (#53) — ROG Xbox Ally X. El usuario bajaba el brillo y se le ponía solo al 44%, con parpadeos a oscuro en ventanas cortas.

**Causa:** con el **Modo Descarga** activado, el atenuado ambiental fijaba el brillo al valor guardado al activar el modo (44%) y lo restauraba en cada transición de actividad, peleándose con el brillo que el usuario ponía. El suelo a 0% daba el "parpadeo a oscuro" y la señal de actividad de la Ally flapeaba activo/inactivo, causando el parpadeo repetido.

**Fix:**
- Si el usuario cambia el brillo (slider o botones físicos) con el modo puesto, se adopta como nuevo nivel de vigilia → el atenuado vuelve a TU brillo, no a un valor viejo. Se distingue nuestra propia escritura de la del usuario por el valor que acabamos de aplicar; nunca se adopta el suelo como nivel de vigilia.
- Debounce de la señal de actividad (despierta rápido, aguanta al inactivo) para matar el parpadeo por flapeo.
- Suelo de atenuado por encima de 0% (nada de negro total) y restauración del brillo al descargar el plugin (no deja la pantalla atenuada).

Mantiene el caso de uso "dejo el equipo bajando desatendido → se atenúa" sin molestar cuando lo estás usando.

**Gate:** typecheck · 186 vitest · build. Lógica pura nueva testeada (`isDimEcho`, `isFloorEcho`, `activityDebounceMs`).

**Validado on-device en el ROG Xbox Ally X (RC73XA), el modelo exacto del reporte:** traza del brillo real del hardware confirma que (1) no parpadea (transiciones limpias, el debounce mató el flapeo), (2) atenúa al dejarlo quieto sin negro total, (3) al volver a tocar restaura el último brillo del usuario, consistente entre ciclos.

Closes #53