### PR TITLE
fix: persist language and UI preferences across reboot

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,6 +93,9 @@ DEFAULTS = {
     # back to. Both restored/derived on exit; eco_enabled is a pure override.
     "eco_enabled": False,
     "eco_brightness": 40,
+    # Frontend UI preferences, mirrored here so they survive a reboot (the
+    # frontend's localStorage cache does not). Opaque string map.
+    "ui_prefs": {},
 }
 
 
@@ -215,6 +218,27 @@ class Plugin:
     async def get_version(self) -> str:
         self._init()
         return read_version()
+
+    async def get_ui_prefs(self) -> dict:
+        self._init()
+        prefs = self._settings.get("ui_prefs")
+        return dict(prefs) if isinstance(prefs, dict) else {}
+
+    async def set_ui_prefs(self, updates: dict) -> bool:
+        # A None value removes that key.
+        self._init()
+        prefs = self._settings.get("ui_prefs")
+        # Copy: an unset key aliases the shared DEFAULTS dict; never mutate it.
+        prefs = dict(prefs) if isinstance(prefs, dict) else {}
+        if isinstance(updates, dict):
+            for key, value in updates.items():
+                if value is None:
+                    prefs.pop(str(key), None)
+                else:
+                    prefs[str(key)] = str(value)
+        self._settings["ui_prefs"] = prefs
+        self._save()
+        return True
 
     async def check_update(self, force: bool = False) -> dict:
         self._init()

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,10 @@ import { callable } from "@decky/api";
 // Names must match the Python `async def` on the Plugin class exactly.
 export const getVersion = callable<[], string>("get_version");
 
