### PR TITLE
fix: re-apply panel color after boot once gamescope is ready

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,6 +209,8 @@ class Plugin:
         )
         self._night_task = None
         self._night_applied = False
+        # Bounded startup task that re-asserts the display look once gamescope is ready.
+        self._display_wait_task = None
         # HDR output on/off (gamescope). State lives in settings (hdr_enabled); gated to
         # HDR-capable panels with gamescope.
         self._hdr_backend = HdrBackend(run_gamescopectl)
@@ -1575,6 +1577,31 @@ class Plugin:
         except Exception:  # noqa: BLE001
             pass
 
+    async def _await_display_backend(self, attempts=30, interval=5.0,
+                                     reasserts=40, reassert_interval=3.0) -> None:
+        """Re-assert the color/HDR look at startup over a short window. gamescope drops a
+        look loaded while it is still bringing up the session, so applying once at load
+        isn't enough — whether gamescope wasn't up yet when we loaded (cold boot) or it
+        was up but still initialising (fast/manual reboot). First wait (bounded) for the
+        socket to answer, then re-apply every few seconds across the session-bringup
+        window, and finally start the night loop. On a host with no gamescope (desktop)
+        it just stays native."""
+        try:
+            for _ in range(attempts):
+                if await self._offload_call(lambda: self._color_backend.supported):
+                    break
+                await asyncio.sleep(interval)
+            else:
+                return  # gamescope never came up (desktop) — nothing to apply
+            for i in range(reasserts):
+                self._reapply_color()
+                self._reapply_hdr()
+                if i < reasserts - 1:
+                    await asyncio.sleep(reassert_interval)
+            self._start_night_loop()
+        except asyncio.CancelledError:
+            pass
+
     def _display_color(self) -> dict:
         """What the UI reflects: saved effective + the unconfirmed preview. Excludes the
         night-mode shift, so the Temperature slider keeps showing the user's own value."""
@@ -2018,6 +2045,9 @@ class Plugin:
             self._reapply_all()
             self._lifecycle.start()
             self._start_night_loop()
+            # Re-assert the look across gamescope's session bringup, when a single apply
+            # doesn't stick (see _await_display_backend). Always runs, not just cold boot.
+            self._display_wait_task = asyncio.create_task(self._await_display_backend())
             if self._settings.get("auto_tdp"):
                 self._start_auto_loop()
             if self._settings.get("telemetry_enabled", True):
@@ -2032,6 +2062,10 @@ class Plugin:
         # await, then shut the executor down.
         await self._offload_call(self._restore_fans_safe)
         self._cancel_color_revert()
+        wait_task = getattr(self, "_display_wait_task", None)
+        if wait_task is not None:
+            wait_task.cancel()
+            self._display_wait_task = None
         self._stop_night_loop()
         await self._offload_call(self._restore_color_safe)
         self._stop_auto_loop()

--- a/tests/test_color_rpc.py
+++ b/tests/test_color_rpc.py
@@ -295,3 +295,60 @@ def test_color_persists_across_instances(tmp_path, monkeypatch):
     asyncio.run(p.set_saturation(133, "global", None))
     p2, _ = _make_plugin(tmp_path, monkeypatch)
     assert asyncio.run(p2.get_color_state())["saturation"] == 133
