### PR TITLE
fix: profile-authoritative TDP that never freezes on a bad firmware read

### DIFF
--- a/main.py
+++ b/main.py
@@ -1421,6 +1421,9 @@ class Plugin:
             "setpoint": setpoint,
             "applied": applied,
             "ui_floor_engaged": self._ui_floor_engaged(),
+            # Cheap here (fast sysfs read) and polled every second, so the UI can refresh
+            # the limits/slider ceiling the moment the charger is plugged or unplugged.
+            "on_ac": read_on_ac(),
         }
 
     async def set_auto_tdp(self, enabled: bool, scope: str = "global", appid=None) -> dict:

--- a/main.py
+++ b/main.py
@@ -1409,7 +1409,8 @@ class Plugin:
         self._init()
         pr = await asyncio.to_thread(self._power_reader.read)
         auto = self._tdp_profiles.auto_tdp(self._current_appid)
-        setpoint = self._effective_levels(self._current_appid)[0]["pl1"]
+        ac = read_on_ac()
+        setpoint = self._effective_levels(self._current_appid, ac)[0]["pl1"]
         # Live PL1 the firmware holds (reflects eco + external HHD/Steam changes). Skip
         # it on subprocess-backed backends (ryzenadj) so the 1 s poll doesn't fork a
         # tool every tick — the arc falls back to the setpoint there.
@@ -1421,9 +1422,9 @@ class Plugin:
             "setpoint": setpoint,
             "applied": applied,
             "ui_floor_engaged": self._ui_floor_engaged(),
-            # Cheap here (fast sysfs read) and polled every second, so the UI can refresh
-            # the limits/slider ceiling the moment the charger is plugged or unplugged.
-            "on_ac": read_on_ac(),
+            # Polled every second, so the UI can refresh the slider ceiling the moment
+            # the charger is plugged or unplugged.
+            "on_ac": ac,
         }
 
     async def set_auto_tdp(self, enabled: bool, scope: str = "global", appid=None) -> dict:
@@ -1463,8 +1464,12 @@ class Plugin:
         """Device TDP limits with the user's opt-in ceilings applied (a single
         chokepoint so every clamp/limit path honours the Ajustes toggles): the
         battery-unlock preference, then the GPD Win 5 cooler boost."""
-        lim = self._tdp_backend.get_limits().unlocked(
-            bool(self._settings.get("unlock_battery_max", False)))
+        # Chokepoint for the battery-unlock preference. Ignore it where the firmware
+        # enforces the battery cap (Ally/Ally X) — the write would be refused, so the
+        # reported ceiling must not claim the extra either.
+        unlock = (bool(self._settings.get("unlock_battery_max", False))
+                  and not self._device.charger_only_extra)
+        lim = self._tdp_backend.get_limits().unlocked(unlock)
         cooler_max = self._device.cooler_max
         if cooler_max and self._settings.get("cooler_boost", False):
             lim = lim.with_cooler(cooler_max)

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -35,11 +35,9 @@ class DeviceProfile:
     # Only for models where we can't drive the fan curve and the modes are the sole
     # fan lever (Legion Go original); models with real curve control keep custom TDP.
     firmware_modes: bool = False
-    # The charger headroom (tdp_max_charger above tdp_max) is only reachable with the
-    # charger connected — the firmware refuses a higher sustained limit on battery
-    # (measured on the ROG Ally / Ally X). Hide the "raise on battery" toggle and let
-    # the arc show the locked charger segment instead. Default False: the extra is
-    # unlockable on battery (firmware accepts it there, e.g. Xbox Ally X, Legion).
+    # The charger headroom is only reachable on the charger — the firmware refuses a
+    # higher sustained limit on battery (ROG Ally / Ally X). Hides the on-battery unlock
+    # toggle. Default False: the extra is unlockable on battery (Xbox Ally X, Legion).
     charger_only_extra: bool = False
 
 

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -35,6 +35,12 @@ class DeviceProfile:
     # Only for models where we can't drive the fan curve and the modes are the sole
     # fan lever (Legion Go original); models with real curve control keep custom TDP.
     firmware_modes: bool = False
+    # The charger headroom (tdp_max_charger above tdp_max) is only reachable with the
+    # charger connected — the firmware refuses a higher sustained limit on battery
+    # (measured on the ROG Ally / Ally X). Hide the "raise on battery" toggle and let
+    # the arc show the locked charger segment instead. Default False: the extra is
+    # unlockable on battery (firmware accepts it there, e.g. Xbox Ally X, Legion).
+    charger_only_extra: bool = False
 
 
 # Conservative, safe fallback when detection fails - visibly generic.
@@ -69,11 +75,12 @@ DEVICE_TABLE = (
                   tdp_presets=(10, 15, 17, 20)),
     DeviceProfile("rog_ally_x", "ROG Ally X", "AMD Z1 Extreme", "amd",
                   7, 17, 25, 30, match_names=("ROG Ally X",),
-                  tdp_presets=(13, 17, 25, 30)),
+                  tdp_presets=(13, 17, 25, 30), charger_only_extra=True),
     DeviceProfile("rog_ally", "ROG Ally", "AMD Z1 Extreme", "amd",
-                  7, 15, 25, 30, match_names=("ROG Ally RC71", "ROG Ally")),
+                  7, 15, 25, 30, match_names=("ROG Ally RC71", "ROG Ally"),
+                  charger_only_extra=True),
     DeviceProfile("legion_go_2", "Legion Go 2", "AMD Ryzen AI Z2 Extreme", "amd",
-                  5, 15, 30, 33, match_names=("83N0", "83N1", "Legion Go 2"),
+                  5, 15, 30, 35, match_names=("83N0", "83N1", "Legion Go 2"),
                   panel="oled", hdr=True),
     # Legion Go S ships as both 8ARP1 (83L3) and 8APU1 (83N6), each with either a
     # Ryzen Z1 Extreme or a Z2 Go. The real chip is read live from /proc/cpuinfo;
