### PR TITLE
fix: apply the charge limit on the Legion Go S (pick the working conservation_mode node)

### DIFF
--- a/py_modules/battery/charge_limit.py
+++ b/py_modules/battery/charge_limit.py
@@ -134,6 +134,7 @@ class LenovoConservationMode(ChargeLimitBackend):
         # tree and blocks _init, hanging the UI on its spinner. Probe the stable
         # flat ACPI/platform symlinks first, then a bounded-depth fallback.
         patterns = [
+            "sys/bus/platform/drivers/ideapad_acpi/VPC2004:*/conservation_mode",
             "sys/bus/acpi/devices/VPC2004:*/conservation_mode",
             "sys/bus/platform/devices/VPC2004:*/conservation_mode",
         ]

--- a/tests/test_charge_limit.py
+++ b/tests/test_charge_limit.py
@@ -160,6 +160,22 @@ def test_lenovo_conservation_found_via_acpi_flat_path(tmp_path):
     assert cl.disable() is True
 
 
+def test_lenovo_conservation_prefers_ideapad_driver_path(tmp_path):
+    # Legion Go S (Z2 Go, 83L3): the deep sys/devices tree exposes a
+    # passthrough conservation_mode node that does nothing, while the real
+    # control lives under the ideapad_acpi driver symlink. The driver path must
+    # win over the bounded-depth /sys/devices fallback.
+    root = str(tmp_path)
+    driver = os.path.join(root, "sys/bus/platform/drivers/ideapad_acpi/VPC2004:00")
+    os.makedirs(driver, exist_ok=True)
+    with open(os.path.join(driver, "conservation_mode"), "w") as f:
+        f.write("0")
+    _mk_conservation(root, value="0")  # decoy passthrough node in the device tree
+    cl = LenovoConservationMode(root=root)
+    assert cl.supported is True
+    assert cl._path == os.path.join(driver, "conservation_mode")
+
+
 def test_sysfs_is_adjustable(tmp_path):
     _mk_bat(str(tmp_path), value="80")
     assert SysfsChargeLimit(root=str(tmp_path)).adjustable is True


### PR DESCRIPTION
Cierra #69.

En algunas Legion Go S el árbol de `/sys/devices` expone más de un `conservation_mode`. La búsqueda por profundidad que teníamos como último recurso podía quedarse con un nodo "passthrough": aceptaba el `1` pero no limitaba de verdad la carga, así que el tope no se aplicaba (la batería detectaba corriente y dejaba de cargar en lugar de parar en el límite).

Ahora se prueba primero el enlace del driver `ideapad_acpi` (`/sys/bus/platform/drivers/ideapad_acpi/VPC2004:*/conservation_mode`), que resuelve al nodo que funciona.

Retrocompatible: en los equipos con un solo nodo (kernels donde solo existe una ruta) todos los enlaces resuelven al mismo fichero, así que no cambia nada. La detección es por presencia de fichero en cada arranque, sin fijar la ruta de una vez.

Confirmado a partir del reporte del equipo afectado (Z2 Go, 83L3), donde dejar la ruta del driver soluciona el límite de carga. Verificado que no hay regresión en la Legion Go S Z1E (83N6), que expone un único nodo.

---

Fixes the battery charge limit not holding on the Legion Go S: prefer the driver-bound `conservation_mode` node over the deep `/sys/devices` fallback, which could hit a passthrough duplicate. Single-node units are unaffected.

Gate: 1210 pytest · ruff. New test covers the multi-node selection.
