### PR TITLE
ci: enforce bilingual changelog and auto-build release notes

### DIFF
--- a/.github/workflows/changelog-bilingual.yml
+++ b/.github/workflows/changelog-bilingual.yml
@@ -1,0 +1,21 @@
+name: changelog-bilingual
+
+# Blocks a PR whose newest CHANGELOG.md section isn't bilingual (every English entry
+# needs a matching Spanish "**ES:**" one). Runs on the release-please PR before merge,
+# so a monolingual release can never reach main. release-please writes English only,
+# so the Spanish line is added by hand on the release PR and this check enforces it.
+on:
+  pull_request:
+    paths: ["CHANGELOG.md"]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - run: python3 scripts/changelog_notes.py --check

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -1,0 +1,29 @@
+name: release-body
+
+# The in-app updater shows the GitHub release body verbatim. release-please writes it
+# in English (the raw changelog section, with links). Rebuild it from the changelog's
+# English/Spanish bullets into a clean, link-free, Spanish-first note, so every release
+# is bilingual with no manual step.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # edit the release notes
+
+jobs:
+  fill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - name: Rewrite release notes from the changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          python3 scripts/changelog_notes.py --release-body > "$RUNNER_TEMP/notes.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.md"

--- a/.github/workflows/release-notes-language.yml
+++ b/.github/workflows/release-notes-language.yml
@@ -1,12 +1,13 @@
 name: release-notes-language
 
-# The in-app updater shows the GitHub release body verbatim. release-please
-# generates it in English only, so this fails loudly if a published (or edited)
-# release is missing either language section, keeping the notes bilingual.
+# The in-app updater shows the GitHub release body verbatim. The release-body workflow
+# rewrites it into both languages right after publish; this is the safety net that fails
+# loudly if an edited release ever ends up missing either language section. Runs on
+# edited (not published) so it validates the rewritten body, not the raw English one.
 
 on:
   release:
-    types: [published, edited]
+    types: [edited]
 
 permissions:
   contents: read

--- a/scripts/changelog_notes.py
+++ b/scripts/changelog_notes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Derive release notes from the newest CHANGELOG.md section.
+
+Modes:
+  --check         exit non-zero unless every entry in the newest release section has
+                  both an English bullet and a matching Spanish (**ES:**) bullet.
+  --release-body  print a clean bilingual release body (Spanish first, then English,
+                  with the PR/commit links stripped) for the in-app updater to render.
+
+The changelog uses release-please's format: a section per version, each entry a
+`* <English> ([#N](...)) ([sha](...))` bullet followed by a `* **ES:** <Spanish> ...`
+bullet. Only the top (newest) section is considered.
+"""
+import pathlib
+import re
+import sys
+
+_LINK = re.compile(r"\s*\(\[[^\]]+\]\(https?://[^)]+\)\).*$")
+
+
+def _top_section(text):
+    lines = text.splitlines()
+    heads = [i for i, line in enumerate(lines) if line.startswith("## [")]
+    if not heads:
+        return []
+    end = heads[1] if len(heads) > 1 else len(lines)
+    return lines[heads[0]:end]
+
+
+def _bullets(section):
+    """(is_es, text) for each `* ` bullet, with trailing PR/commit links stripped."""
+    out = []
+    for line in section:
+        if not line.startswith("* "):
+            continue
+        body = line[2:].strip()
+        is_es = body.startswith("**ES:**")
+        if is_es:
+            body = body[len("**ES:**"):].strip()
+        out.append((is_es, _LINK.sub("", body).strip()))
+    return out
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    section = _top_section(pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8"))
+    bullets = _bullets(section)
+    english = [b for is_es, b in bullets if not is_es]
+    spanish = [b for is_es, b in bullets if is_es]
+
+    if mode == "--check":
+        if english and len(spanish) != len(english):
+            print("::error::CHANGELOG.md top section is not bilingual: "
+                  f"{len(english)} English bullet(s) vs {len(spanish)} Spanish "
+                  "(**ES:**) one(s). Add a '* **ES:** ...' line for each entry.")
+            return 1
+        print("CHANGELOG top section is bilingual.")
+        return 0
+
+    if mode == "--release-body":
+        parts = []
+        if spanish:
+            parts += ["### Novedades", ""] + [f"- {b}" for b in spanish] + [""]
+        if english:
+            parts += ["### What's new", ""] + [f"- {b}" for b in english]
+        sys.stdout.write("\n".join(parts).strip() + "\n")
+        return 0
+
+    print("usage: changelog_notes.py --check | --release-body", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Español

Mata de raíz el problema recurrente del changelog bilingüe. Antes había dos pasos manuales por release (el changelog de la PR y el cuerpo de la Release), los dos a mano y fáciles de olvidar.

- **changelog-bilingual** (check en la PR): si la sección más nueva del `CHANGELOG.md` tiene entradas en inglés sin su línea `**ES:**`, el check sale rojo y no deja mergear. Una release monolingüe ya no puede llegar a main.
- **release-body** (al publicar): reescribe el cuerpo de la Release a partir de las viñetas EN/ES del changelog, en formato limpio, sin enlaces y con el español primero (que es lo que renderiza el actualizador del plugin). Se acabó el `gh release edit` a mano.
- `scripts/changelog_notes.py` alimenta ambos (`--check` / `--release-body`). El guard de idioma existente ahora corre en `edited`, así valida el cuerpo ya reescrito.

Único paso humano que queda: escribir la frase en español una vez en la PR de release. El CI hace el resto.

## English

Kills the recurring bilingual-changelog pain. There used to be two manual steps per release (the PR changelog and the release body), both by hand and easy to forget.

- **changelog-bilingual** (PR check): if the newest `CHANGELOG.md` section has English entries without their `**ES:**` line, the check goes red and blocks the merge. A monolingual release can no longer reach main.
- **release-body** (on publish): rebuilds the release body from the changelog's EN/ES bullets into a clean, link-free, Spanish-first note (what the in-app updater renders). No more manual `gh release edit`.
- `scripts/changelog_notes.py` backs both (`--check` / `--release-body`). The existing language guard now runs on `edited`, so it validates the rewritten body.

Only human step left: write the Spanish line once on the release PR. CI does the rest.