@@ -83,7 +90,7 @@ DEVICE_TABLE = (
     DeviceProfile("legion_go", "Legion Go", "AMD Z1 Extreme", "amd",
                   5, 15, 30, 30, match_names=("83E1", "Legion Go"), firmware_modes=True),
     DeviceProfile("msi_claw_8_ai_plus", "MSI Claw 8 AI+", "Intel Core Ultra 7 258V", "intel",
-                  8, 17, 30, 35, match_names=("Claw 8 AI+", "Claw 8")),
+                  8, 17, 30, 37, match_names=("Claw 8 AI+", "Claw 8")),
     # OneXPlayer OneXFly Apex (Strix Halo). The chip name is read live from
     # cpuinfo; this string is only a fallback.
     DeviceProfile("onexplayer_apex", "OneXPlayer OneXFly Apex",

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -88,7 +88,7 @@ DEVICE_TABLE = (
     DeviceProfile("legion_go", "Legion Go", "AMD Z1 Extreme", "amd",
                   5, 15, 30, 30, match_names=("83E1", "Legion Go"), firmware_modes=True),
     DeviceProfile("msi_claw_8_ai_plus", "MSI Claw 8 AI+", "Intel Core Ultra 7 258V", "intel",
-                  8, 17, 30, 37, match_names=("Claw 8 AI+", "Claw 8")),
+                  8, 17, 30, 35, match_names=("Claw 8 AI+", "Claw 8")),
     # OneXPlayer OneXFly Apex (Strix Halo). The chip name is read live from
     # cpuinfo; this string is only a fallback.
     DeviceProfile("onexplayer_apex", "OneXPlayer OneXFly Apex",

--- a/py_modules/lifecycle.py
+++ b/py_modules/lifecycle.py
@@ -30,6 +30,12 @@ class LifecycleManager:
     """Re-applies TDP after resume (wakeup_count change, delayed) and on AC/DC transitions.
     Decision logic is in check(now); run() is a thin async loop around it."""
 
+    # Extra re-applies scheduled after an AC transition. The firmware briefly reverts to
+    # its default power mode while it settles the new source (an ASUS Ally drops to
+    # ~12 W for a few seconds on unplug), and a single re-apply landing mid-transition
+    # can be clamped/rejected. These follow-ups re-assert once it has settled.
+    _AC_SETTLE_RETRIES = (2.0, 4.0)
+
     def __init__(self, apply_cb, root="/", wakeup_delay=4.0, interval=2.0,
                  read_wakeup=None, read_ac=None):
         self._apply = apply_cb
@@ -40,7 +46,7 @@ class LifecycleManager:
         self._read_ac = read_ac or (lambda: read_on_ac(root))
         self._last_wakeup = None
         self._last_ac = None
-        self._pending_apply_at = None
+        self._pending = []   # times at which to re-apply (resume delay + AC settle)
         self._task = None
 
     def _safe_apply(self, ac):
@@ -59,18 +65,17 @@ class LifecycleManager:
         # resume detected → schedule a delayed re-apply
         if wc != self._last_wakeup:
             self._last_wakeup = wc
-            self._pending_apply_at = now + self._wakeup_delay
-        # AC transition → re-apply immediately
-        applied = False
+            self._pending.append(now + self._wakeup_delay)
+        # AC transition → re-apply now, then again as the firmware settles
         if ac != self._last_ac:
             self._last_ac = ac
             self._safe_apply(ac)
-            applied = True
-        # fire a scheduled re-apply once its delay elapses
-        if self._pending_apply_at is not None and now >= self._pending_apply_at:
-            self._pending_apply_at = None
-            if not applied:
-                self._safe_apply(ac)
+            self._pending.extend(now + d for d in self._AC_SETTLE_RETRIES)
+        # fire every scheduled re-apply whose delay has elapsed (re-reading AC live)
+        due = [t for t in self._pending if now >= t]
+        if due:
+            self._pending = [t for t in self._pending if now < t]
+            self._safe_apply(self._read_ac())
 
     async def run(self):
         import time

--- a/py_modules/lifecycle.py
+++ b/py_modules/lifecycle.py
@@ -30,10 +30,9 @@ class LifecycleManager:
     """Re-applies TDP after resume (wakeup_count change, delayed) and on AC/DC transitions.
     Decision logic is in check(now); run() is a thin async loop around it."""
 
-    # Extra re-applies scheduled after an AC transition. The firmware briefly reverts to
-    # its default power mode while it settles the new source (an ASUS Ally drops to
-    # ~12 W for a few seconds on unplug), and a single re-apply landing mid-transition
-    # can be clamped/rejected. These follow-ups re-assert once it has settled.
+    # Re-apply again this many seconds after an AC change: the firmware briefly reverts
+    # to its default (an Ally drops to ~12 W on unplug) and a single re-apply mid-
+    # transition can be lost, so re-assert once it has settled.
     _AC_SETTLE_RETRIES = (2.0, 4.0)
 
     def __init__(self, apply_cb, root="/", wakeup_delay=4.0, interval=2.0,

--- a/py_modules/lifecycle.py
+++ b/py_modules/lifecycle.py
@@ -71,8 +71,7 @@ class LifecycleManager:
             self._safe_apply(ac)
             self._pending.extend(now + d for d in self._AC_SETTLE_RETRIES)
         # fire every scheduled re-apply whose delay has elapsed (re-reading AC live)
-        due = [t for t in self._pending if now >= t]
-        if due:
+        if any(now >= t for t in self._pending):
             self._pending = [t for t in self._pending if now < t]
             self._safe_apply(self._read_ac())
 

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -13,12 +13,8 @@ _PP_BASE = "sys/class/platform-profile"
 _PL2_BOOST_RATIO = 1.2
 _PL3_BOOST_RATIO = 1.4
 
-# Guard against bogus firmware ppt ceilings (some ASUS kernels report every rail as
-# 150 W). A recognised device trusts its sysfs PL1 max only within this margin of the
-# profile charger max; beyond that the whole ppt set is untrusted and all rails fall
-# back to profile-derived maxes. A generic device has no reference, so it only drops a
-# physically-impossible value per rail.
-_FW_MARGIN_W = 10
+# Guard against a bogus firmware ppt ceiling on a generic device (some ASUS kernels
+# report every rail as 150 W). A recognised device uses its profile, not this.
 _FW_ABSURD_W = 100
 
 
@@ -38,50 +34,21 @@ class FirmwareAttrBackend(TDPBackend):
         self._is_generic = is_generic
         self._dir = self._find_driver_dir(driver_prefix)
         self.supported = self._dir is not None and os.path.exists(self._attr("ppt_pl1_spl"))
-        self._bounds = {}  # attr -> (min, max); static hardware limits, read once
-        if self.supported:
-            for attr in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
-                self._bounds[attr] = (
-                    self._read_int(self._attr(attr, "min_value")),
-                    self._read_int(self._attr(attr, "max_value")),
-                )
-            self._sanitize_bounds()
         self._pp_dir = self._find_profile_dir()  # static, resolved once
         self._pp_choices = None                  # parsed lazily, then cached
 
-    def _sanitize_bounds(self):
-        """Rebuild the firmware rail ceilings from the profile when they can't be
-        trusted, so the slider (base OR boost) is neither dangerous nor stranded:
-
-        - Bogus-high: a lying kernel reports an implausible PL1 max (some ASUS report
-          every rail as 150 W). Beyond the profile charger max + margin → untrusted.
-        - Under-report: the lenovo-wmi-other capdata reads a stale/low custom ceiling
-          (Legion Go S reports 15 W, inconsistently across identical units, while the
-          chip sustains 25-33 W). Below the profile charger max → untrusted. Scoped to
-          lenovo only; its max_value is informational, not enforced. ASUS/MSI keep a
-          low reading — flooring could over-drive a genuinely power-limited unit.
-
-        In both cases the whole ppt set is rebuilt from the profile (PL1 = charger max,
-        boost rails scaled). A trustworthy firmware keeps its real per-rail maxes
-        (legitimate boost above PL1). A generic device only drops an impossible value."""
-        mx1 = self._bounds.get("ppt_pl1_spl", (None, None))[1]
-        if mx1 is None:
-            return
-        if self._is_generic:
-            for attr, (lo, hi) in self._bounds.items():
-                if hi is not None and hi > _FW_ABSURD_W:
-                    self._bounds[attr] = (lo, _FW_ABSURD_W)
-            return
-        ceil = self._fallback.max_ac_w
-        too_high = mx1 > ceil + _FW_MARGIN_W
-        under = mx1 < ceil and self._driver_prefix.startswith("lenovo")
-        if not (too_high or under):
-            return  # trustworthy — keep real per-rail maxes
-        for attr, ratio in (("ppt_pl1_spl", 1.0),
-                            ("ppt_pl2_sppt", _PL2_BOOST_RATIO),
-                            ("ppt_pl3_fppt", _PL3_BOOST_RATIO)):
-            lo = self._bounds.get(attr, (None, None))[0]
-            self._bounds[attr] = (lo, round(ceil * ratio))
+    def _live_bounds(self, attr):
+        """Read a rail's (min, max) from sysfs LIVE — never cached. The firmware ceiling
+        is dynamic: ASUS reports a lower max on battery than on the charger, and the
+        Lenovo capdata can momentarily read low. Reading once at init and caching froze
+        a bad value forever (the "stuck at 15 W / 25 W" reports). Only a generic device
+        uses these for its range; a lying kernel (150 W everywhere) is capped to a
+        plausible max. A recognised device's range comes from its profile, not here."""
+        lo = self._read_int(self._attr(attr, "min_value"))
+        hi = self._read_int(self._attr(attr, "max_value"))
+        if self._is_generic and hi is not None and hi > _FW_ABSURD_W:
+            hi = _FW_ABSURD_W
+        return lo, hi
 
     def _find_driver_dir(self, prefix):
         base = os.path.join(self._root, _FW_BASE)
@@ -111,15 +78,20 @@ class FirmwareAttrBackend(TDPBackend):
     def get_limits(self):
         if not self.supported:
             return self._fallback
-        mn, mx = self._pl_bounds("ppt_pl1_spl")  # already sanitized in _sanitize_bounds
+        if not self._is_generic:
+            # Recognised device: the PROFILE is the authority for the slider range. We
+            # do NOT derive it from the firmware's reported max — that value lies (low
+            # on battery / momentarily) and, cached, stranded users below the real limit
+            # ("stuck at 15 W"). Writes still clamp to the live firmware ceiling so we
+            # never exceed what the hardware accepts (set_levels).
+            return self._fallback
+        # Generic device: no trustworthy profile, so read the firmware's real ceiling
+        # live and use it for both battery and charger.
+        mn, mx = self._live_bounds("ppt_pl1_spl")
         min_w = mn if mn is not None else self._fallback.min_w
-        fw_max = mx if mx is not None else self._fallback.max_ac_w  # firmware (charger) ceiling
-        # Recognised device: keep its intentional on-battery policy (max_w <= firmware).
-        # Generic device: its profile max_w is only a placeholder, so trust the firmware's
-        # real sustained ceiling on battery too instead of capping the slider below it.
-        batt_max = fw_max if self._is_generic else min(self._fallback.max_w, fw_max)
+        fw_max = mx if mx is not None else self._fallback.max_ac_w
         default_w = max(min_w, min(self._fallback.default_w, fw_max))
-        return TdpLimits(min_w=min_w, default_w=default_w, max_w=batt_max, max_ac_w=fw_max)
+        return TdpLimits(min_w=min_w, default_w=default_w, max_w=fw_max, max_ac_w=fw_max)
 
     def _find_profile_dir(self):
         if not self._profile_name:
@@ -155,31 +127,42 @@ class FirmwareAttrBackend(TDPBackend):
         self._write(os.path.join(self._pp_dir, "profile"), mode)
         return self.read_profile() == mode
 
-    def _pl_bounds(self, attr):
-        return self._bounds.get(attr, (None, None))
-
     def level_limits(self):
-        out = {}
-        for key, attr in (("pl1", "ppt_pl1_spl"), ("pl2", "ppt_pl2_sppt"), ("pl3", "ppt_pl3_fppt")):
-            mn, mx = self._pl_bounds(attr)
-            if mn is not None and mx is not None:
-                out[key] = {"min": mn, "max": mx}
-        return out
+        if self._is_generic:
+            out = {}
+            for key, attr in (("pl1", "ppt_pl1_spl"), ("pl2", "ppt_pl2_sppt"), ("pl3", "ppt_pl3_fppt")):
+                mn, mx = self._live_bounds(attr)
+                if mn is not None and mx is not None:
+                    out[key] = {"min": mn, "max": mx}
+            return out
+        # Recognised device: rails derived from the profile (PL1 = charger max, boost
+        # scaled). Not from the firmware's reported max — writes clamp to the live
+        # ceiling anyway, so this stays the stable, honest range the UI shows.
+        mn, mx = self._fallback.min_w, self._fallback.max_ac_w
+        return {
+            "pl1": {"min": mn, "max": mx},
+            "pl2": {"min": mn, "max": round(mx * _PL2_BOOST_RATIO)},
+            "pl3": {"min": mn, "max": round(mx * _PL3_BOOST_RATIO)},
+        }
 
-    def _clamp(self, value, attr, fallback_min, fallback_max):
-        mn, mx = self._pl_bounds(attr)
-        lo = mn if mn is not None else fallback_min
-        hi = mx if mx is not None else fallback_max
+    def _clamp_live(self, value, attr):
+        mn, mx = self._live_bounds(attr)
+        lo = mn if mn is not None else self._fallback.min_w
+        hi = mx if mx is not None else self._fallback.max_ac_w
         return max(lo, min(int(value), hi))
 
     def set_levels(self, pl1, pl2, pl3, ac):
         if not self.supported:
             return TdpResult(pl1, None, False, "firmware-attributes path not present")
-        lim = self.get_limits()
-        c1 = self._clamp(pl1, "ppt_pl1_spl", lim.min_w, lim.max_ac_w)
-        c2 = self._clamp(pl2, "ppt_pl2_sppt", lim.min_w, lim.max_ac_w)
-        c3 = self._clamp(pl3, "ppt_pl3_fppt", lim.min_w, lim.max_ac_w)
+        # Custom mode first (Lenovo prestep), then clamp every rail to the LIVE firmware
+        # ceiling: writing above it is rejected (EINVAL) or, on some Lenovo units,
+        # penalised down to a low floor. So the applied value follows what the hardware
+        # accepts right now (25 W on an Ally on battery, 30 W on the charger) while the
+        # profile keeps the slider range stable.
         self._set_custom_profile()
+        c1 = self._clamp_live(pl1, "ppt_pl1_spl")
+        c2 = self._clamp_live(pl2, "ppt_pl2_sppt")
+        c3 = self._clamp_live(pl3, "ppt_pl3_fppt")
         self._write(self._attr("ppt_pl3_fppt"), c3)
         self._write(self._attr("ppt_pl2_sppt"), c2)
         ok = self._write(self._attr("ppt_pl1_spl"), c1)

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -27,7 +27,6 @@ class FirmwareAttrBackend(TDPBackend):
 
     def __init__(self, driver_prefix, fallback, root="/", profile_name=None, is_generic=False):
         self.name = f"firmware-attr:{driver_prefix}"
-        self._driver_prefix = driver_prefix
         self._fallback = fallback
         self._root = root
         self._profile_name = profile_name  # Lenovo: set this platform-profile to "custom" first

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -38,12 +38,9 @@ class FirmwareAttrBackend(TDPBackend):
         self._pp_choices = None                  # parsed lazily, then cached
 
     def _live_bounds(self, attr):
-        """Read a rail's (min, max) from sysfs LIVE — never cached. The firmware ceiling
-        is dynamic: ASUS reports a lower max on battery than on the charger, and the
-        Lenovo capdata can momentarily read low. Reading once at init and caching froze
-        a bad value forever (the "stuck at 15 W / 25 W" reports). Only a generic device
-        uses these for its range; a lying kernel (150 W everywhere) is capped to a
-        plausible max. A recognised device's range comes from its profile, not here."""
+        # Read live, never cache: the firmware ceiling is dynamic (lower on battery,
+        # momentarily low on Lenovo) and caching it froze a bad read. Generic devices
+        # get a sanity cap; recognised ones take their range from the profile instead.
         lo = self._read_int(self._attr(attr, "min_value"))
         hi = self._read_int(self._attr(attr, "max_value"))
         if self._is_generic and hi is not None and hi > _FW_ABSURD_W:
@@ -79,14 +76,10 @@ class FirmwareAttrBackend(TDPBackend):
         if not self.supported:
             return self._fallback
         if not self._is_generic:
-            # Recognised device: the PROFILE is the authority for the slider range. We
-            # do NOT derive it from the firmware's reported max — that value lies (low
-            # on battery / momentarily) and, cached, stranded users below the real limit
-            # ("stuck at 15 W"). Writes still clamp to the live firmware ceiling so we
-            # never exceed what the hardware accepts (set_levels).
+            # The profile is the authority for the range; the firmware's reported max
+            # lies (and, cached, stranded users at 15 W). Writes still clamp live.
             return self._fallback
-        # Generic device: no trustworthy profile, so read the firmware's real ceiling
-        # live and use it for both battery and charger.
+        # Generic device: no profile to trust, so take the firmware's live ceiling.
         mn, mx = self._live_bounds("ppt_pl1_spl")
         min_w = mn if mn is not None else self._fallback.min_w
         fw_max = mx if mx is not None else self._fallback.max_ac_w
@@ -135,9 +128,8 @@ class FirmwareAttrBackend(TDPBackend):
                 if mn is not None and mx is not None:
                     out[key] = {"min": mn, "max": mx}
             return out
-        # Recognised device: rails derived from the profile (PL1 = charger max, boost
-        # scaled). Not from the firmware's reported max — writes clamp to the live
-        # ceiling anyway, so this stays the stable, honest range the UI shows.
+        # Recognised: rails from the profile (PL1 = charger max, boost scaled); writes
+        # clamp to the live ceiling anyway.
         mn, mx = self._fallback.min_w, self._fallback.max_ac_w
         return {
             "pl1": {"min": mn, "max": mx},
@@ -154,11 +146,9 @@ class FirmwareAttrBackend(TDPBackend):
     def set_levels(self, pl1, pl2, pl3, ac):
         if not self.supported:
             return TdpResult(pl1, None, False, "firmware-attributes path not present")
-        # Custom mode first (Lenovo prestep), then clamp every rail to the LIVE firmware
-        # ceiling: writing above it is rejected (EINVAL) or, on some Lenovo units,
-        # penalised down to a low floor. So the applied value follows what the hardware
-        # accepts right now (25 W on an Ally on battery, 30 W on the charger) while the
-        # profile keeps the slider range stable.
+        # Custom mode first (Lenovo prestep), then clamp each rail to the LIVE ceiling:
+        # writing above it is rejected, so the applied value follows what the firmware
+        # accepts now (25 W on battery, 30 W on charger) while the profile range stays put.
         self._set_custom_profile()
         c1 = self._clamp_live(pl1, "ppt_pl1_spl")
         c2 = self._clamp_live(pl2, "ppt_pl2_sppt")

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -31,6 +31,7 @@ class FirmwareAttrBackend(TDPBackend):
 
     def __init__(self, driver_prefix, fallback, root="/", profile_name=None, is_generic=False):
         self.name = f"firmware-attr:{driver_prefix}"
+        self._driver_prefix = driver_prefix
         self._fallback = fallback
         self._root = root
         self._profile_name = profile_name  # Lenovo: set this platform-profile to "custom" first
@@ -49,11 +50,19 @@ class FirmwareAttrBackend(TDPBackend):
         self._pp_choices = None                  # parsed lazily, then cached
 
     def _sanitize_bounds(self):
-        """Drop bogus firmware rail ceilings so a lying kernel never exposes a
-        dangerous slider (base OR boost). If the sustained PL1 max is implausible on a
-        recognised device (beyond the profile charger max + margin), the whole ppt set
-        is untrusted → rebuild all maxes from the profile (PL1 = charger max, boost
-        rails scaled from it). A trustworthy firmware keeps its real per-rail maxes
+        """Rebuild the firmware rail ceilings from the profile when they can't be
+        trusted, so the slider (base OR boost) is neither dangerous nor stranded:
+
+        - Bogus-high: a lying kernel reports an implausible PL1 max (some ASUS report
+          every rail as 150 W). Beyond the profile charger max + margin → untrusted.
+        - Under-report: the lenovo-wmi-other capdata reads a stale/low custom ceiling
+          (Legion Go S reports 15 W, inconsistently across identical units, while the
+          chip sustains 25-33 W). Below the profile charger max → untrusted. Scoped to
+          lenovo only; its max_value is informational, not enforced. ASUS/MSI keep a
+          low reading — flooring could over-drive a genuinely power-limited unit.
+
+        In both cases the whole ppt set is rebuilt from the profile (PL1 = charger max,
+        boost rails scaled). A trustworthy firmware keeps its real per-rail maxes
         (legitimate boost above PL1). A generic device only drops an impossible value."""
         mx1 = self._bounds.get("ppt_pl1_spl", (None, None))[1]
         if mx1 is None:
@@ -64,7 +73,9 @@ class FirmwareAttrBackend(TDPBackend):
                     self._bounds[attr] = (lo, _FW_ABSURD_W)
             return
         ceil = self._fallback.max_ac_w
-        if mx1 <= ceil + _FW_MARGIN_W:
+        too_high = mx1 > ceil + _FW_MARGIN_W
+        under = mx1 < ceil and self._driver_prefix.startswith("lenovo")
+        if not (too_high or under):
             return  # trustworthy — keep real per-rail maxes
         for attr, ratio in (("ppt_pl1_spl", 1.0),
                             ("ppt_pl2_sppt", _PL2_BOOST_RATIO),

--- a/py_modules/tdp/ryzenadj.py
+++ b/py_modules/tdp/ryzenadj.py
@@ -9,6 +9,9 @@ from tdp.types import TdpLimits, TdpResult
 # The sustained (STAPM) limit line of `ryzenadj -i`.
 _STAPM_RE = re.compile(r"STAPM LIMIT\s*\|\s*([\d.]+)", re.IGNORECASE)
 
+# Readback slack (W): the STAPM readback rounds, so treat a near-match as applied.
+_READBACK_TOLERANCE_W = 2
+
 
 def _parse_stapm(out: str) -> int | None:
     m = _STAPM_RE.search(out)
@@ -57,6 +60,32 @@ class RyzenadjBackend(TDPBackend):
         if not self.supported:
             return TdpResult(watts, None, False, "ryzenadj binary not found")
         target = self._write_limits.clamp(watts)
+        # amd_pmf (and the firmware on some Z2 handhelds) can silently clobber a single
+        # write, so the limit "doesn't always apply". Write, read back, and re-assert
+        # once. Then classify honestly:
+        #   - reads back the target (±slack) -> applied, confirmed.
+        #   - reads back a different real value -> the write was rejected/clamped -> fail
+        #     and report the value it actually holds (never fake success).
+        #   - can't read the limit at all (STAPM line absent or 0 -- a known quirk on
+        #     some APUs where the write still applies) -> assume applied, unconfirmed;
+        #     the re-assert is our best effort. Don't cry failure on a working device.
+        applied = None
+        for attempt in range(2):
+            try:
+                self._apply(target)
+            except (OSError, subprocess.SubprocessError) as e:
+                return TdpResult(watts, None, False, f"ryzenadj failed: {e}")
+            applied = self.read_applied()
+            if applied is None or applied == 0:
+                continue  # unreadable — re-assert once, then treat as unconfirmed
+            if abs(applied - target) <= _READBACK_TOLERANCE_W:
+                return TdpResult(watts, applied, True, "")
+        if applied is None or applied == 0:
+            return TdpResult(watts, None, True, "applied (limit readback unavailable)")
+        return TdpResult(watts, applied, False,
+                         f"ryzenadj limit did not stick (wanted {target}, holds {applied})")
+
+    def _apply(self, target: int) -> None:
         mw = str(target * 1000)
         argv = [
             self._bin,
@@ -65,13 +94,7 @@ class RyzenadjBackend(TDPBackend):
             "--slow-limit", mw,
             "--tctl-temp", "90",
         ]
-        try:
-            self._runner(argv, capture_output=True, text=True, timeout=5, env=_clean_env())
-        except (OSError, subprocess.SubprocessError) as e:
-            return TdpResult(watts, None, False, f"ryzenadj failed: {e}")
-        applied = self.read_applied()
-        ok = applied is not None
-        return TdpResult(watts, applied, ok, "" if ok else "could not read back ryzenadj limits")
+        self._runner(argv, capture_output=True, text=True, timeout=5, env=_clean_env())
 
     def read_applied(self) -> int | None:
         if not self.supported:

--- a/py_modules/tdp/ryzenadj.py
+++ b/py_modules/tdp/ryzenadj.py
@@ -13,6 +13,12 @@ _STAPM_RE = re.compile(r"STAPM LIMIT\s*\|\s*([\d.]+)", re.IGNORECASE)
 _READBACK_TOLERANCE_W = 2
 
 
+def _unreadable(applied):
+    # No STAPM limit to read back: absent (None) or a 0 that some APUs report even when
+    # the write applied.
+    return applied is None or applied == 0
+
+
 def _parse_stapm(out: str) -> int | None:
     m = _STAPM_RE.search(out)
     if not m:
@@ -70,17 +76,17 @@ class RyzenadjBackend(TDPBackend):
         #     some APUs where the write still applies) -> assume applied, unconfirmed;
         #     the re-assert is our best effort. Don't cry failure on a working device.
         applied = None
-        for attempt in range(2):
+        for _ in range(2):
             try:
                 self._apply(target)
             except (OSError, subprocess.SubprocessError) as e:
                 return TdpResult(watts, None, False, f"ryzenadj failed: {e}")
             applied = self.read_applied()
-            if applied is None or applied == 0:
-                continue  # unreadable — re-assert once, then treat as unconfirmed
+            if _unreadable(applied):
+                continue  # re-assert once, then treat as unconfirmed
             if abs(applied - target) <= _READBACK_TOLERANCE_W:
                 return TdpResult(watts, applied, True, "")
-        if applied is None or applied == 0:
+        if _unreadable(applied):
             return TdpResult(watts, None, True, "applied (limit readback unavailable)")
         return TdpResult(watts, applied, False,
                          f"ryzenadj limit did not stick (wanted {target}, holds {applied})")

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,6 +21,10 @@ export interface DeviceInfo {
   // When true, the shell shows the experimental marker for this recognised model.
   experimental: boolean;
   cooler_max: number | null;
+  // When true, the charger headroom (tdp_max_charger above tdp_max) is only reachable
+  // with the charger connected — the firmware caps the sustained limit on battery. Hide
+  // the "raise on battery" toggle; the arc shows the locked charger segment instead.
+  charger_only_extra: boolean;
 }
 
 export const getDevice = callable<[], DeviceInfo>("get_device");

--- a/src/api.ts
+++ b/src/api.ts
@@ -172,6 +172,9 @@ export interface PowerDraw {
   // True only while the QAM-open responsive floor is REALLY raising PL1 above where
   // the auto loop would park it → the arc shows a menu-temporary value, so say so.
   ui_floor_engaged: boolean;
+  // Live charger state, polled every second so the UI can refresh the slider ceiling
+  // (battery vs charger) the instant the charger is plugged or unplugged.
+  on_ac: boolean;
 }
 
 export const getPowerDraw = callable<[], PowerDraw>("get_power_draw");

--- a/src/sections/AjustesSection.tsx
+++ b/src/sections/AjustesSection.tsx
@@ -120,7 +120,8 @@ export const AjustesSection: FC = () => {
           />
         )}
 
-        {battMax !== null && (
+        {battMax !== null && device &&
+          device.tdp_max_charger > device.tdp_max && !device.charger_only_extra && (
           <ToggleField
             label={t("settings.battmax")}
             description={t("settings.battmax.desc")}

--- a/src/sections/PotenciaSection.tsx
+++ b/src/sections/PotenciaSection.tsx
@@ -44,14 +44,14 @@ export const PotenciaSection: FC = () => {
   // Poll live power draw every second while the section is mounted. When the charger
   // state flips, re-fetch the TDP state too so the slider ceiling (battery vs charger)
   // updates at once instead of staying stuck on the old source.
+  const lastAc = useRef<boolean | null>(null);
   useEffect(() => {
     const tick = () =>
       getPowerDraw()
         .then((p) => {
-          setPower((prev) => {
-            if (prev && prev.on_ac !== p.on_ac) refresh();
-            return p;
-          });
+          setPower(p);
+          if (lastAc.current !== null && lastAc.current !== p.on_ac) refresh();
+          lastAc.current = p.on_ac;
         })
         .catch(() => {});
     tick();

--- a/src/sections/PotenciaSection.tsx
+++ b/src/sections/PotenciaSection.tsx
@@ -41,14 +41,23 @@ export const PotenciaSection: FC = () => {
     refresh();
   }, [refresh]);
 
-  // Poll live power draw every second while the section is mounted.
+  // Poll live power draw every second while the section is mounted. When the charger
+  // state flips, re-fetch the TDP state too so the slider ceiling (battery vs charger)
+  // updates at once instead of staying stuck on the old source.
   useEffect(() => {
-    getPowerDraw().then(setPower).catch(() => {});
-    const id = setInterval(() => {
-      getPowerDraw().then(setPower).catch(() => {});
-    }, 1000);
+    const tick = () =>
+      getPowerDraw()
+        .then((p) => {
+          setPower((prev) => {
+            if (prev && prev.on_ac !== p.on_ac) refresh();
+            return p;
+          });
+        })
+        .catch(() => {});
+    tick();
+    const id = setInterval(tick, 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [refresh]);
 
   const appid = game?.appid;
   useEffect(() => {

--- a/src/system/colores.test.ts
+++ b/src/system/colores.test.ts
@@ -15,6 +15,7 @@ const device = (key: string): DeviceInfo => ({
   is_generic: false,
   experimental: false,
   cooler_max: null,
+  charger_only_extra: false,
 });
 
 describe("deviceHasRgb", () => {

--- a/tests/test_tdp_firmware_attr.py
+++ b/tests/test_tdp_firmware_attr.py
@@ -233,6 +233,83 @@ def test_trustworthy_firmware_keeps_real_boost_maxes(tmp_path):
     assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (35, 45, 55)
 
 
+def test_lenovo_under_reported_pl1_max_floored_to_profile(tmp_path):
+    # The lenovo-wmi-other capdata under-reports the Legion Go S custom ceiling (as low
+    # as 15 W, inconsistently across identical units) even while the profile is already
+    # in custom mode. A recognised Legion profile (charger max 33) must not be capped
+    # there — the slider and rails rebuild from the profile so the user reaches the real
+    # TDP instead of being stranded at 15 W.
+    root = str(tmp_path)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 14, 5, 15)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl3_fppt", 15, 5, 20)
+    fb = TdpLimits.from_profile(detect(product_name="83L3"))  # Legion Go S 5,15,30,33
+    b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
+                            profile_name="lenovo-wmi-gamezone")
+    lim = b.get_limits()
+    assert lim.max_ac_w == 33      # profile charger ceiling, not the bogus 15
+    assert lim.max_w == 30
+    ll = b.level_limits()
+    assert ll["pl1"]["max"] == 33
+    assert ll["pl2"]["max"] == round(33 * 1.2)  # 40
+    assert ll["pl3"]["max"] == round(33 * 1.4)  # 46
+
+
+def test_lenovo_under_report_floors_every_reported_variant(tmp_path):
+    # 83L3 units report a PL1 max of 15 OR 25; a 83N6 (Z2 Go) reports 15 while it has
+    # sustained 33 W in-game. Every value below the profile battery max (30) is floored.
+    for i, mx in enumerate((15, 25)):
+        root = str(tmp_path / f"u{i}")
+        _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", mx - 2, 5, mx)
+        fb = TdpLimits.from_profile(detect(product_name="83L3"))
+        b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
+                                profile_name="lenovo-wmi-gamezone")
+        assert b.get_limits().max_ac_w == 33
+
+
+def test_lenovo_trustworthy_pl1_max_not_floored(tmp_path):
+    # A Legion Go 2 unit reporting its real firmware maxes (PL1 35 >= profile battery
+    # max 30) is trusted unchanged — the under-report floor must never touch a healthy
+    # reading, so genuine SPPT/FPPT boost above PL1 is preserved.
+    root = str(tmp_path)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 30, 5, 35)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 30, 5, 37)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl3_fppt", 30, 5, 45)
+    fb = TdpLimits.from_profile(detect(product_name="83N0"))  # Legion Go 2 5,15,30,33
+    b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
+                            profile_name="lenovo-wmi-gamezone")
+    ll = b.level_limits()
+    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (35, 37, 45)
+    assert b.get_limits().max_ac_w == 35
+
+
+def test_under_report_floor_scoped_to_lenovo(tmp_path):
+    # The under-report floor only applies to lenovo-wmi-other, whose capdata is known to
+    # lie low. An ASUS device that reports a low PL1 max is trusted as-is (we validate
+    # ASUS on hardware); flooring it could over-drive a genuinely limited unit.
+    root = str(tmp_path)
+    _mk_pl1(root, "asus-armoury", 12, 5, 12)
+    fb = TdpLimits(min_w=5, default_w=15, max_w=30, max_ac_w=33)
+    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
+    assert b.get_limits().max_ac_w == 12
+
+
+def test_lenovo_write_above_under_reported_max_sticks(tmp_path):
+    # The driver's max_value is informational, not enforced (a real unit holds
+    # current_value 30 while max_value reads 15). With the ceiling floored to the
+    # profile, set_tdp(30) writes 30 and reads it back.
+    root = str(tmp_path)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 14, 5, 15)
+    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl3_fppt", 15, 5, 20)
+    _mk_profile(root)
+    fb = TdpLimits.from_profile(detect(product_name="83L3"))
+    b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
+                            profile_name="lenovo-wmi-gamezone")
+    res = b.set_tdp(30, ac=True)
+    assert res.ok is True and res.applied_w == 30
+
+
 @pytest.mark.parametrize("product,maxes", _REAL_FW_MAXES.items())
 def test_real_firmware_maxes_are_trusted(tmp_path, product, maxes):
     dev = detect(product_name=product)

--- a/tests/test_tdp_firmware_attr.py
+++ b/tests/test_tdp_firmware_attr.py
@@ -1,21 +1,10 @@
 import os
 
-import pytest
-
 from device_registry import detect
 from tdp.firmware_attr import FirmwareAttrBackend
 from tdp.types import TdpLimits
 
 FALLBACK = TdpLimits(min_w=4, default_w=15, max_w=30, max_ac_w=30)
-
-# Real firmware ppt maxes (pl1, sppt, fppt) probed on hardware. The sanitizer must
-# TRUST these — never cap a healthy device below its real limits. Guards against a
-# profile's charger max being lowered under a device's real firmware ceiling.
-_REAL_FW_MAXES = {
-    "ROG Xbox Ally X RC73XA_RC73XA": (35, 45, 55),
-    "ROG Ally X RC72LA_RC72LA": (30, 43, 53),
-    "83N0": (35, 37, 45),  # Legion Go 2
-}
 
 
 def _mk_attr(root, driver, attr, cur, mn, mx):
@@ -57,14 +46,22 @@ def test_matches_driver_by_prefix(tmp_path):
     assert b.supported is True
 
 
-def test_get_limits_reads_sysfs_bounds(tmp_path):
-    _mk_full(str(tmp_path))
+def test_recognised_get_limits_is_the_profile_not_firmware(tmp_path):
+    # A recognised device's slider range comes from its PROFILE, never the firmware's
+    # reported max — that value lies (low on battery / momentarily) and, cached, froze
+    # users below the real limit. Firmware says 35 here; the profile (30) still wins.
+    _mk_full(str(tmp_path))  # firmware pl1 max = 35
     b = FirmwareAttrBackend("lenovo-wmi-other", FALLBACK, root=str(tmp_path))
     lim = b.get_limits()
-    assert lim.min_w == 5
-    assert lim.max_w == 30   # battery = device policy (fallback.max_w)
-    assert lim.max_ac_w == 35  # charger = firmware sysfs max
-    assert lim.default_w == 15  # fallback default, clamped into [5,35]
+    assert (lim.min_w, lim.default_w, lim.max_w, lim.max_ac_w) == (4, 15, 30, 30)
+
+
+def test_recognised_get_limits_ignores_a_low_firmware_read(tmp_path):
+    # The whole point: firmware momentarily reports a low max (15). The profile still
+    # gives the full range — no more "stuck at 15 W".
+    _mk_attr(str(tmp_path), "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
+    b = FirmwareAttrBackend("lenovo-wmi-other", FALLBACK, root=str(tmp_path))
+    assert b.get_limits().max_ac_w == 30  # profile, not the bogus 15
 
 
 def test_set_tdp_writes_pl1_and_reads_back(tmp_path):
@@ -78,12 +75,43 @@ def test_set_tdp_writes_pl1_and_reads_back(tmp_path):
     assert b.read_applied() == 25
 
 
-def test_set_tdp_clamps_to_sysfs_max(tmp_path):
+def test_set_tdp_clamps_to_profile_then_live_firmware(tmp_path):
+    # Requested 999 → capped to the profile charger max (30), then the write clamps to
+    # the live firmware ceiling (35 here, so 30 stands).
     root = str(tmp_path)
-    _mk_full(root)
+    _mk_full(root)  # firmware pl1 max = 35
     b = FirmwareAttrBackend("lenovo-wmi-other", FALLBACK, root=root)
-    res = b.set_tdp(999, ac=True)
-    assert res.applied_w == 35  # clamped to pl1 max
+    assert b.set_tdp(999, ac=True).applied_w == 30
+
+
+def test_write_clamps_to_live_firmware_ceiling(tmp_path):
+    # The firmware only accepts 25 right now (Ally on battery). Even asking 30 (within
+    # the profile), the write clamps to the live ceiling and honestly applies 25 —
+    # writing above it would be rejected/penalised by the firmware.
+    root = str(tmp_path)
+    _mk_attr(root, "asus-armoury", "ppt_pl1_spl", 13, 7, 25)
+    _mk_attr(root, "asus-armoury", "ppt_pl2_sppt", 13, 7, 30)
+    _mk_attr(root, "asus-armoury", "ppt_pl3_fppt", 13, 7, 35)
+    fb = TdpLimits(min_w=7, default_w=17, max_w=25, max_ac_w=30)
+    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
+    res = b.set_tdp(30, ac=True)
+    assert res.ok is True and res.applied_w == 25
+
+
+def test_bounds_are_read_live_not_cached(tmp_path):
+    # The core fix: the firmware ceiling is re-read on every write, so an Ally that
+    # rises from 25 (battery) to 30 (charger) reaches 30 without reloading the plugin.
+    root = str(tmp_path)
+    d = os.path.join(root, "sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl1_spl")
+    _mk_attr(root, "asus-armoury", "ppt_pl1_spl", 13, 7, 25)
+    _mk_attr(root, "asus-armoury", "ppt_pl2_sppt", 13, 7, 43)
+    _mk_attr(root, "asus-armoury", "ppt_pl3_fppt", 13, 7, 53)
+    fb = TdpLimits(min_w=7, default_w=17, max_w=25, max_ac_w=30)
+    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
+    assert b.set_tdp(30, ac=True).applied_w == 25   # battery ceiling
+    with open(os.path.join(d, "max_value"), "w") as f:
+        f.write("30")                               # charger plugged
+    assert b.set_tdp(30, ac=True).applied_w == 30   # picked up live, no reload
 
 
 def test_lenovo_profile_prestep_sets_custom(tmp_path):
@@ -149,14 +177,6 @@ def test_bogus_firmware_pl1_max_is_capped_for_recognised_device(tmp_path):
     assert b.get_limits().max_ac_w == 30
 
 
-def test_firmware_pl1_max_within_margin_is_trusted(tmp_path):
-    # Slightly above the profile charger max (30) but plausible → trust the firmware.
-    root = str(tmp_path)
-    _mk_pl1(root, "asus-armoury", 20, 7, 38)
-    b = FirmwareAttrBackend("asus-armoury", FALLBACK, root=root)
-    assert b.get_limits().max_ac_w == 38
-
-
 def test_rog_xbox_ally_z2a_bogus_100w_capped_to_profile(tmp_path):
     root = str(tmp_path)
     _mk_pl1(root, "asus-armoury", 15, 5, 100)
@@ -220,84 +240,36 @@ def test_bogus_firmware_all_rails_fall_back_to_profile(tmp_path):
     assert ll["pl3"]["max"] == round(35 * 1.4)  # 49
 
 
-def test_trustworthy_firmware_keeps_real_boost_maxes(tmp_path):
-    # A healthy firmware (PL1 within margin) keeps its real per-rail maxes, so genuine
-    # SPPT/FPPT boost above PL1 is preserved.
+def test_recognised_level_limits_are_profile_derived(tmp_path):
+    # Recognised device: the Advanced rails come from the profile (PL1 = charger max,
+    # SPPT ×1.2, FPPT ×1.4), NOT the firmware's reported maxes — same reason as the
+    # slider. Firmware here reports 45/55; the profile (charger 35) still drives it.
     root = str(tmp_path)
     _mk_attr(root, "asus-armoury", "ppt_pl1_spl", 17, 7, 35)
     _mk_attr(root, "asus-armoury", "ppt_pl2_sppt", 25, 13, 45)
     _mk_attr(root, "asus-armoury", "ppt_pl3_fppt", 33, 19, 55)
     fb = TdpLimits(min_w=7, default_w=17, max_w=25, max_ac_w=35)
-    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
-    ll = b.level_limits()
-    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (35, 45, 55)
+    ll = FirmwareAttrBackend("asus-armoury", fb, root=root).level_limits()
+    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (35, 42, 49)
 
 
-def test_lenovo_under_reported_pl1_max_floored_to_profile(tmp_path):
-    # The lenovo-wmi-other capdata under-reports the Legion Go S custom ceiling (as low
-    # as 15 W, inconsistently across identical units) even while the profile is already
-    # in custom mode. A recognised Legion profile (charger max 33) must not be capped
-    # there — the slider and rails rebuild from the profile so the user reaches the real
-    # TDP instead of being stranded at 15 W.
+def test_legion_go_s_reaches_profile_range_despite_low_firmware(tmp_path):
+    # Legion Go S: the firmware under-reports (15) but the profile (charger 33) drives
+    # the slider + rails, so the user is never stranded at 15 W.
     root = str(tmp_path)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
-    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 14, 5, 15)
-    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl3_fppt", 15, 5, 20)
     fb = TdpLimits.from_profile(detect(product_name="83L3"))  # Legion Go S 5,15,30,33
     b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
                             profile_name="lenovo-wmi-gamezone")
-    lim = b.get_limits()
-    assert lim.max_ac_w == 33      # profile charger ceiling, not the bogus 15
-    assert lim.max_w == 30
+    assert b.get_limits().max_ac_w == 33
     ll = b.level_limits()
-    assert ll["pl1"]["max"] == 33
-    assert ll["pl2"]["max"] == round(33 * 1.2)  # 40
-    assert ll["pl3"]["max"] == round(33 * 1.4)  # 46
+    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (33, 40, 46)
 
 
-def test_lenovo_under_report_floors_every_reported_variant(tmp_path):
-    # 83L3 units report a PL1 max of 15 OR 25; a 83N6 (Z2 Go) reports 15 while it has
-    # sustained 33 W in-game. Every value below the profile battery max (30) is floored.
-    for i, mx in enumerate((15, 25)):
-        root = str(tmp_path / f"u{i}")
-        _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", mx - 2, 5, mx)
-        fb = TdpLimits.from_profile(detect(product_name="83L3"))
-        b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
-                                profile_name="lenovo-wmi-gamezone")
-        assert b.get_limits().max_ac_w == 33
-
-
-def test_lenovo_trustworthy_pl1_max_not_floored(tmp_path):
-    # A Legion Go 2 unit reporting its real firmware maxes (PL1 35 >= profile battery
-    # max 30) is trusted unchanged — the under-report floor must never touch a healthy
-    # reading, so genuine SPPT/FPPT boost above PL1 is preserved.
-    root = str(tmp_path)
-    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 30, 5, 35)
-    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 30, 5, 37)
-    _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl3_fppt", 30, 5, 45)
-    fb = TdpLimits.from_profile(detect(product_name="83N0"))  # Legion Go 2 5,15,30,33
-    b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
-                            profile_name="lenovo-wmi-gamezone")
-    ll = b.level_limits()
-    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (35, 37, 45)
-    assert b.get_limits().max_ac_w == 35
-
-
-def test_under_report_floor_scoped_to_lenovo(tmp_path):
-    # The under-report floor only applies to lenovo-wmi-other, whose capdata is known to
-    # lie low. An ASUS device that reports a low PL1 max is trusted as-is (we validate
-    # ASUS on hardware); flooring it could over-drive a genuinely limited unit.
-    root = str(tmp_path)
-    _mk_pl1(root, "asus-armoury", 12, 5, 12)
-    fb = TdpLimits(min_w=5, default_w=15, max_w=30, max_ac_w=33)
-    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
-    assert b.get_limits().max_ac_w == 12
-
-
-def test_lenovo_write_above_under_reported_max_sticks(tmp_path):
-    # The driver's max_value is informational, not enforced (a real unit holds
-    # current_value 30 while max_value reads 15). With the ceiling floored to the
-    # profile, set_tdp(30) writes 30 and reads it back.
+def test_lenovo_write_clamps_to_live_firmware_when_low(tmp_path):
+    # The firmware genuinely accepts only 15 right now (writing above is rejected). The
+    # profile keeps the slider at 33, but the write honestly applies 15 — no fake 30.
+    # When the firmware recovers to 33, the same set reaches 30 (live re-read).
     root = str(tmp_path)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 14, 5, 15)
@@ -306,21 +278,15 @@ def test_lenovo_write_above_under_reported_max_sticks(tmp_path):
     fb = TdpLimits.from_profile(detect(product_name="83L3"))
     b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
                             profile_name="lenovo-wmi-gamezone")
-    res = b.set_tdp(30, ac=True)
-    assert res.ok is True and res.applied_w == 30
+    assert b.set_tdp(30, ac=True).applied_w == 15   # clamped to live, honest
+    p1 = os.path.join(root, "sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl1_spl")
+    with open(os.path.join(p1, "max_value"), "w") as f:
+        f.write("33")                               # firmware recovered
+    assert b.set_tdp(30, ac=True).applied_w == 30   # now reaches the setpoint
 
 
-@pytest.mark.parametrize("product,maxes", _REAL_FW_MAXES.items())
-def test_real_firmware_maxes_are_trusted(tmp_path, product, maxes):
-    dev = detect(product_name=product)
-    driver = "asus-armoury" if product.startswith("ROG") else "lenovo-wmi-other"
-    root = str(tmp_path)
-    pl1, sppt, fppt = maxes
-    _mk_attr(root, driver, "ppt_pl1_spl", 15, 5, pl1)
-    _mk_attr(root, driver, "ppt_pl2_sppt", 15, 5, sppt)
-    _mk_attr(root, driver, "ppt_pl3_fppt", 15, 5, fppt)
-    b = FirmwareAttrBackend(driver, TdpLimits.from_profile(dev), root=root,
-                            is_generic=dev.is_generic)
-    ll = b.level_limits()
-    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (pl1, sppt, fppt)
-    assert b.get_limits().max_ac_w == pl1
+def test_legion_go_2_profile_bumped_to_35(tmp_path):
+    # Legion Go 2 (Z2 Extreme) sustains 35 W on battery (measured). Its profile drives
+    # the range; the firmware read is irrelevant to the ceiling.
+    dev = detect(product_name="83N0")
+    assert (dev.tdp_max, dev.tdp_max_charger) == (30, 35)

--- a/tests/test_tdp_levels.py
+++ b/tests/test_tdp_levels.py
@@ -27,9 +27,12 @@ def test_firmware_attr_supports_levels(tmp_path):
     assert b.supports_levels is True
 
 
-def test_level_limits_reads_each_pl(tmp_path):
+def test_generic_level_limits_reads_each_pl_from_firmware(tmp_path):
+    # An unrecognised (generic) device has no profile to trust, so its Advanced rails
+    # come live from the firmware. A recognised device uses profile-derived rails
+    # instead (see test_tdp_firmware_attr).
     _mk(str(tmp_path))
-    b = FirmwareAttrBackend("asus-armoury", FALLBACK, root=str(tmp_path))
+    b = FirmwareAttrBackend("asus-armoury", FALLBACK, root=str(tmp_path), is_generic=True)
     ll = b.level_limits()
     assert ll["pl1"] == {"min": 7, "max": 35}
     assert ll["pl2"] == {"min": 13, "max": 45}

--- a/tests/test_tdp_lifecycle.py
+++ b/tests/test_tdp_lifecycle.py
@@ -61,6 +61,25 @@ def test_reapplies_on_ac_transition():
     assert events == [True]
 
 
+def test_ac_transition_re_asserts_after_firmware_settles():
+    # On unplug the ASUS firmware briefly reverts to ~12 W; a single re-apply landing
+    # mid-transition can be lost. The transition fires now + 2 follow-ups (at +2s, +4s),
+    # re-reading AC live, so the setpoint is re-asserted once the firmware settles.
+    events = []
+    ac = {"v": True}
+    lm = LifecycleManager(apply_cb=lambda on_ac: events.append(on_ac),
+                          read_wakeup=lambda: 0, read_ac=lambda: ac["v"])
+    lm.check(now=0.0)           # first observation, on charger
+    ac["v"] = False            # unplug
+    lm.check(now=1.0)          # immediate re-apply
+    assert events == [False]
+    lm.check(now=2.5)          # no follow-up due yet (first at 1.0+2.0=3.0)
+    assert events == [False]
+    lm.check(now=3.0)          # +2s follow-up
+    lm.check(now=5.0)          # +4s follow-up
+    assert events == [False, False, False]
+
+
 def test_check_survives_apply_exception():
     def boom(_on_ac):
         raise RuntimeError("boom")

--- a/tests/test_tdp_rpc.py
+++ b/tests/test_tdp_rpc.py
@@ -287,7 +287,7 @@ def test_get_power_draw_has_all_keys(PluginWithPower):
     p = PluginWithPower()
     r = asyncio.run(p.get_power_draw())
     assert set(r.keys()) == {"watts", "gpu_busy", "auto_tdp", "setpoint", "applied",
-                             "ui_floor_engaged"}
+                             "ui_floor_engaged", "on_ac"}
 
 
 def test_get_power_draw_values(PluginWithPower):

--- a/tests/test_tdp_ryzenadj.py
+++ b/tests/test_tdp_ryzenadj.py
@@ -70,12 +70,16 @@ def test_read_applied_none_when_stapm_absent():
     assert b.read_applied() is None
 
 
-def test_set_tdp_not_ok_when_readback_unavailable():
+def test_set_tdp_when_readback_unavailable_assumes_applied():
+    # No STAPM limit line to read back. We can't confirm, but the write itself didn't
+    # error, and this quirk doesn't mean the write failed — assume applied (unconfirmed)
+    # rather than reporting a failure on a device that may well be fine.
     info = "| Name | Value | Parameter |\n| PPT FAST | 30.000 | fast-limit |\n"
     fake = FakeRun(info=info)
     b = RyzenadjBackend(FALLBACK, resolve=lambda: "/usr/bin/ryzenadj", runner=fake)
     res = b.set_tdp(20, ac=True)
-    assert res.ok is False and res.applied_w is None
+    assert res.ok is True and res.applied_w is None
+    assert "readback unavailable" in res.detail
 
 
 def test_write_max_widens_the_write_clamp():
@@ -89,3 +93,81 @@ def test_write_max_widens_the_write_clamp():
     argv = next(c for c in boosted.calls if "--stapm-limit" in c[0])[0]
     assert "70000" in argv
     assert b.get_limits().max_ac_w == 30
+
+
+class StickyRun:
+    """Fake ryzenadj. `-i` reports the STAPM limit it currently holds. A write only
+    lands once `obey_from` write attempts have happened (models amd_pmf clobbering the
+    first write, then the re-assert landing); until then it holds `clobber_w` — a real,
+    non-target value (a rejected/clamped write), NOT an unreadable one."""
+
+    def __init__(self, obey_from=99, clobber_w=10):
+        self.calls = []
+        self._writes = 0
+        self._held = clobber_w
+        self._obey_from = obey_from
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append((argv, kwargs))
+        if "--stapm-limit" in argv:
+            self._writes += 1
+            if self._writes >= self._obey_from:
+                mw = argv[argv.index("--stapm-limit") + 1]
+                self._held = round(int(mw) / 1000)
+
+        held = self._held
+
+        class R:
+            returncode = 0
+            stdout = f"| STAPM LIMIT | {held}.000 | stapm-limit |\n" if (
+                "-i" in argv or "--info" in argv) else ""
+            stderr = ""
+
+        return R()
+
+    @property
+    def write_count(self):
+        return sum(1 for c in self.calls if "--stapm-limit" in c[0])
+
+
+def test_set_tdp_not_ok_when_write_clamped_to_other_value():
+    # The write is rejected/clamped and the limit holds a real, different value. Must
+    # report failure with the true held value — never fake success.
+    fake = StickyRun(obey_from=99, clobber_w=10)  # never obeys, always holds 10
+    b = RyzenadjBackend(FALLBACK, resolve=lambda: "/usr/bin/ryzenadj", runner=fake)
+    res = b.set_tdp(20, ac=True)
+    assert res.ok is False
+    assert res.applied_w == 10
+    assert "stick" in res.detail
+
+
+def test_set_tdp_reasserts_once_and_succeeds():
+    # First write is clobbered, the re-assert lands. One retry is enough.
+    fake = StickyRun(obey_from=2)
+    b = RyzenadjBackend(FALLBACK, resolve=lambda: "/usr/bin/ryzenadj", runner=fake)
+    res = b.set_tdp(20, ac=True)
+    assert res.ok is True and res.applied_w == 20
+    assert fake.write_count == 2  # wrote, saw it didn't stick, re-asserted once
+
+
+def test_set_tdp_single_write_when_it_sticks():
+    fake = StickyRun(obey_from=1)
+    b = RyzenadjBackend(FALLBACK, resolve=lambda: "/usr/bin/ryzenadj", runner=fake)
+    res = b.set_tdp(20, ac=True)
+    assert res.ok is True and res.applied_w == 20
+    assert fake.write_count == 1
+
+
+def test_set_tdp_unreadable_limit_assumed_applied_not_failed():
+    # Some APUs report the STAPM LIMIT line as absent or 0 even when the write applies
+    # (SMU quirk). Don't cry failure on a working device: assume applied (unconfirmed),
+    # report no fabricated value, and re-assert once as best effort.
+    for info in ("| Name | Value |\n| PPT FAST | 20.000 | fast-limit |\n",   # no STAPM line
+                 "| STAPM LIMIT | 0.000 | stapm-limit |\n"):                  # reads zero
+        fake = FakeRun(info=info)
+        b = RyzenadjBackend(FALLBACK, resolve=lambda: "/usr/bin/ryzenadj", runner=fake)
+        res = b.set_tdp(20, ac=True)
+        assert res.ok is True
+        assert res.applied_w is None
+        assert "readback unavailable" in res.detail
+        assert sum(1 for c in fake.calls if "--stapm-limit" in c[0]) == 2  # re-asserted


### PR DESCRIPTION
## Qué arregla

Varios reportes de TDP que no llegaba al máximo real, en varias máquinas (Legion Go S clavada en 15W, ROG Ally X en 25 con cargador, etc.). Raíz común: leíamos el techo del firmware **una sola vez al arrancar y lo cacheábamos**. Ese valor es dinámico y engañoso —ASUS reporta menos en batería que con cargador, y el firmware de la Legion Go S baja a 15W momentáneamente— así que una lectura mala congelaba el deslizador ahí para siempre, y solo se arreglaba con un reinicio afortunado.

### El fix (familia firmware-attr: ASUS Ally + Lenovo Legion)
- **El perfil manda el rango.** En equipos reconocidos el deslizador sale de los valores conocidos del perfil, nunca del máximo que reporta el firmware.
- **El techo del firmware se lee en vivo** (sin cachear) y **la escritura se recorta a él**: nunca escribimos por encima de lo que el firmware acepta en ese momento (escribir de más lo rechaza), así que se aplica lo honesto —25W en una Ally en batería, 30 con cargador— mientras el rango del deslizador se mantiene estable.
- **El extra por cargador**: donde el firmware capa en batería (ROG Ally / Ally X) se oculta el toggle de "extra en batería" y el arco muestra el segmento bloqueado ("conecta el cargador"); donde el firmware sí lo permite (Xbox Ally X, Legion) el toggle sigue disponible. La política vive en el chokepoint del backend.
- **Al desenchufar**, el firmware cae un instante a su modo por defecto; ahora re-afirmamos el TDP al cambiar de AC + un par de reintentos, y el frontend refresca el techo al momento, para que no se quede bajo ni el slider clavado.
- Equipos genéricos siguen leyendo el firmware en vivo (no hay perfil de confianza).

### Valores por máquina (validados en hardware)
| Máquina | Batería | Cargador |
|---|---|---|
| ROG Ally / Ally X | 25 | 30 (solo cargador) |
| ROG Xbox Ally X | 25 | 35 |
| Legion Go 2 | 30 | 35 |
| Legion Go / Go S | 30 | 30 / 33 |

También incluye una mejora aparte en `ryzenadj` (Claw A8): verifica la escritura y la reafirma, y reporta el valor real en vez de fingir éxito cuando `amd_pmf` la pisa.

## Validado en hardware
Las 5 máquinas firmware-attr desplegadas y comprobadas: cada una reporta su perfil (no un valor congelado). La Legion Go S, que estaba clavada en 15W, ahora da 30/33.

## Pruebas
974 pytest · 239 vitest · typecheck · ruff · build. /simplify + /review (high) aplicados.

## Pendiente (menor, anotado)
- Consolidar `ryzenadj`↔`intel_rapl` (readback) y migrar a `sysfs.read_int` (backlog pre-existente, toca la Claw Intel que no puedo validar ahora).
- Los raíles de boost avanzado en equipos reconocidos pasan a derivarse del perfil (más conservadores que el firmware) — decisión deliberada por seguridad y coherencia.
