### PR TITLE
fix: restore generic-pwm fan control by engaging manual mode before writing duty

### DIFF
--- a/py_modules/fans/generic_pwm.py
+++ b/py_modules/fans/generic_pwm.py
@@ -60,12 +60,13 @@ class GenericPwmFanBackend(SoftwareLoopBackend):
         return True
 
     def _apply_once_locked(self) -> bool:
-        """Write the interpolated pwm to every fan (caller holds `_io_lock`). Writes
-        the PWM FIRST and switches to manual only after it lands, so a fan is never
-        put in manual holding a stale/0 duty (no stuck-manual dead state); a failed
-        write just leaves that fan in firmware auto. `all_ok` requires the manual mode
-        to actually read back — never our write alone. Returns True only when every
-        fan landed. No temp → release."""
+        """Write the interpolated pwm to every fan (caller holds `_io_lock`). Engage
+        manual mode (`pwmN_enable` = 1) and confirm it by readback BEFORE writing the
+        duty: `pwmN` only takes effect in manual mode and some drivers (gpd_fan) reject
+        a `pwmN` write with -EPERM while still in auto. If manual engages but the duty
+        write is refused, hand that fan back to firmware auto rather than leave it stuck
+        in manual at a stale/max duty. Returns True only when every fan landed (manual
+        readback AND duty write, never a write alone). No temp → release."""
         if self._points is None:
             self._drive_ok = False
             return False
@@ -80,9 +81,13 @@ class GenericPwmFanBackend(SoftwareLoopBackend):
         pwm = max(0, min(255, pwm))
         all_ok = True
         for m in self._fans:
-            pwm_ok = _write(self._pwm(m), str(pwm))
-            en_ok = _write(self._enable(m), str(_ENABLE_MANUAL)) if pwm_ok else False
-            if not (pwm_ok and en_ok and _read_int(self._enable(m)) == _ENABLE_MANUAL):
+            manual = (_write(self._enable(m), str(_ENABLE_MANUAL))
+                      and _read_int(self._enable(m)) == _ENABLE_MANUAL)
+            pwm_ok = _write(self._pwm(m), str(pwm)) if manual else False
+            if not (manual and pwm_ok):
+                # Couldn't take manual control or the duty was refused → return this
+                # fan to its firmware auto mode (never leave it stuck manual@max).
+                _write(self._enable(m), str(self._orig_enable.get(m, _ENABLE_AUTO)))
                 all_ok = False
         self._drive_ok = all_ok
         return all_ok

