### PR TITLE
docs: add support and status badges to the README header

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,19 @@
 
 [Español](README.md) · **English**
 
+<p align="center">
+  <a href="https://ko-fi.com/hooandee"><img src="https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi"></a>
+  <a href="https://www.patreon.com/hooandee"><img src="https://img.shields.io/badge/Patreon-Support%20me-FF424D?style=for-the-badge&logo=patreon&logoColor=white" alt="Patreon"></a>
+  <a href="https://www.youtube.com/channel/UCDsSJByXklp6xc_WwQJI7Lw/join"><img src="https://img.shields.io/badge/YouTube-Become%20a%20member-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube"></a>
+  <a href="https://discord.gg/x2ZNARy"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://linktr.ee/hooandee"><img src="https://img.shields.io/badge/All%20my%20links-Linktree-43E660?style=for-the-badge&logo=linktree&logoColor=white" alt="Linktree"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Hooandee/panel-de-control/actions/workflows/ci.yml"><img src="https://github.com/Hooandee/panel-de-control/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/Hooandee/panel-de-control/releases/latest"><img src="https://img.shields.io/github/v/release/Hooandee/panel-de-control?label=latest%20release&color=blue" alt="Latest release"></a>
+</p>
+
 The control center your handheld gaming PC was missing. Tune power, fan curves, battery, display and
 controllers from a single panel inside Steam's quick access menu, without leaving your game and
 without memorizing sysfs paths.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 **Español** · [English](README.en.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/hooandee"><img src="https://img.shields.io/badge/Ko--fi-Inv%C3%ADtame%20un%20caf%C3%A9-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi"></a>
+  <a href="https://www.patreon.com/hooandee"><img src="https://img.shields.io/badge/Patreon-Ap%C3%B3yame-FF424D?style=for-the-badge&logo=patreon&logoColor=white" alt="Patreon"></a>
+  <a href="https://www.youtube.com/channel/UCDsSJByXklp6xc_WwQJI7Lw/join"><img src="https://img.shields.io/badge/YouTube-Hazte%20miembro-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube"></a>
+  <a href="https://discord.gg/x2ZNARy"><img src="https://img.shields.io/badge/Discord-%C3%9Anete-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://linktr.ee/hooandee"><img src="https://img.shields.io/badge/Todos%20mis%20enlaces-Linktree-43E660?style=for-the-badge&logo=linktree&logoColor=white" alt="Linktree"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Hooandee/panel-de-control/actions/workflows/ci.yml"><img src="https://github.com/Hooandee/panel-de-control/actions/workflows/ci.yml/badge.svg" alt="Estado del CI"></a>
+  <a href="https://github.com/Hooandee/panel-de-control/releases/latest"><img src="https://img.shields.io/github/v/release/Hooandee/panel-de-control?label=%C3%BAltima%20versi%C3%B3n&color=blue" alt="Última versión"></a>
+</p>
+
 El centro de control que le faltaba a tu Handheld PC. Ajusta la potencia, las curvas de
 ventilador, la batería, la pantalla y los mandos desde un único panel dentro del menú de acceso
 rápido de Steam, sin salir del juego y sin memorizar rutas de sysfs.


### PR DESCRIPTION
Pone arriba del todo de ambos README, justo bajo el selector de idioma, dos filas centradas:

- **Apoyo:** Ko-fi, Patreon, YouTube (hazte miembro), Discord y Linktree, con su logo y color de marca, para que la gente pueda apoyar el proyecto de un clic.
- **Estado:** un badge del CI en vivo y otro de la última versión publicada (lee la release más reciente de GitHub).

ES y EN quedan en sync (mismos badges, textos traducidos).

Nota: los badges de CI y versión solo se renderizarán cuando el repositorio sea público (shields.io y el badge de Actions consultan la API pública sin credenciales). Los botones de apoyo se ven ya.

---

Adds two centered rows at the very top of both READMEs, right below the language switcher:

- **Support:** Ko-fi, Patreon, YouTube (become a member), Discord and Linktree, with brand logos and colors, so people can back the project in one click.
- **Status:** a live CI badge and a latest-release badge (reads the most recent GitHub release).

ES and EN stay in sync (same badges, translated labels).

Note: the CI and version badges will only render once the repo is public (shields.io and the Actions badge hit the public API with no credentials). The support buttons already render.