### PR TITLE
feat: Legion Go S full TDP range, reset-to-default, and system UI language

### DIFF
--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -80,11 +80,11 @@ DEVICE_TABLE = (
     DeviceProfile("legion_go_2", "Legion Go 2", "AMD Ryzen AI Z2 Extreme", "amd",
                   5, 15, 30, 35, match_names=("83N0", "83N1", "Legion Go 2"),
                   panel="oled", hdr=True),
-    # Legion Go S ships as both 8ARP1 (83L3) and 8APU1 (83N6), each with either a
-    # Ryzen Z1 Extreme or a Z2 Go. The real chip is read live from /proc/cpuinfo;
-    # this string is only a fallback when that read fails.
+    # 83L3/83N6, Z1 Extreme or Z2 Go (real chip read live from cpuinfo; this is the
+    # fallback). PL1 33 W on battery, 40 W on charger — the extra is charger-only.
     DeviceProfile("legion_go_s", "Legion Go S", "AMD Ryzen Z1 Extreme / Z2 Go", "amd",
-                  5, 15, 30, 33, match_names=("83L3", "83N6", "Legion Go S")),
+                  5, 15, 33, 40, match_names=("83L3", "83N6", "Legion Go S"),
+                  charger_only_extra=True),
     DeviceProfile("legion_go", "Legion Go", "AMD Z1 Extreme", "amd",
                   5, 15, 30, 30, match_names=("83E1", "Legion Go"), firmware_modes=True),
     DeviceProfile("msi_claw_8_ai_plus", "MSI Claw 8 AI+", "Intel Core Ultra 7 258V", "intel",

--- a/src/components/ExperimentalFanCard.tsx
+++ b/src/components/ExperimentalFanCard.tsx
@@ -58,8 +58,8 @@ export const ExperimentalFanCard: FC<Props> = ({ enabled, onToggle }) => {
         <ToggleField
           label={t("fans.experimental.toggle")}
           checked={enabled}
+          bottomSeparator="none"
           onChange={(next: boolean) => {
-            // Enabling takes over the EC → confirm first. Disabling is immediate.
             if (next) showModal(<ConfirmModal onConfirm={() => onToggle(true)} />);
             else onToggle(false);
           }}

--- a/src/components/TdpSection.tsx
+++ b/src/components/TdpSection.tsx
@@ -1,7 +1,8 @@
-import { PanelSectionRow, SliderField } from "@decky/ui";
+import { PanelSectionRow, SliderField, Focusable } from "@decky/ui";
 import { FC } from "react";
 
 import { TdpState, TdpScope, PowerDraw, BoostMode } from "../api";
+import { resetWatts } from "../tdp/logic";
 import { useI18n } from "../i18n";
 import { theme } from "../theme";
 import { Loading } from "./Loading";
@@ -56,6 +57,10 @@ export const TdpSection: FC<TdpSectionProps> = ({ tdp, scope, game, power, onSco
   const activeMax = tdp.on_ac ? tdp.limits.max_ac : tdp.limits.max;
   const isAutoOn = power?.auto_tdp ?? false;
   const atCeiling = Math.min(view.watts, activeMax) >= activeMax;
+  // Reference watts clamped to the active ceiling; the reset link shows only when
+  // the current value differs from it.
+  const resetTarget = resetWatts(tdp.limits.default, tdp.limits.min, activeMax);
+  const showReset = Math.round(view.watts) !== resetTarget;
   // Firmware modes replace the watt presets. In a named mode the firmware owns
   // power+fan, so the arc/slider show its applied watts; the slider drops to custom.
   const fwModes = tdp.firmware_modes ?? [];
@@ -194,19 +199,40 @@ export const TdpSection: FC<TdpSectionProps> = ({ tdp, scope, game, power, onSco
               </PanelSectionRow>
             </>
           ) : (
-            <PanelSectionRow>
-              <Presets
-                presets={tdp.presets}
-                onAc={tdp.on_ac}
-                activeWatts={view.watts}
-                labels={{
-                  save: t("tdp.preset.save"),
-                  balanced: t("tdp.preset.balanced"),
-                  turbo: t("tdp.preset.turbo"),
-                }}
-                onPick={onWatts}
-              />
-            </PanelSectionRow>
+            <>
+              <PanelSectionRow>
+                <Presets
+                  presets={tdp.presets}
+                  onAc={tdp.on_ac}
+                  activeWatts={view.watts}
+                  labels={{
+                    save: t("tdp.preset.save"),
+                    balanced: t("tdp.preset.balanced"),
+                    turbo: t("tdp.preset.turbo"),
+                  }}
+                  onPick={onWatts}
+                />
+              </PanelSectionRow>
+              {showReset && (
+                <PanelSectionRow>
+                  <Focusable
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      padding: "4px 0",
+                      marginTop: 4,
+                      color: theme.color.textMuted,
+                      fontSize: theme.font.caption,
+                      cursor: "pointer",
+                    }}
+                    onActivate={() => onWatts(resetTarget)}
+                    onClick={() => onWatts(resetTarget)}
+                  >
+                    {t("tdp.reset.default", { w: resetTarget })}
+                  </Focusable>
+                </PanelSectionRow>
+              )}
+            </>
           )}
           {!inFwMode && tdp.supports_advanced && (
             <PanelSectionRow>

--- a/src/i18n/detect.test.ts
+++ b/src/i18n/detect.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { steamLangToLang } from "./detect";
+
+describe("steamLangToLang (seed the default from Steam's UI language)", () => {
+  it("maps English to en", () => {
+    expect(steamLangToLang("english")).toBe("en");
+    expect(steamLangToLang("English")).toBe("en");
+    expect(steamLangToLang("  ENGLISH  ")).toBe("en");
+    expect(steamLangToLang("en")).toBe("en");
+  });
+
+  it("maps Spanish and its variants to es", () => {
+    expect(steamLangToLang("spanish")).toBe("es");
+    expect(steamLangToLang("latam")).toBe("es");
+  });
+
+  it("maps any other language to es (our default)", () => {
+    expect(steamLangToLang("german")).toBe("es");
+    expect(steamLangToLang("brazilian")).toBe("es");
+    expect(steamLangToLang("schinese")).toBe("es");
+  });
+
+  it("degrades to es for null/blank/garbage", () => {
+    expect(steamLangToLang(null)).toBe("es");
+    expect(steamLangToLang(undefined)).toBe("es");
+    expect(steamLangToLang("")).toBe("es");
+    expect(steamLangToLang("   ")).toBe("es");
+  });
+});

--- a/src/i18n/detect.ts
+++ b/src/i18n/detect.ts
@@ -1,0 +1,9 @@
+import type { Lang } from "./index";
+
+// Steam's UI language name (e.g. "english", "spanish") → plugin language.
+// English → en; everything else, and null/blank/unknown → es (the default).
+export function steamLangToLang(raw: string | null | undefined): Lang {
+  const v = (raw ?? "").trim().toLowerCase();
+  if (v === "en" || v.startsWith("english")) return "en";
+  return "es";
+}

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -6,10 +6,19 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { format, Params } from "./format";
-import { hydratePrefs, onPrefsHealed, readString, writeString } from "../system/pdcStorage";
+import {
+  hydratePrefs,
+  onPrefsHealed,
+  prefsHydrated,
+  readString,
+  writeString,
+} from "../system/pdcStorage";
+import { steamLangToLang } from "./detect";
+import { readSteamLanguage } from "./steamLanguage";
 
 export type Lang = "es" | "en";
 
@@ -249,6 +258,7 @@ const es: Record<string, string> = {
   "tdp.preset.save": "Ahorro",
   "tdp.preset.balanced": "Equilibrado",
   "tdp.preset.turbo": "Turbo",
+  "tdp.reset.default": "Restablecer al valor predeterminado ({w} W)",
   "tdp.fwmode.low-power": "Silencioso",
   "tdp.fwmode.balanced": "Equilibrado",
   "tdp.fwmode.performance": "Rendimiento",
@@ -392,7 +402,7 @@ const es: Record<string, string> = {
 };
 
 const en: Record<string, string> = {
-  "app.title": "Control Center",
+  "app.title": "Control Panel",
   "load.error": "Couldn't load the plugin state. Please try again in a moment.",
   "load.retry": "Retry",
   "device.detected": "{name}",
@@ -621,6 +631,7 @@ const en: Record<string, string> = {
   "tdp.preset.save": "Save",
   "tdp.preset.balanced": "Balanced",
   "tdp.preset.turbo": "Turbo",
+  "tdp.reset.default": "Reset to default ({w} W)",
   "tdp.fwmode.low-power": "Quiet",
   "tdp.fwmode.balanced": "Balanced",
   "tdp.fwmode.performance": "Performance",
@@ -780,12 +791,41 @@ const I18nContext = createContext<I18nValue | null>(null);
 
 export const I18nProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [lang, setLangState] = useState<Lang>(initialLang);
+  const seeded = useRef(false);
 
-  // Re-read once hydratePrefs heals the cache, in case we rendered stale.
+  // On first run only (no saved language), seed the default from Steam's UI
+  // language once the cache is genuinely healed — never overriding a saved choice.
   useEffect(() => {
-    const off = onPrefsHealed(() => setLangState(initialLang()));
-    void hydratePrefs();
-    return off;
+    let cancelled = false;
+    const trySeed = async () => {
+      if (cancelled || seeded.current || readString(STORAGE_KEY)) return;
+      seeded.current = true; // claim the one-shot before the await
+      const raw = await readSteamLanguage();
+      if (cancelled || readString(STORAGE_KEY)) return; // a choice may have landed
+      if (raw === null) {
+        seeded.current = false; // couldn't read Steam → keep the default, retry next load
+        return;
+      }
+      const seed = steamLangToLang(raw);
+      setLangState(seed);
+      writeString(STORAGE_KEY, seed);
+    };
+    const off = onPrefsHealed(() => {
+      if (cancelled) return;
+      setLangState(initialLang());
+      void trySeed();
+    });
+    // Covers a cache already healed before we subscribed; gated on a real heal.
+    void hydratePrefs().then(() => {
+      if (!cancelled && prefsHydrated()) void trySeed();
+    });
+    return () => {
+      cancelled = true;
+      // Release the one-shot so a remount (StrictMode) can still seed; a completed
+      // seed is already guarded by the persisted key.
+      seeded.current = false;
+      off();
+    };
   }, []);
 
   const setLang = useCallback((l: Lang) => {

--- a/src/i18n/steamLanguage.ts
+++ b/src/i18n/steamLanguage.ts
@@ -1,0 +1,14 @@
+// Steam's current UI language via SteamClient.Settings.GetCurrentLanguage().
+// Returns null when the API is absent or the call fails.
+export async function readSteamLanguage(): Promise<string | null> {
+  try {
+    const settings = SteamClient?.Settings as
+      | { GetCurrentLanguage?: () => Promise<string> }
+      | undefined;
+    if (!settings || typeof settings.GetCurrentLanguage !== "function") return null;
+    const lang = await settings.GetCurrentLanguage();
+    return typeof lang === "string" ? lang : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,21 @@
 import { ErrorBoundary, staticClasses } from "@decky/ui";
 import { definePlugin } from "@decky/api";
+import { FC } from "react";
 import { LuGauge } from "react-icons/lu";
 
-import { I18nProvider } from "./i18n";
+import { I18nProvider, translate } from "./i18n";
 import { ControlCenter } from "./components/ControlCenter";
 import { startGameWatcher } from "./tdp/gameWatcher";
 import { startEcoAmbient } from "./system/ecoAmbient";
 import { startValueToast, refreshValueToast } from "./system/valueToast";
 import { hydratePrefs, onPrefsHealed } from "./system/pdcStorage";
 import { reloadLayout } from "./customize/store";
+
+// Localized header title only; the internal plugin name / install folder stays
+// "Panel de Control" (renaming it would break existing installs and the updater).
+const PluginTitle: FC = () => (
+  <div className={staticClasses.Title}>{translate("app.title")}</div>
+);
 
 export default definePlugin(() => {
   // Restore durable UI prefs into the localStorage cache at plugin scope (so the
@@ -31,7 +38,7 @@ export default definePlugin(() => {
 
   return {
     name: "Panel de Control",
-    titleView: <div className={staticClasses.Title}>Panel de Control</div>,
+    titleView: <PluginTitle />,
     content: (
       <I18nProvider>
         <ErrorBoundary>

--- a/src/system/pdcStorage.ts
+++ b/src/system/pdcStorage.ts
@@ -71,6 +71,13 @@ export function onPrefsHealed(cb: () => void): () => void {
 }
 
 let hydration: Promise<void> | null = null;
+let hydrated = false;
+
+/** True once the cache has been healed from the durable backend copy — lets a
+ * caller tell "no saved value" apart from "backend not read yet". */
+export function prefsHydrated(): boolean {
+  return hydrated;
+}
 
 // Heal the localStorage cache from the durable backend copy. Shared promise:
 // the plugin-scope startup and the i18n provider await the same round-trip.
@@ -95,6 +102,7 @@ async function doHydrate(): Promise<void> {
     } catch {}
   }
   if (Object.keys(migrate).length) void setUiPrefs(migrate).catch(() => {});
+  hydrated = true;
   healed.forEach((cb) => {
     try {
       cb();

--- a/src/tdp/logic.test.ts
+++ b/src/tdp/logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { fraction, zoneFor, arcColor } from "./logic";
-import { offsetOf, totalFor, maxOffset, dialToWatts, boostWatts, boostEndFraction } from "./logic";
+import { offsetOf, totalFor, maxOffset, dialToWatts, boostWatts, boostEndFraction, resetWatts } from "./logic";
 
 describe("fraction", () => {
   it("maps min→0 and maxAc→1", () => {
@@ -86,6 +86,38 @@ describe("dialToWatts (learned-band suggestion)", () => {
   it("is NaN-safe (→ floor)", () => {
     expect(dialToWatts(15, NaN, 0.5)).toBe(15);
     expect(dialToWatts(15, 21, NaN)).toBe(15);
+  });
+});
+
+describe("resetWatts (device default reference)", () => {
+  it("returns the default when it sits inside the range", () => {
+    expect(resetWatts(15, 7, 35)).toBe(15);
+  });
+
+  it("clamps a default above the active ceiling (on battery)", () => {
+    expect(resetWatts(30, 7, 25)).toBe(25);
+  });
+
+  it("clamps a default below the minimum", () => {
+    expect(resetWatts(3, 7, 35)).toBe(7);
+  });
+
+  it("rounds a fractional default", () => {
+    expect(resetWatts(16.6, 7, 35)).toBe(17);
+  });
+
+  it("survives a degenerate range (activeMax below min)", () => {
+    expect(resetWatts(15, 20, 10)).toBe(20);
+  });
+
+  it("is NaN-safe (→ min)", () => {
+    expect(resetWatts(NaN, 7, 35)).toBe(7);
+  });
+
+  it("never returns NaN when a limit is NaN", () => {
+    expect(resetWatts(15, NaN, 35)).toBe(15);
+    expect(resetWatts(15, 7, NaN)).toBe(7);
+    expect(Number.isFinite(resetWatts(NaN, NaN, NaN))).toBe(true);
   });
 });
 

--- a/src/tdp/logic.ts
+++ b/src/tdp/logic.ts
@@ -69,6 +69,14 @@ export function dialToWatts(floor: number, ceil: number, dial: number): number {
   return Math.max(lo, Math.min(hi, Math.round(lo + d * (hi - lo))));
 }
 
+/** Default watts clamped into [min, activeMax]; NaN in any argument degrades safely. */
+export function resetWatts(defaultW: number, min: number, activeMax: number): number {
+  const lo = Number.isFinite(min) ? min : 0;
+  const hi = Number.isFinite(activeMax) ? Math.max(lo, activeMax) : lo;
+  if (!Number.isFinite(defaultW)) return Math.round(lo);
+  return Math.round(clamp(defaultW, lo, hi));
+}
+
 /**
  * Extra watts the hardware is drawing ABOVE your set TDP (the "HW boost" the
  * SPPT/FPPT rails deliver on top of PL1). `drawWatts == null` → null (the

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -192,6 +192,15 @@ def test_ally_x_has_charger_boost():
     assert prof.tdp_max_charger > prof.tdp_max
 
 
+def test_legion_go_s_reaches_firmware_ceilings():
+    for name in ("83L3", "83N6"):
+        prof = detect(product_name=name)
+        assert prof.key == "legion_go_s"
+        assert prof.tdp_max == 33          # sustained ceiling on battery
+        assert prof.tdp_max_charger == 40  # extra reachable only on charger
+        assert prof.charger_only_extra is True
+
+
 def test_deck_has_no_charger_boost():
     prof = detect(product_name="Galileo")
     assert prof.tdp_max == 15

--- a/tests/test_tdp_firmware_attr.py
+++ b/tests/test_tdp_firmware_attr.py
@@ -254,22 +254,20 @@ def test_recognised_level_limits_are_profile_derived(tmp_path):
 
 
 def test_legion_go_s_reaches_profile_range_despite_low_firmware(tmp_path):
-    # Legion Go S: the firmware under-reports (15) but the profile (charger 33) drives
-    # the slider + rails, so the user is never stranded at 15 W.
+    # Firmware may under-report; the profile (charger 40) drives the slider + rails.
     root = str(tmp_path)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
-    fb = TdpLimits.from_profile(detect(product_name="83L3"))  # Legion Go S 5,15,30,33
+    fb = TdpLimits.from_profile(detect(product_name="83L3"))  # Legion Go S 5,15,33,40
     b = FirmwareAttrBackend("lenovo-wmi-other", fb, root=root,
                             profile_name="lenovo-wmi-gamezone")
-    assert b.get_limits().max_ac_w == 33
+    assert b.get_limits().max_ac_w == 40
     ll = b.level_limits()
-    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (33, 40, 46)
+    assert (ll["pl1"]["max"], ll["pl2"]["max"], ll["pl3"]["max"]) == (40, 48, 56)
 
 
 def test_lenovo_write_clamps_to_live_firmware_when_low(tmp_path):
-    # The firmware genuinely accepts only 15 right now (writing above is rejected). The
-    # profile keeps the slider at 33, but the write honestly applies 15 — no fake 30.
-    # When the firmware recovers to 33, the same set reaches 30 (live re-read).
+    # Firmware accepts only 15 now: the slider stays 40 but the write applies 15;
+    # when it recovers to 33 the same set reaches 30 (live re-read).
     root = str(tmp_path)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl1_spl", 13, 5, 15)
     _mk_attr(root, "lenovo-wmi-other-0", "ppt_pl2_sppt", 14, 5, 15)


### PR DESCRIPTION
## Qué incluye

- **Legion Go S: rango de TDP completo.** El techo real es 33 W en batería y 40 W con cargador; antes se quedaba corto en 30/33. Validado en la variante Z1 Extreme.
- **Restablecer TDP al valor predeterminado.** Un enlace bajo los preajustes de Potencia que devuelve el TDP al valor por defecto del dispositivo, con alcance global o por juego. Se oculta cuando ya estás en ese valor.
- **Idioma según el sistema.** Si Steam está en inglés, el plugin arranca en inglés y el título se muestra como "Control Panel"; en cualquier otro idioma sigue en español. Si cambias el idioma a mano, esa elección manda.
- **Detalle visual.** Se quita una línea separadora que sobraba bajo el control experimental de ventilador en la Go S.

## Notas

- Los 40 W de la Go S están validados en la Z1 Extreme. La variante Z2 Go comparte de momento el mismo rango; la escritura se ajusta siempre al límite real del firmware, así que nunca se aplica más de lo que el equipo acepta. Afinar el tope por chip queda pendiente.
- El control de ventilador (botón de reinicio y confirmación por tacómetro) va en su propia rama para terminarlo aparte; no entra en esta PR.

---

## What's included

- **Legion Go S full TDP range.** The real ceiling is 33 W on battery and 40 W on the charger; it used to stop short at 30/33. Validated on the Z1 Extreme variant.
- **Reset TDP to default.** A link under the Power presets that returns TDP to the device default, global or per game. Hidden when you are already there.
- **Follow the system language.** With Steam in English the plugin starts in English and the title reads "Control Panel"; any other language stays in Spanish. A manual language choice always wins.
- **Visual detail.** Removes a stray separator line under the experimental fan control on the Go S.

## Notes

- The Go S 40 W is validated on the Z1 Extreme. The Z2 Go variant shares the same range for now; writes always clamp to the live firmware limit, so it never applies more than the device accepts. Per-chip tuning is a follow-up.
- The fan-control work (reset button and tachometer confirmation) lives on its own branch to finish separately and is not part of this PR.
