### PR TITLE
fix: report the game exit so per-game TDP profiles don't leak into Global

### DIFF
--- a/src/tdp/gameReport.test.ts
+++ b/src/tdp/gameReport.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldReportAppid } from "./gameReport";
+
+describe("shouldReportAppid", () => {
+  it("reports a game starting", () => {
+    expect(shouldReportAppid("123", null, undefined)).toBe(true);
+  });
+
+  it("does not re-report the committed game", () => {
+    expect(shouldReportAppid("123", "123", undefined)).toBe(false);
+  });
+
+  it("reports the game exit (null) even though nothing is in flight", () => {
+    // The regression: `null` is a real target ("no game"). When the idle sentinel was
+    // also `null`, this returned false and the exit was swallowed → backend stayed
+    // pinned to the last game and its per-game profile leaked into the Global view.
+    expect(shouldReportAppid(null, "123", undefined)).toBe(true);
+  });
+
+  it("does not double-send while a null report is already in flight", () => {
+    expect(shouldReportAppid(null, "123", null)).toBe(false);
+  });
+
+  it("does not re-send an appid already in flight", () => {
+    expect(shouldReportAppid("123", null, "123")).toBe(false);
+  });
+
+  it("nothing to do when already committed to no game", () => {
+    expect(shouldReportAppid(null, null, undefined)).toBe(false);
+  });
+});

--- a/src/tdp/gameReport.ts
+++ b/src/tdp/gameReport.ts
@@ -1,0 +1,15 @@
+// Pure guard for the persistent game watcher (gameWatcher.ts). Kept free of any
+// @decky/ui import so it stays unit-testable.
+//
+// `inFlight === undefined` means nothing is being sent right now. `null` is a REAL
+// target ("no game running"), so it must NOT double as the idle sentinel: when both
+// used `null`, a game exit (target=null) matched the idle sentinel and the report was
+// swallowed — the backend stayed pinned to the last game and its per-game profile
+// leaked into the Global view, with auto-TDP appearing stuck on.
+export function shouldReportAppid(
+  target: string | null,
+  committed: string | null,
+  inFlight: string | null | undefined,
+): boolean {
+  return target !== committed && target !== inFlight;
+}

--- a/src/tdp/gameWatcher.ts
+++ b/src/tdp/gameWatcher.ts
@@ -1,4 +1,5 @@
 import { setCurrentGame } from "../api";
+import { shouldReportAppid } from "./gameReport";
 import { readRunningGame } from "./runningGame";
 
 /**
@@ -41,8 +42,9 @@ export function startGameWatcher(): () => void {
   let eventFallbackTimer: ReturnType<typeof setInterval> | null = null;
   let lastAppid: string | null = null;
   // The appid currently being sent to the backend (in-flight), so overlapping
-  // ticks/events don't fire duplicate RPCs for the same target.
-  let inFlight: string | null = null;
+  // ticks/events don't fire duplicate RPCs for the same target. `undefined` = idle;
+  // `null` is a real target ("no game"), so it must not be the idle value.
+  let inFlight: string | null | undefined = undefined;
   let sawRealAppid = false; // have we ever SUCCESSFULLY reported a non-null appid?
   let startupTicks = 0;
 
@@ -58,7 +60,7 @@ export function startGameWatcher(): () => void {
     const next = readRunningGame();
     const appid = next ? next.appid : null;
     // Nothing to do if it's already committed or the same request is in flight.
-    if (appid === lastAppid || appid === inFlight) return;
+    if (!shouldReportAppid(appid, lastAppid, inFlight)) return;
     inFlight = appid;
     try {
       Promise.resolve(setCurrentGame(appid))
@@ -66,7 +68,7 @@ export function startGameWatcher(): () => void {
           if (!alive) return;
           // Commit ONLY on success, so a failed report retries next tick.
           lastAppid = appid;
-          inFlight = null;
+          inFlight = undefined;
           if (appid !== null) {
             sawRealAppid = true;
             stopStartupPoll(); // got a real game → startup retries no longer needed
@@ -74,11 +76,11 @@ export function startGameWatcher(): () => void {
         })
         .catch(() => {
           // Backend not ready / RPC failed → do NOT commit; allow a retry.
-          if (inFlight === appid) inFlight = null;
+          if (inFlight === appid) inFlight = undefined;
         });
     } catch {
       // setCurrentGame threw synchronously (API missing) → allow a retry.
-      if (inFlight === appid) inFlight = null;
+      if (inFlight === appid) inFlight = undefined;
     }
   };
 


### PR DESCRIPTION
## Qué

Al salir de un juego, la vista de Potencia se quedaba mostrando el perfil del juego bajo la etiqueta "Global", y el auto-TDP parecía seguir activado aunque lo apagaras con el toggle.

## Causa

El watcher persistente del juego (`gameWatcher`) usaba `null` a la vez como centinela de "nada en vuelo" y como valor real de "no hay juego". Al salir del juego, el objetivo `null` coincidía con el centinela y el reporte se saltaba, así que el backend nunca recibía `setCurrentGame(null)` y `_current_appid` se quedaba pegado al último juego. Todo el estado de TDP se lee con ese appid, de ahí que Global mostrara los valores del juego y el auto-TDP se viera pillado.

## Fix

- Centinela de "en vuelo" pasa a `undefined`, dejando `null` como objetivo real y reportable.
- Guarda extraída a una función pura (`shouldReportAppid`) con tests que cubren arranque, cambio de juego, salida y el caso concreto que fallaba.

Sin cambios de polling ni de re-render (el watcher es de ámbito plugin, solo reporta en cambio) → sin riesgo de regresión en otras máquinas.

Gate: typecheck · 4978 vitest · build.

Fixes #281
