### PR TITLE
ci: fail releases whose notes aren't bilingual

### DIFF
--- a/.github/workflows/release-notes-language.yml
+++ b/.github/workflows/release-notes-language.yml
@@ -1,0 +1,31 @@
+name: release-notes-language
+
+# The in-app updater shows the GitHub release body verbatim. release-please
+# generates it in English only, so this fails loudly if a published (or edited)
+# release is missing either language section, keeping the notes bilingual.
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  check-bilingual:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require both language sections
+        env:
+          BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          missing=""
+          printf '%s' "$BODY" | grep -qF "### Novedades" || missing="$missing '### Novedades' (español)"
+          printf '%s' "$BODY" | grep -qF "### What's new" || missing="$missing '### What's new' (English)"
+          if [ -n "$missing" ]; then
+            echo "::error::Release notes must be bilingual. Missing section(s):$missing"
+            echo "Edit the release body so it has a '### Novedades' section (Spanish) and a '### What's new' section (English)."
+            exit 1
+          fi
+          echo "Release notes include both languages."


### PR DESCRIPTION
## Por qué
El gestor de actualizaciones del plugin muestra el cuerpo del release de GitHub tal cual, y release-please lo genera solo en inglés. Por eso el changelog salía en inglés en el updater.

## Qué hace
Un workflow que, al publicar o editar un release, falla (check rojo visible) si el cuerpo no trae las dos secciones: `### Novedades` (español) y `### What's new` (inglés). Así nunca puede colarse un release en un solo idioma sin que salte el aviso. Las notas se redactan ES+EN en cada versión.

## What it does (EN)
On release publish/edit, this workflow fails if the body is missing the Spanish (`### Novedades`) or English (`### What's new`) section, so release notes can never silently ship in a single language.