+
+
+class _LateColorBackend:
+    """gamescope's Wayland socket comes up AFTER load: `supported` reads False until
+    it has been polled `ready_after` times, then True (permanently). apply() records
+    what got pushed."""
+
+    def __init__(self, ready_after=2):
+        self.ready_after = ready_after
+        self._reads = 0
+        self.probe_detail = "fake"
+        self.force_composite = False
+        self.applied = []
+
+    @property
+    def supported(self):
+        self._reads += 1
+        return self._reads > self.ready_after
+
+    def apply(self, state):
+        self.applied.append(dict(state))
+        return True
+
+
+def test_display_reapply_waits_for_gamescope_on_cold_boot(tmp_path, monkeypatch):
+    # Cold boot: the socket isn't up when the plugin loads, so the startup apply
+    # no-ops. The waiter must retry and push the persisted look once it comes up.
+    late = _LateColorBackend(ready_after=2)
+    p, _ = _make_plugin(tmp_path, monkeypatch, color=late)
+    asyncio.run(p.set_saturation(150, "global", None))  # persists regardless
+    late.applied.clear()
+    asyncio.run(p._await_display_backend(
+        attempts=8, interval=0, reasserts=3, reassert_interval=0))
+    assert late.applied, "color look was never re-applied once gamescope came up"
+    assert late.applied[-1]["saturation"] == 150
+
+
+def test_display_reapply_reasserts_multiple_times(tmp_path, monkeypatch):
+    # gamescope can drop a look loaded during session bringup, so the waiter must
+    # re-assert several times, not once.
+    late = _LateColorBackend(ready_after=0)
+    p, _ = _make_plugin(tmp_path, monkeypatch, color=late)
+    asyncio.run(p.set_saturation(150, "global", None))
+    late.applied.clear()
+    asyncio.run(p._await_display_backend(
+        attempts=2, interval=0, reasserts=4, reassert_interval=0))
+    assert len(late.applied) == 4
+
+
+def test_display_reapply_gives_up_without_gamescope(tmp_path, monkeypatch):
+    # No gamescope (desktop): bounded — returns without ever applying (honest no-op).
+    never = _LateColorBackend(ready_after=999)
+    p, _ = _make_plugin(tmp_path, monkeypatch, color=never)
+    asyncio.run(p.set_saturation(150, "global", None))
+    never.applied.clear()
+    asyncio.run(p._await_display_backend(attempts=3, interval=0))
+    assert never.applied == []


### PR DESCRIPTION
## Qué

Arregla que el color del panel se quedaba en nativo tras reiniciar o apagar/encender, aunque los valores seguían guardados en el plugin. Reportado en la Legion Go 2 (SteamOS), pero afecta a cualquier equipo con color por gamescope. Cierra #172.

## Por qué pasaba

El color es un LUT que se carga en gamescope con `set_look`: estado en runtime que se borra en cada reinicio. El plugin ya lo reaplicaba al arrancar, pero gamescope descarta un look que se carga mientras todavía está montando la sesión, así que aplicarlo una sola vez no basta. Da igual que el plugin gane la carrera al socket (arranque en frío) o que gamescope ya esté arriba cuando el plugin carga (reinicio rápido/manual): en ambos casos la aplicación temprana se pierde.

## Qué cambia

Una tarea de arranque acotada que espera al socket de gamescope y luego re-afirma el look de color + HDR cada pocos segundos durante la ventana en la que gamescope monta la sesión, y al final arranca el bucle de modo noche. Se ejecuta siempre, no solo en arranque en frío. En un equipo sin gamescope se queda en nativo sin inventar nada. Todo fuera del event loop y acotado.

Validado on-device en la Legion Go 2 (varios reinicios y apagado/encendido).

---

## What

Fixes the panel color reverting to native after a reboot or power-cycle even though the values stayed saved in the plugin. Reported on the Legion Go 2 (SteamOS), but it affects any gamescope-color device. Closes #172.

## Why

Color is a LUT loaded into gamescope via `set_look`: runtime state wiped on every reboot. The plugin already re-applied it at startup, but gamescope drops a look loaded while it is still bringing up the session, so applying it once isn't enough. It happens whether the plugin beats gamescope to the socket (cold boot) or gamescope is already up when the plugin loads (fast/manual reboot): the early apply is lost either way.

## What changes

A bounded startup task that waits for gamescope's socket, then re-asserts the color + HDR look every few seconds across the session-bringup window, and finally starts the night loop. It always runs, not only on a cold boot. On a host without gamescope it just stays native. All off the event loop and bounded.

Validated on-device on the Legion Go 2 (multiple reboots and a full power-cycle).
