### PR TITLE
fix: debounce external-TDP adoption so a firmware spike doesn't stick

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from version import read_version
 from settings_store import SettingsStore
 from tdp import factory as tdp_factory
 from tdp import suggest as tdp_suggest
+from tdp.adopt import should_adopt_external
 from tdp.types import TdpResult
 from tdp_profiles import ProfileStore
 from power_presets import PowerPresetStore
@@ -338,6 +339,9 @@ class Plugin:
         # against this, not the profile, so it fires only for a real external change —
         # never on a stale/default read before our first apply or mid-transition (None).
         self._last_written_pl1 = None
+        # Divergent PL1 candidate awaiting a second matching read before adoption
+        # (debounce against one-shot firmware spikes). See tdp/adopt.py.
+        self._adopt_pending = None
         self._lifecycle = LifecycleManager(apply_cb=self._reapply_all,
                                            reassert_cb=self._reassert_tdp_only)
         self._auto_task = None
@@ -1904,9 +1908,14 @@ class Plugin:
             return TdpResult(None, self._tdp_backend.read_applied(), True, f"firmware-mode:{mode}")
         lv, _active, ac = self._effective_levels(self._current_appid, on_ac)
         res = self._tdp_backend.set_levels(lv["pl1"], lv["pl2"], lv["pl3"], ac)
+        # A fresh write is a new baseline for adoption — drop any armed spike candidate.
+        self._adopt_pending = None
         # Record what the firmware now holds (readback), so adoption can tell a real
         # external change from our own write.
         self._last_written_pl1 = res.applied_w if res.applied_w is not None else lv["pl1"]
+        if not res.ok and not self._tdp_profiles.auto_tdp(self._current_appid):
+            decky.logger.info("TDP: write pl1=%sW not confirmed (firmware holds %sW) %s",
+                              lv["pl1"], res.applied_w, res.detail)
         return res
 
     def _reassert_tdp_only(self, on_ac=None) -> None:
@@ -2509,18 +2518,31 @@ class Plugin:
         so a later re-apply doesn't stomp it. Compares against the value WE last wrote
         (``_last_written_pl1``): None until our first apply and cleared during a
         re-apply, so a stale/default read at startup or mid-transition never adopts.
-        Skipped in eco / auto (we own the setpoint there). True when adopted."""
+        Skipped in eco / auto (we own the setpoint there). To avoid mistaking a one-shot
+        firmware spike for a deliberate change, a divergent value must persist across two
+        consecutive reads before we adopt it (see tdp/adopt.py). True when adopted."""
         if applied is None or self._last_written_pl1 is None:
+            self._adopt_pending = None
             return False
         if self._settings.get("eco_enabled") or self._tdp_profiles.auto_tdp(self._current_appid):
+            self._adopt_pending = None
             return False
-        if abs(int(applied) - int(self._last_written_pl1)) < _EXTERNAL_TDP_THRESHOLD:
+        prev_pending = self._adopt_pending
+        adopt, self._adopt_pending = should_adopt_external(
+            applied, self._last_written_pl1, prev_pending, _EXTERNAL_TDP_THRESHOLD)
+        if self._adopt_pending is not None and self._adopt_pending != prev_pending:
+            decky.logger.info(
+                "TDP: external PL1 read %sW vs our %sW; waiting to confirm before adopting",
+                int(applied), self._last_written_pl1)
+        if not adopt:
             return False
         appid = self._current_appid
         # Adopt into the scope that's actually live (game only when it has its OWN active
         # profile) — never detach a follow-global game that merely kept stored values.
         scope = self._auto_scope()
         self._tdp_profiles.set_pl1(scope, int(applied), appid=appid)
+        decky.logger.info("TDP: adopted external change %sW -> %sW (scope=%s appid=%s)",
+                          self._last_written_pl1, int(applied), scope, appid)
         self._last_written_pl1 = int(applied)
         return True
 

--- a/py_modules/tdp/adopt.py
+++ b/py_modules/tdp/adopt.py
@@ -1,0 +1,32 @@
+"""External-TDP adoption debounce.
+
+The firmware PL1 read back can differ from what we wrote either because a real
+external tool (HHD / Steam) changed it — which we WANT to adopt so a later
+re-apply doesn't stomp the user's deliberate change — or because the firmware
+spiked the rail for a moment on its own (seen on newer ASUS kernels under load).
+Adopting a one-shot spike would turn a transient into a permanent setpoint (the
+slider "jumps" and stays). So require the divergent value to persist across two
+consecutive reads before adopting: a real change persists, a spike does not.
+"""
+from __future__ import annotations
+
+
+def should_adopt_external(applied, last_written, pending, threshold):
+    """Decide whether to adopt ``applied`` as our setpoint.
+
+    Returns ``(adopt, next_pending)``: ``adopt`` is True only when ``applied``
+    diverges from ``last_written`` by at least ``threshold`` AND equals the
+    candidate seen on the previous read (``pending``). ``next_pending`` is the
+    candidate to carry into the next read (None once cleared/adopted).
+    """
+    if applied is None or last_written is None:
+        return (False, None)
+    if abs(int(applied) - int(last_written)) < threshold:
+        # Back within range → not an external change; drop any armed candidate.
+        return (False, None)
+    a = int(applied)
+    if pending is not None and int(pending) == a:
+        # Same divergent value twice in a row → a real, settled external change.
+        return (True, None)
+    # First sighting (or the value moved) → arm and wait for confirmation.
+    return (False, a)

