### PR TITLE
feat: rear-button remap for the MSI Claw A8

### DIFF
--- a/py_modules/controllers/ip_profile.py
+++ b/py_modules/controllers/ip_profile.py
@@ -45,6 +45,9 @@ DEVICE_BUTTONS = {
     "msi_claw_8_ai_plus": [
         ("RightPaddle1", "M1"), ("LeftPaddle1", "M2"),
     ],
+    "msi_claw_a8": [
+        ("RightPaddle1", "M1"), ("LeftPaddle1", "M2"),
+    ],
 }
 
 # Gamepad buttons offered as remap targets (what an extra button can become).

--- a/tests/test_controllers_ip_profile.py
+++ b/tests/test_controllers_ip_profile.py
@@ -53,6 +53,15 @@ def test_buttons_msi_claw_two_grips():
     ]
 
 
+def test_buttons_msi_claw_a8_two_grips():
+    caps = ["Gamepad:Button:South", "Gamepad:Button:LeftPaddle1",
+            "Gamepad:Button:RightPaddle1", "Gamepad:Button:Guide"]
+    assert ip.buttons_for("msi_claw_a8", caps) == [
+        ("RightPaddle1", "M1"),
+        ("LeftPaddle1", "M2"),
+    ]
+
+
 def test_buttons_defensively_intersect_live_capabilities():
     # A known device that (for whatever reason) doesn't report a capability →
     # that button is omitted, never invented.
@@ -73,6 +82,7 @@ def test_buttons_unknown_device_is_empty():
 def test_is_known_device():
     assert ip.is_known_device("legion_go_2") is True
     assert ip.is_known_device("msi_claw_8_ai_plus") is True
+    assert ip.is_known_device("msi_claw_a8") is True
     assert ip.is_known_device("legion_go_s") is False  # no known button map
     assert ip.is_known_device(None) is False
 


### PR DESCRIPTION
Añade el remapeo de los botones traseros (M1/M2) de la **MSI Claw A8** en la pestaña Mandos.

Hasta ahora la Claw A8 aparecía sin botones que remapear porque no estaba en la tabla de botones por dispositivo (solo estaban las Legion y el Claw Intel). El demonio de InputPlumber ya expone las M-keys de la A8 como paddles de gamepad (M1 = `RightPaddle1`, M2 = `LeftPaddle1`, igual que el Claw Intel), así que basta con declararlas.

- `msi_claw_a8` añadido a la tabla de botones (intersectada con las capabilities vivas, así que si el equipo no las reporta no se inventa nada).
- Tests para la A8 (`buttons_for` + `is_known_device`).

Sigue siendo un equipo **experimental** que no tenemos en mano: el mapeo sale de la config de InputPlumber que corre en la propia máquina del usuario y coincide con el Claw Intel ya validado. Queda confirmar en hardware que el silkscreen M1/M2 case con right/left.

Reporte: PDC-72NX.