+// Durable mirror of the frontend's localStorage prefs (a null value removes a key).
+export const getUiPrefs = callable<[], Record<string, string>>("get_ui_prefs");
+export const setUiPrefs = callable<[Record<string, string | null>], boolean>("set_ui_prefs");
+
 export interface DeviceInfo {
   key: string;
   display_name: string;

--- a/src/customize/store.ts
+++ b/src/customize/store.ts
@@ -4,6 +4,7 @@
 // sections live. Never throws; degrades to defaults if storage is unavailable.
 import { useSyncExternalStore } from "react";
 import { Layout, coerceLayout } from "./layout";
+import { readString, writeString, removeString } from "../system/pdcStorage";
 
 const KEY = "pdc:layout";
 const EMPTY: Layout = { tabs: { order: [], hidden: [] }, blocks: {}, subitems: {} };
@@ -16,7 +17,7 @@ const listeners = new Set<() => void>();
 
 function read(): Layout {
   try {
-    const raw = window.localStorage?.getItem(KEY);
+    const raw = readString(KEY);
     if (!raw) return EMPTY;
     // Coerce shapes: valid JSON with wrong types (e.g. order:5) must NOT throw
     // downstream — that would brick the panel with no in-UI recovery path.
@@ -34,22 +35,22 @@ export function getLayout(): Layout {
 
 export function saveLayout(next: Layout): void {
   cache = next;
-  try {
-    window.localStorage?.setItem(KEY, JSON.stringify(next));
-  } catch {
-    /* storage unavailable — layout just won't persist this session */
-  }
+  writeString(KEY, JSON.stringify(next));
   listeners.forEach((l) => l());
 }
 
 /** Wipe all customization → back to code defaults. */
 export function resetLayout(): void {
   cache = EMPTY;
-  try {
-    window.localStorage?.removeItem(KEY);
-  } catch {
-    /* ignore */
-  }
+  removeString(KEY);
+  listeners.forEach((l) => l());
+}
+
+// Re-read once hydratePrefs heals the cache; notify only if it changed.
+export function reloadLayout(): void {
+  const next = read();
+  if (JSON.stringify(next) === JSON.stringify(getLayout())) return;
+  cache = next;
   listeners.forEach((l) => l());
 }
 

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,5 +1,15 @@
-import { FC, ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+import {
+  FC,
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { format, Params } from "./format";
+import { hydratePrefs, onPrefsHealed, readString, writeString } from "../system/pdcStorage";
 
 export type Lang = "es" | "en";
 
@@ -554,13 +564,8 @@ const en: Record<string, string> = {
 const DICTS: Record<Lang, Record<string, string>> = { es, en };
 
 function initialLang(): Lang {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "es" || stored === "en") return stored;
-  } catch {
-    /* localStorage may be unavailable; default below */
-  }
-  return "es"; // Spanish default
+  const stored = readString(STORAGE_KEY);
+  return stored === "es" || stored === "en" ? stored : "es"; // Spanish default
 }
 
 interface I18nValue {
@@ -574,13 +579,16 @@ const I18nContext = createContext<I18nValue | null>(null);
 export const I18nProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [lang, setLangState] = useState<Lang>(initialLang);
 
+  // Re-read once hydratePrefs heals the cache, in case we rendered stale.
+  useEffect(() => {
+    const off = onPrefsHealed(() => setLangState(initialLang()));
+    void hydratePrefs();
+    return off;
+  }, []);
+
   const setLang = useCallback((l: Lang) => {
     setLangState(l);
-    try {
-      localStorage.setItem(STORAGE_KEY, l);
-    } catch {
-      /* ignore persistence failure */
-    }
+    writeString(STORAGE_KEY, l);
   }, []);
 
   const t = useCallback(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,9 +6,19 @@ import { I18nProvider } from "./i18n";
 import { ControlCenter } from "./components/ControlCenter";
 import { startGameWatcher } from "./tdp/gameWatcher";
 import { startEcoAmbient } from "./system/ecoAmbient";
-import { startValueToast } from "./system/valueToast";
+import { startValueToast, refreshValueToast } from "./system/valueToast";
+import { hydratePrefs, onPrefsHealed } from "./system/pdcStorage";
+import { reloadLayout } from "./customize/store";
 
 export default definePlugin(() => {
+  // Restore durable UI prefs into the localStorage cache at plugin scope (so the
+  // QAM-closed toast uses the right language), then re-apply the healed values.
+  onPrefsHealed(() => {
+    refreshValueToast();
+    reloadLayout();
+  });
+  void hydratePrefs();
+
   // Persistent current-game watcher: runs at plugin scope (while Steam runs),
   // independent of the QAM being open. It is the single source that reports the
   // running game to the backend so auto-TDP / telemetry / fan auto-apply engage

--- a/src/sections/activeTab.ts
+++ b/src/sections/activeTab.ts
@@ -1,22 +1,16 @@
-// The last active tab, persisted in localStorage. Decky remounts the panel on
-// each QAM open — and some actions (e.g. applying a controller remap reloads the
-// virtual gamepad, which makes Steam remount the panel) — so without this the
-// shell would snap back to the first tab. Pure UI preference, no backend. Never
-// throws; degrades to "no memory" if storage is unavailable.
+import { readString, writeString } from "../system/pdcStorage";
+
+// The last active tab. Decky remounts the panel on each QAM open — and some
+// actions (e.g. applying a controller remap reloads the virtual gamepad, which
+// makes Steam remount the panel) — so without this the shell would snap back to
+// the first tab. Ephemeral by design: pdc:activeTab is in prefsSync's EPHEMERAL
+// set, so it stays in localStorage only and is not mirrored to the backend.
 const KEY = "pdc:activeTab";
 
 export function readActiveTab(): string | null {
-  try {
-    return window.localStorage?.getItem(KEY) ?? null;
-  } catch {
-    return null;
-  }
+  return readString(KEY);
 }
 
 export function writeActiveTab(id: string): void {
-  try {
-    window.localStorage?.setItem(KEY, id);
-  } catch {
-    /* storage unavailable — active tab just won't persist */
-  }
+  writeString(KEY, id);
 }

--- a/src/system/pdcStorage.ts
+++ b/src/system/pdcStorage.ts
@@ -1,14 +1,103 @@
-export function readFlag(key: string, fallback = false): boolean {
+import { getUiPrefs, setUiPrefs } from "../api";
+import { isDurableKey, planPrefsSync } from "./prefsSync";
+
+// localStorage cache with a durable backend mirror. Only durable keys (see
+// isDurableKey) are mirrored; ephemeral ones just pass through the cache.
+
+// Keys the user wrote this session — the heal must not clobber them with a
+// backend snapshot captured before the write.
+const dirty = new Set<string>();
+// Re-apply hooks fired once the cache is healed (see hydratePrefs).
+const healed = new Set<() => void>();
+
+function mirror(key: string, value: string | null): void {
+  if (!isDurableKey(key)) return;
+  dirty.add(key);
+  void setUiPrefs({ [key]: value }).catch(() => {});
+}
+
+export function readString(key: string): string | null {
   try {
-    const v = window.localStorage?.getItem(key);
-    return v === null || v === undefined ? fallback : v === "1";
+    return window.localStorage?.getItem(key) ?? null;
   } catch {
-    return fallback;
+    return null;
   }
 }
 
-export function writeFlag(key: string, on: boolean): void {
+export function writeString(key: string, value: string): void {
   try {
-    window.localStorage?.setItem(key, on ? "1" : "0");
+    window.localStorage?.setItem(key, value);
   } catch {}
+  mirror(key, value);
+}
+
+export function removeString(key: string): void {
+  try {
+    window.localStorage?.removeItem(key);
+  } catch {}
+  mirror(key, null);
+}
+
+export function readFlag(key: string, fallback = false): boolean {
+  const v = readString(key);
+  return v == null ? fallback : v === "1";
+}
+
+export function writeFlag(key: string, on: boolean): void {
+  writeString(key, on ? "1" : "0");
+}
+
+function managedLocal(): Record<string, string> {
+  const out: Record<string, string> = {};
+  try {
+    const ls = window.localStorage;
+    if (!ls) return out;
+    for (let i = 0; i < ls.length; i++) {
+      const k = ls.key(i);
+      if (k && isDurableKey(k)) {
+        const v = ls.getItem(k);
+        if (v != null) out[k] = v;
+      }
+    }
+  } catch {}
+  return out;
+}
+
+/** Register a hook to run after the cache is healed (e.g. re-read a value that
+ * may have rendered stale). Returns an unsubscribe. */
+export function onPrefsHealed(cb: () => void): () => void {
+  healed.add(cb);
+  return () => healed.delete(cb);
+}
+
+let hydration: Promise<void> | null = null;
+
+// Heal the localStorage cache from the durable backend copy. Shared promise:
+// the plugin-scope startup and the i18n provider await the same round-trip.
+export function hydratePrefs(): Promise<void> {
+  if (!hydration) hydration = doHydrate();
+  return hydration;
+}
+
+async function doHydrate(): Promise<void> {
+  let backend: Record<string, string>;
+  try {
+    backend = await getUiPrefs();
+  } catch {
+    hydration = null; // transient failure (e.g. backend not ready) — allow a retry
+    return;
+  }
+  const { heal, migrate } = planPrefsSync(backend ?? {}, managedLocal());
+  for (const [k, v] of Object.entries(heal)) {
+    if (dirty.has(k)) continue; // a fresh local write wins over the snapshot
+    try {
+      window.localStorage?.setItem(k, v);
+    } catch {}
+  }
+  if (Object.keys(migrate).length) void setUiPrefs(migrate).catch(() => {});
+  healed.forEach((cb) => {
+    try {
+      cb();
+    } catch {}
+  });
 }

--- a/src/system/prefsSync.test.ts
+++ b/src/system/prefsSync.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { isDurableKey, planPrefsSync } from "./prefsSync";
+
+describe("isDurableKey", () => {
+  it("mirrors the language key and the pdc: namespace", () => {
+    expect(isDurableKey("panel-de-control-lang")).toBe(true);
+    expect(isDurableKey("pdc:layout")).toBe(true);
+    expect(isDurableKey("pdc:collapsed:battery")).toBe(true);
+    expect(isDurableKey("pdc:valueToast:enabled")).toBe(true);
+  });
+  it("excludes the ephemeral active-tab and unmanaged keys", () => {
+    expect(isDurableKey("pdc:activeTab")).toBe(false);
+    expect(isDurableKey("some-other-key")).toBe(false);
+  });
+});
+
+describe("planPrefsSync", () => {
+  it("heals from the backend (backend wins)", () => {
+    const { heal, migrate } = planPrefsSync(
+      { "panel-de-control-lang": "en" },
+      { "panel-de-control-lang": "es" },
+    );
+    expect(heal).toEqual({ "panel-de-control-lang": "en" });
+    expect(migrate).toEqual({});
+  });
+  it("migrates a durable local-only key up to the backend", () => {
+    const { heal, migrate } = planPrefsSync({}, { "pdc:layout": "{}" });
+    expect(heal).toEqual({});
+    expect(migrate).toEqual({ "pdc:layout": "{}" });
+  });
+  it("never migrates or heals ephemeral keys", () => {
+    const { heal, migrate } = planPrefsSync(
+      { "pdc:activeTab": "nav.system" },
+      { "pdc:activeTab": "nav.power" },
+    );
+    expect(heal).toEqual({});
+    expect(migrate).toEqual({});
+  });
+  it("combines heal and migrate across keys", () => {
+    const { heal, migrate } = planPrefsSync(
+      { "panel-de-control-lang": "en" },
+      { "panel-de-control-lang": "es", "pdc:valueToast:enabled": "1" },
+    );
+    expect(heal).toEqual({ "panel-de-control-lang": "en" });
+    expect(migrate).toEqual({ "pdc:valueToast:enabled": "1" });
+  });
+});

--- a/src/system/prefsSync.ts
+++ b/src/system/prefsSync.ts
@@ -1,0 +1,27 @@
+// Pure policy for mirroring frontend UI preferences to the durable backend.
+
+const LANG_KEY = "panel-de-control-lang"; // predates the pdc: namespace
+const EPHEMERAL = new Set<string>(["pdc:activeTab"]); // not persisted across reboots
+
+export function isDurableKey(key: string): boolean {
+  if (EPHEMERAL.has(key)) return false;
+  return key === LANG_KEY || key.startsWith("pdc:");
+}
+
+// Reconcile the backend copy with the local cache: heal = write into
+// localStorage (backend wins); migrate = push a local-only key up so a
+// pre-existing choice survives the first reboot after upgrade.
+export function planPrefsSync(
+  backend: Record<string, string>,
+  local: Record<string, string>,
+): { heal: Record<string, string>; migrate: Record<string, string> } {
+  const heal: Record<string, string> = {};
+  for (const [k, v] of Object.entries(backend)) {
+    if (isDurableKey(k)) heal[k] = v;
+  }
+  const migrate: Record<string, string> = {};
+  for (const [k, v] of Object.entries(local)) {
+    if (isDurableKey(k) && !(k in heal)) migrate[k] = v;
+  }
+  return { heal, migrate };
+}

--- a/src/system/valueToast.tsx
+++ b/src/system/valueToast.tsx
@@ -111,14 +111,23 @@ export function isValueToastEnabled(): boolean {
   return readFlag(KEY);
 }
 
-export function setValueToastEnabled(on: boolean): void {
-  writeFlag(KEY, on);
+function applyEnabled(on: boolean): void {
   enabled = on;
   if (on) {
     if (alive) subscribeAll();
   } else {
     clearTimers();
   }
+}
+
+export function setValueToastEnabled(on: boolean): void {
+  writeFlag(KEY, on);
+  applyEnabled(on);
+}
+
+// Re-apply the healed flag without re-persisting it (after hydratePrefs).
+export function refreshValueToast(): void {
+  applyEnabled(isValueToastEnabled());
 }
 
 export function startValueToast(): () => void {

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -86,6 +86,38 @@ def test_set_telemetry_enabled_persists(Plugin):
     assert asyncio.run(Plugin().get_telemetry_enabled()) is True
 
 
+def test_ui_prefs_default_empty(Plugin):
+    assert asyncio.run(Plugin().get_ui_prefs()) == {}
+
+
+def test_set_ui_prefs_persists(Plugin):
+    p = Plugin()
+    asyncio.run(p.set_ui_prefs({"panel-de-control-lang": "en", "pdc:valueToast:enabled": "1"}))
+    prefs = asyncio.run(p.get_ui_prefs())
+    assert prefs == {"panel-de-control-lang": "en", "pdc:valueToast:enabled": "1"}
+    # Survives a fresh Plugin instance (same settings dir) → survives a reboot.
+    assert asyncio.run(Plugin().get_ui_prefs()) == prefs
+
+
+def test_set_ui_prefs_none_removes_key(Plugin):
+    p = Plugin()
+    asyncio.run(p.set_ui_prefs({"pdc:layout": "{}"}))
+    asyncio.run(p.set_ui_prefs({"pdc:layout": None}))
+    assert asyncio.run(p.get_ui_prefs()) == {}
+
+
+def test_set_ui_prefs_coerces_value_to_string(Plugin):
+    p = Plugin()
+    asyncio.run(p.set_ui_prefs({"k": 1}))
+    assert asyncio.run(p.get_ui_prefs()) == {"k": "1"}
+
+
+def test_set_ui_prefs_does_not_mutate_defaults(Plugin):
+    import main
+    asyncio.run(Plugin().set_ui_prefs({"k": "v"}))
+    assert main.DEFAULTS["ui_prefs"] == {}
+
+
 def test_qam_tdp_boost_default_false(Plugin):
     # Honesty default: opening the QAM must NOT raise TDP unless the user opts in.
     p = Plugin()


### PR DESCRIPTION
Fixes #97 (language resetting to Spanish after a reboot).

## Qué pasaba
El idioma, el toggle de "mostrar valor al cambiar volumen/brillo", el estado plegado de las tarjetas de Sistema y la personalización de pestañas/bloques vivían solo en localStorage. El cliente de Steam no lo mantiene de forma fiable entre reinicios, así que se reseteaban.

## Qué hace
Los espeja al almacén de ajustes del plugin (la fuente durable) y sana el caché de localStorage desde ahí al arrancar. Una elección previa que solo estuviera en local se migra hacia arriba, así nadie pierde su ajuste al actualizar. La última pestaña activa se queda efímera a propósito (aterrizar en la primera es aceptable).

## What it does (EN)
The language, the value-on-change toast toggle, the collapse state of the System cards and the tab/block customization only lived in localStorage, which the Steam client doesn't keep reliably across a reboot, so they reset. They are now mirrored to the plugin's settings store (the durable source) and the localStorage cache is healed from it on startup; a pre-existing local-only choice is migrated up so no setting is lost on upgrade. The last active tab stays ephemeral on purpose.

## Notas
- Gate verde: 775 pytest, 192 vitest, typecheck, build, ruff.
- Pendiente de validar el reinicio real on-device.