### PR TITLE
feat: recognise the GPD Win Mini 2025 and MSI Claw A8 with a safe generic AMD TDP path

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -145,6 +145,12 @@ TDP runs through the same generic AMD path (ryzenadj), but with a 30 W ceiling i
 capped at the generic profile's 15 W. As with the OneXFly we do not own one, so reports from the
 Settings tab are gold for confirming what actually responds.
 
+The **GPD Win Mini 2025** (Ryzen AI 9 HX 370/365) and the **MSI Claw A8** (Ryzen Z2 Extreme) are now
+recognised by name and come in as experimental too. They used to show up as generic with TDP stuck
+at 15 W; now they go up to a safe 35 W ceiling (the manufacturer-rated peak, well below the chip's
+theoretical cTDP) with three tuned presets. Both run through the same generic AMD path (ryzenadj),
+and we do not own either, so reports from the Settings tab help confirm it.
+
 ### Notes
 
 1. The Claw controls TDP through `intel-rapl`, which only exposes the base limit (PL1); there are no

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ Su TDP va por la misma vía genérica de AMD (ryzenadj), pero con un techo de 30
 capado a los 15 W del perfil genérico. Igual que con el OneXFly no lo tenemos en mano, así que los
 reportes desde Ajustes son oro para confirmar lo que responde de verdad.
 
+La **GPD Win Mini 2025** (Ryzen AI 9 HX 370/365) y la **MSI Claw A8** (Ryzen Z2 Extreme) también se
+reconocen por su nombre y entran como experimentales. Antes salían como genéricas y el TDP se
+quedaba en 15 W; ahora suben hasta un techo seguro de 35 W (el máximo que homologa el fabricante,
+muy por debajo del cTDP teórico del chip) con sus tres presets afinados. Van por la misma vía
+genérica de AMD (ryzenadj) y no las tenemos en mano, así que los reportes desde Ajustes ayudan a
+confirmarlo.
+
 ### Notas
 
 1. El Claw controla el TDP por `intel-rapl`, que solo expone el límite base (PL1); no hay raíles de

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -75,4 +75,11 @@ DEVICE_TABLE = (
     DeviceProfile("aokzoe_a1x", "AOKZOE A1X", "AMD Ryzen AI 9 HX 370", "amd",
                   4, 18, 30, 30, match_names=("AOKZOE A1X",), experimental=True,
                   tdp_presets=(12, 18, 30, 30)),
+    DeviceProfile("gpd_win_mini_2025", "GPD Win Mini 2025",
+                  "AMD Ryzen AI 9 HX 370", "amd",
+                  5, 20, 35, 35, match_names=("G1617-02",), experimental=True,
+                  tdp_presets=(12, 22, 32, 32)),
+    DeviceProfile("msi_claw_a8", "MSI Claw A8", "AMD Ryzen Z2 Extreme", "amd",
+                  6, 17, 35, 35, match_names=("Claw A8",), experimental=True,
+                  tdp_presets=(10, 20, 33, 33)),
 )

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -65,6 +65,31 @@ def test_aokzoe_a1x_matches_case_insensitively():
     assert prof.key == "aokzoe_a1x"
 
 
+def test_gpd_win_mini_2025_is_recognised_experimental():
+    prof = detect(product_name="G1617-02")
+    assert prof.key == "gpd_win_mini_2025"
+    assert prof.is_generic is False
+    assert prof.experimental is True
+    assert prof.vendor == "amd"
+    assert prof.tdp_max == 35
+    assert prof.tdp_presets == (12, 22, 32, 32)
+
+
+def test_msi_claw_a8_is_recognised_experimental():
+    prof = detect(product_name="Claw A8 BZ2EM")
+    assert prof.key == "msi_claw_a8"
+    assert prof.is_generic is False
+    assert prof.experimental is True
+    assert prof.vendor == "amd"
+    assert prof.tdp_max == 35
+    assert prof.tdp_presets == (10, 20, 33, 33)
+
+
+def test_msi_claw_a8_is_not_the_intel_claw():
+    assert detect(product_name="Claw A8 BZ2EM").key == "msi_claw_a8"
+    assert detect(product_name="Claw 8 AI+ A2VM").key == "msi_claw_8_ai_plus"
+
+
 def test_known_devices_are_not_experimental():
     for product in ("Galileo", "ROG Ally X RC72LA_RC72LA", "83N0", "Claw 8 AI+ A2VM"):
         assert detect(product_name=product).experimental is False


### PR DESCRIPTION
Dos máquinas que la gente pedía mucho salían como "dispositivo genérico" con el TDP capado a 15 W. Ahora se reconocen por su nombre y usan la vía genérica de AMD (ryzenadj) con límites y presets propios.

**GPD Win Mini 2025** (Ryzen AI 9 HX 370/365) — 5 a 35 W · presets 12 / 22 / 32
**MSI Claw A8** (Ryzen Z2 Extreme, la AMD, no la Claw Intel) — 6 a 35 W · presets 10 / 20 / 33

Los dos techos de 35 W son el máximo que homologa el fabricante, muy por debajo del cTDP teórico del chip, así que nada de sustos. Con esto también se encienden solos, por sondeo de capacidades, batería, CPU, color, frecuencia de GPU y el monitor de ventiladores (y los mandos en la GPD vía HHD).

Entran como **experimentales** porque no tenemos ninguna de las dos en mano: se confirman con reportes desde Ajustes o con voluntarios.

Cierra parte de: #118, #125, #106, #63 (GPD) y #132, #71, #134 (Claw A8).