--- a/tests/test_tdp_adopt.py
+++ b/tests/test_tdp_adopt.py
@@ -1,0 +1,33 @@
+from tdp.adopt import should_adopt_external
+
+THRESH = 2
+
+
+def test_no_data():
+    assert should_adopt_external(None, 13, None, THRESH) == (False, None)
+    assert should_adopt_external(30, None, None, THRESH) == (False, None)
+
+
+def test_within_threshold_never_adopts_and_clears_pending():
+    # A 1 W wobble is not an external change; any armed candidate is dropped.
+    assert should_adopt_external(14, 13, 30, THRESH) == (False, None)
+
+
+def test_first_divergence_arms_but_does_not_adopt():
+    # A one-shot spike must NOT be adopted on its first sighting.
+    assert should_adopt_external(30, 13, None, THRESH) == (False, 30)
+
+
+def test_same_divergence_twice_adopts():
+    # Persisted across two reads → a real external change; adopt and clear.
+    assert should_adopt_external(30, 13, 30, THRESH) == (True, None)
+
+
+def test_moving_target_re_arms_without_adopting():
+    # Value diverges but differs from the armed candidate → re-arm, don't adopt.
+    assert should_adopt_external(30, 13, 28, THRESH) == (False, 30)
+
+
+def test_transient_then_back_in_range_is_dropped():
+    # Spike sighted (armed 30), next read is back at the setpoint → cleared, no adopt.
+    assert should_adopt_external(13, 13, 30, THRESH) == (False, None)

--- a/tests/test_tdp_rpc.py
+++ b/tests/test_tdp_rpc.py
@@ -428,11 +428,27 @@ def test_adopt_external_tdp_syncs_and_flags(Plugin):
     p = Plugin()
     asyncio.run(p.set_tdp_watts(15, "global"))
     p._tdp_backend._applied = 18  # HHD/Steam moved the firmware PL1 behind our back
+    # Debounced: a real external change persists, so it's adopted on the second read.
+    assert asyncio.run(p.get_tdp_state())["external_change"] is False  # first read arms
     st = asyncio.run(p.get_tdp_state())
-    assert st["external_change"] is True
+    assert st["external_change"] is True  # confirmed on the second read → adopt
     assert st["global_watts"] == 18  # adopted → our setpoint follows, no stomp next reapply
-    # already adopted → a second read is no longer flagged
+    # already adopted → a further read is no longer flagged
     assert asyncio.run(p.get_tdp_state())["external_change"] is False
+
+
+def test_transient_firmware_spike_not_adopted(Plugin):
+    # A one-shot spike (seen for a single read, then gone) must NOT be adopted as the
+    # user's setpoint — this debounce is what stops the slider "jumping" to the spike
+    # value on newer kernels that momentarily bump the rail under load.
+    p = Plugin()
+    asyncio.run(p.set_tdp_watts(15, "global"))
+    p._tdp_backend._applied = 30  # firmware spiked for a moment
+    assert asyncio.run(p.get_tdp_state())["external_change"] is False  # armed, not adopted
+    p._tdp_backend._applied = 15  # next read is back at our setpoint
+    st = asyncio.run(p.get_tdp_state())
+    assert st["external_change"] is False
+    assert st["global_watts"] == 15  # setpoint untouched by the transient
 
 
 def test_adopt_skipped_in_download_mode(Plugin):


### PR DESCRIPTION
## Qué

Con el TDP fijo manual, el valor "saltaba" solo a un número más alto y se quedaba ahí (reportes en Ally X con kernel nuevo).

## Causa

El plugin adopta un PL1 cambiado por fuera (HHD/Steam) como setpoint propio, para no pisar un cambio deliberado del usuario en el siguiente re-apply. Esa adopción disparaba con **una sola lectura** divergente. En kernels ASUS nuevos el firmware puede subir el riel un instante bajo carga, así que un pico puntual se adoptaba como el ajuste del usuario: el slider saltaba al pico y se quedaba.

## Fix

- **Debounce de adopción**: el valor divergente debe repetirse en **dos lecturas consecutivas** antes de adoptarse. Un cambio externo real persiste; un pico no.
- **Logging** en la ruta TDP: al escribir el setpoint (cuando el firmware no confirma) y cuando la adopción se arma / dispara (viejo→nuevo). Antes no había ninguna señal, por eso los bundles no captaban el salto.

## Validación

- Lógica pura con tests (`should_adopt_external`) + test de regresión del spike transitorio.
- Gate: ruff · **1207 pytest** · (frontend intacto).
- **On-device en las 3 máquinas** (Ally X asus-armoury, Legion Go S y Legion Go 2 lenovo-wmi-other): el pico transitorio no se adopta; un cambio persistente se adopta en la 2ª lectura. Logs nuevos verificados.

Relacionado con #283 (a confirmar con un reporte nuevo, gracias a los logs añadidos).
