### PR TITLE
feat: recognise the AOKZOE A1X with a generic AMD TDP path

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -140,6 +140,11 @@ charge limit only light up if the device exposes the nodes, and until someone ru
 we would rather not assume anything. If you own one, reports from the Settings tab help a lot to
 dial it in.
 
+The **AOKZOE A1X** (Ryzen AI 9 HX 370) is also recognised by name and comes in as experimental. Its
+TDP runs through the same generic AMD path (ryzenadj), but with a 30 W ceiling instead of being
+capped at the generic profile's 15 W. As with the OneXFly we do not own one, so reports from the
+Settings tab are gold for confirming what actually responds.
+
 ### Notes
 
 1. The Claw controls TDP through `intel-rapl`, which only exposes the base limit (PL1); there are no

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ ventiladores y el límite de carga se activan solo si el equipo expone los nodos
 alguien lo pruebe en mano preferimos no dar nada por hecho. Si tienes uno, los reportes desde
 Ajustes ayudan un montón a afinarlo.
 
+El **AOKZOE A1X** (Ryzen AI 9 HX 370) también se reconoce por su nombre y entra como experimental.
+Su TDP va por la misma vía genérica de AMD (ryzenadj), pero con un techo de 30 W en vez de quedarse
+capado a los 15 W del perfil genérico. Igual que con el OneXFly no lo tenemos en mano, así que los
+reportes desde Ajustes son oro para confirmar lo que responde de verdad.
+
 ### Notas
 
 1. El Claw controla el TDP por `intel-rapl`, que solo expone el límite base (PL1); no hay raíles de

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -72,4 +72,7 @@ DEVICE_TABLE = (
     DeviceProfile("onexplayer_apex", "OneXPlayer OneXFly Apex",
                   "AMD Ryzen AI Max+ 395", "amd",
                   5, 20, 45, 54, match_names=("ONEXPLAYER APEX",), experimental=True),
+    DeviceProfile("aokzoe_a1x", "AOKZOE A1X", "AMD Ryzen AI 9 HX 370", "amd",
+                  4, 18, 30, 30, match_names=("AOKZOE A1X",), experimental=True,
+                  tdp_presets=(12, 18, 30, 30)),
 )

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -50,6 +50,21 @@ def test_onexplayer_apex_matches_case_insensitively():
     assert prof.key == "onexplayer_apex"
 
 
+def test_aokzoe_a1x_is_recognised_experimental():
+    prof = detect(product_name="AOKZOE A1X")
+    assert prof.key == "aokzoe_a1x"
+    assert prof.is_generic is False
+    assert prof.experimental is True
+    assert prof.vendor == "amd"
+    assert prof.tdp_max == 30
+    assert prof.tdp_presets == (12, 18, 30, 30)
+
+
+def test_aokzoe_a1x_matches_case_insensitively():
+    prof = detect(product_name="AOKZOE A1X Handheld")
+    assert prof.key == "aokzoe_a1x"
+
+
 def test_known_devices_are_not_experimental():
     for product in ("Galileo", "ROG Ally X RC72LA_RC72LA", "83N0", "Claw 8 AI+ A2VM"):
         assert detect(product_name=product).experimental is False


### PR DESCRIPTION
Reconoce el **AOKZOE A1X** (Ryzen AI 9 HX 370, Strix Point) por su nombre, en vez de dejarlo caer en el perfil `GENERIC`.

## El problema

Al no estar en `DEVICE_TABLE`, el A1X caía en `GENERIC`, que capa el TDP a 15 W tanto en la UI como en el clamp de `RyzenadjBackend.set_tdp` (`TdpLimits.from_profile`). El chip aguanta el doble.

## El arreglo

Entrada en `DEVICE_TABLE` (`experimental=True`) con techo real de 30 W. La ruta de TDP ya existe (cadena genérica de AMD → `ryzenadj`, confirmada en el reporte), así que no toca ningún mecanismo: solo cambiamos los límites que hereda el dispositivo.

- DMI `product_name = "AOKZOE A1X"` (match específico, no un `A1X` suelto).
- Se une al patrón experimental existente: badge en la cabecera + nota honesta en Ajustes (ya genérico por la bandera `experimental`).
- Fans, límite de carga, GPU clock, color y mandos entran solos por las cadenas de sondeo genéricas.

## Verificación

777 pytest · ruff · typecheck · build, todo en verde. Nuevos tests de detección (reconocimiento + case-insensitive + no-genérico).

No lo tenemos en mano, así que sigue **experimental** hasta confirmar por reporte / on-device.

---

Recognises the **AOKZOE A1X** (Ryzen AI 9 HX 370, Strix Point) by name instead of letting it fall into the `GENERIC` profile, which clamped its TDP to 15 W in both the UI and the `ryzenadj` write. The chip does about double that. The entry (experimental, 30 W ceiling) rides the existing generic AMD `ryzenadj` path, so no mechanism changes.

Closes #122. From report PDC-PJ66 (#124).