--- a/tests/test_fan_generic_pwm.py
+++ b/tests/test_fan_generic_pwm.py
@@ -3,7 +3,9 @@ fan chip exposes the standard manual-PWM interface (pwmN + pwmN_enable) but no
 vendor curve-table. Synthetic sysfs; the asyncio loop isn't exercised (start() is
 a no-op without a running loop) — the seams are the immediate apply + release."""
 import os
+import re
 
+import fans.generic_pwm as generic_pwm
 from fans.generic_pwm import GenericPwmFanBackend
 from fans.control import NullFanBackend, select_fan_backend
 
@@ -34,6 +36,28 @@ CURVE = [(40, 0), (50, 30), (60, 60), (70, 95), (80, 135), (85, 175), (90, 215),
 
 def _backend(root, temp=70.0):
     return GenericPwmFanBackend(root=str(root), temp_fn=lambda: temp)
+
+
+def _install_strict_driver(monkeypatch):
+    """Model the hwmon contract of drivers like gpd_fan: a ``pwmN`` write is rejected
+    unless ``pwmN_enable`` currently reads manual (1). A plain temp file accepts any
+    write regardless of mode, so without this a spec-compliant enable-first order and a
+    broken pwm-first one are indistinguishable."""
+    real_write = generic_pwm._write
+
+    def strict_write(path, value):
+        m = re.match(r"pwm(\d+)$", os.path.basename(path))
+        if m:  # duty write: only honored while the fan is already in manual mode
+            enable_path = os.path.join(os.path.dirname(path), f"pwm{m.group(1)}_enable")
+            try:
+                with open(enable_path) as f:
+                    if f.read().strip() != "1":
+                        return False  # driver returns -EPERM outside manual mode
+            except OSError:
+                return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(generic_pwm, "_write", strict_write)
 
 
 def test_unsupported_without_pwm(tmp_path):
@@ -69,6 +93,32 @@ def test_apply_switches_to_manual_and_writes_curve_pwm(tmp_path):
     assert res["ok"] is True
     assert _r(d, "pwm1_enable") == "1"
     assert int(_r(d, "pwm1")) == 95  # curve pwm at 70C
+
+
+def test_engages_manual_before_pwm_on_strict_driver(tmp_path, monkeypatch):
+    # A driver that rejects a pwm write while in auto (gpd_fan) is only driven if the
+    # backend switches to manual first; a pwm-first order leaves it on firmware auto.
+    d = _mk_pwm_chip(str(tmp_path), name="gpdfan", enable="2")
+    _install_strict_driver(monkeypatch)
+    b = _backend(tmp_path, temp=70.0)
+    res = b.apply_curve_all(CURVE)
+    assert res["ok"] is True
+    assert _r(d, "pwm1_enable") == "1"       # manual actually engaged
+    assert int(_r(d, "pwm1")) == 95          # curve duty landed (only possible in manual)
+
+
+def test_strict_driver_with_oxp_auto_sentinel_drives_and_releases(tmp_path, monkeypatch):
+    # Same strict pwm gate but the auto sentinel is 0 (oxp-sensors): manual is still 1,
+    # so the fan drives, and release restores the captured auto value (0) — the fix is
+    # not tied to the enable==2 sentinel.
+    d = _mk_pwm_chip(str(tmp_path), name="oxpec", enable="0")
+    _install_strict_driver(monkeypatch)
+    b = _backend(tmp_path, temp=80.0)
+    assert b.apply_curve_all(CURVE)["ok"] is True
+    assert _r(d, "pwm1_enable") == "1"
+    assert int(_r(d, "pwm1")) == 135
+    b.set_auto(None)
+    assert _r(d, "pwm1_enable") == "0"       # back to the real auto value, not 2
 
 
 def test_hot_point_keeps_safety_floor(tmp_path):
@@ -155,8 +205,9 @@ def test_read_state_firmware_when_not_driving(tmp_path):
 
 
 def test_partial_write_leaves_failed_fan_in_firmware(tmp_path):
-    # fan2's pwm write fails → PWM-first means fan2 never switches to manual (no stuck
-    # manual@0); fan1 (fully written) reads manual. One failure ≠ all firmware.
+    # fan2's pwm write fails after manual engaged → fan2 is rolled back to firmware auto
+    # (never left stuck manual@max); fan1 (fully written) reads manual. One failure ≠
+    # all firmware.
     import os as _os
     d = _mk_pwm_chip(str(tmp_path), fans=(1, 2))
     _w(d, "fan1_input", "1800")
@@ -167,8 +218,8 @@ def test_partial_write_leaves_failed_fan_in_firmware(tmp_path):
     assert res["ok"] is False
     st = {f["key"]: f["enable"] for f in b.read_state()["fans"]}
     assert st["fan1"] == 1                    # fully driven → manual
-    assert st["fan2"] == 2                    # never switched to manual → firmware
-    assert _r(d, "pwm2_enable") == "2"        # stays auto, never stuck manual@0
+    assert st["fan2"] == 2                    # duty refused → rolled back to firmware
+    assert _r(d, "pwm2_enable") == "2"        # stays auto, never stuck manual@max
 
 
 def test_factory_selects_generic_pwm_last(tmp_path):


### PR DESCRIPTION
El control de ventilador dejó de funcionar tras actualizar en handhelds con el chip hwmon genérico (pwmN + pwmN_enable), por ejemplo la GPD Win Mini 2025 (driver `gpd_fan`).

La causa: el backend escribía `pwmN` (la velocidad) antes de poner el ventilador en modo manual, y solo cambiaba a manual si esa escritura salía bien. Drivers como `gpd_fan` rechazan una escritura de `pwmN` con `-EPERM` mientras siguen en automático, así que el modo manual nunca se activaba y el ventilador se quedaba en control del firmware.

Ahora se activa el modo manual (`pwmN_enable=1`) y se confirma por relectura antes de escribir la velocidad. Si la escritura de velocidad se rechaza después, el ventilador vuelve a automático del firmware para que nunca quede atrapado en manual a tope.

Los tests ahora modelan el contrato real del driver (una escritura de `pwmN` se rechaza fuera de modo manual), cubriendo los dos valores de "automático" (2 y 0), para que un orden correcto sea distinguible de uno roto.

Reportado en #267 y #242.
