### PR TITLE
docs: update Legion Go S fan note for experimental EC control

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -154,8 +154,9 @@ dial it in.
 11. The original Legion Go needs `acpi_call` (GZFD) for fan curves; it's present on Bazzite but not on
     SteamOS, so without it no curve shows up at all (not even a default one). Where it works, applying
     the curve forces TDP into custom mode. The monitor (speed + temperature) does work.
-12. The Legion Go S only allows coarse fan modes (quiet, balanced, performance), not a freeform curve,
-    so it can't apply a learned curve either.
+12. The Legion Go S drives its fan over an unofficial embedded-controller (EC) path, so it's an
+    optional experimental control: you enable it by hand, with a safety speed cap. Left off, it stays
+    monitor-only.
 13. On Intel the color is only applied while the compositor is active, so that path is forced and the
     small cost is disclosed.
 14. The "OLED look" preset is hidden on panels that are already OLED (Steam Deck OLED, Legion Go 2)

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ Ajustes ayudan un montón a afinarlo.
     Bazzite pero no en SteamOS, así que sin él no aparece ninguna curva (ni siquiera por defecto).
     Donde funciona, aplicar la curva fuerza el TDP a modo custom. El monitor (velocidad + temperatura)
     sí funciona.
-12. La Legion Go S solo permite modos gruesos de ventilador (silencioso, equilibrado, rendimiento),
-    no una curva libre, así que tampoco puede aplicar una curva aprendida.
+12. La Legion Go S controla el ventilador por una vía no oficial del controlador integrado (EC), así
+    que es un control experimental y opcional: hay que activarlo a mano, con un tope de velocidad de
+    seguridad. Desactivado, se queda solo en monitor.
 13. En Intel el color solo se aplica mientras el compositor está activo, así que se fuerza esa ruta y
     se avisa del pequeño coste.
 14. El preset "Aspecto OLED" se oculta en los paneles que ya son OLED (Steam Deck OLED, Legion Go 2)


### PR DESCRIPTION
The feature matrix footnote for the Legion Go S still described the old coarse fan modes (quiet/balanced/performance), which were removed. Updated it (ES + EN) to describe the current opt-in experimental EC fan control with its safety cap.