### PR TITLE
fix: keep the bundled power binary executable after a self-update

### DIFF
--- a/py_modules/self_updater.py
+++ b/py_modules/self_updater.py
@@ -12,6 +12,7 @@ Repo-specific values are read at runtime, so this file is identical across plugi
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import tempfile
@@ -137,6 +138,19 @@ def check(force: bool = False) -> dict:
     return result
 
 
+def _extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract preserving the unix permission bits the archive records. plain
+    extractall() drops them, so a bundled executable (bin/ryzenadj) would land
+    non-executable and fail to run. A zip with no recorded mode (external_attr high
+    bits == 0) keeps the default extract."""
+    for info in zf.infolist():
+        out = zf.extract(info, dest)
+        # Low 9 bits only (rwx for u/g/o); never carry setuid/setgid/sticky from a zip.
+        mode = (info.external_attr >> 16) & 0o777
+        if mode:
+            os.chmod(out, mode)
+
+
 def install() -> dict:
     """Download the latest release zip and overwrite the installed plugin dir in place.
 
@@ -156,7 +170,7 @@ def install() -> dict:
             zpath.write_bytes(blob)
             extract = tmpd / "x"
             with zipfile.ZipFile(zpath) as zf:
-                zf.extractall(extract)
+                _extract_zip(zf, extract)
             src = extract / name  # top folder == plugin.json name
             if not src.is_dir():
                 subdirs = [p for p in extract.iterdir() if p.is_dir()]
@@ -182,7 +196,6 @@ def install() -> dict:
 def restart_loader() -> None:
     """Restart Decky to load the just-installed files. Fire-and-forget (kills this process)."""
     try:
-        import os
         import subprocess
 
         # Decky's PyInstaller build points LD_LIBRARY_PATH at its bundled libs

--- a/py_modules/tdp/ryzenadj.py
+++ b/py_modules/tdp/ryzenadj.py
@@ -29,13 +29,28 @@ def _parse_stapm(out: str) -> int | None:
         return None
 
 
+def _ensure_executable(path: str) -> None:
+    """Make our bundled binary runnable. A plain zip extract (the self-updater) drops
+    the exec bit, so it can land mode 0o644, and execve gives EACCES even as root when
+    no exec bit is set. We own this file, so restore +x. Best-effort: never raise."""
+    try:
+        mode = os.stat(path).st_mode
+        if mode & 0o111 != 0o111:
+            os.chmod(path, mode | 0o111)
+    except OSError:
+        pass
+
+
 def _default_resolve():
     found = shutil.which("ryzenadj")
     if found:
         return found
     bundled = os.path.join(os.path.dirname(__file__), "..", "..", "bin", "ryzenadj")
     bundled = os.path.abspath(bundled)
-    return bundled if os.path.exists(bundled) else None
+    if not os.path.exists(bundled):
+        return None
+    _ensure_executable(bundled)
+    return bundled
 
 
 def _clean_env():

--- a/tests/test_tdp_ryzenadj.py
+++ b/tests/test_tdp_ryzenadj.py
@@ -1,3 +1,6 @@
+import os
+
+from tdp import ryzenadj
 from tdp.ryzenadj import RyzenadjBackend
 from tdp.types import TdpLimits
 
@@ -26,6 +29,21 @@ class FakeRun:
             stderr = ""
 
         return R()
+
+
+def test_ensure_executable_adds_exec_bit(tmp_path):
+    # The bundled binary can arrive mode 0o644 (a plain zip extract drops the exec
+    # bit). Even root gets EACCES on a file with no exec bits set, so we self-heal.
+    p = tmp_path / "ryzenadj"
+    p.write_bytes(b"\x7fELF")
+    os.chmod(p, 0o644)
+    ryzenadj._ensure_executable(str(p))
+    assert os.stat(p).st_mode & 0o111 == 0o111
+
+
+def test_ensure_executable_missing_path_is_silent(tmp_path):
+    # Never raises on a path that isn't there.
+    ryzenadj._ensure_executable(str(tmp_path / "does-not-exist"))
 
 
 def test_unsupported_when_binary_missing():

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -183,6 +183,45 @@ def test_shape_matches_github_dotted_asset_name(updater, monkeypatch):
     assert result["has_update"] is True
 
 
+def test_extract_zip_preserves_executable_bit(updater, tmp_path):
+    # zipfile.extractall() drops the unix mode the archive records, so a bundled
+    # executable (bin/ryzenadj) lands non-executable and fails to run (EACCES).
+    # _extract_zip must restore the recorded mode.
+    import os
+    import zipfile
+
+    zpath = tmp_path / "release.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        exe = zipfile.ZipInfo("Plugin/bin/ryzenadj")
+        exe.external_attr = 0o755 << 16
+        zf.writestr(exe, b"\x7fELF binary")
+        plain = zipfile.ZipInfo("Plugin/main.py")
+        plain.external_attr = 0o644 << 16
+        zf.writestr(plain, b"x = 1\n")
+
+    dest = tmp_path / "out"
+    with zipfile.ZipFile(zpath) as zf:
+        updater._extract_zip(zf, dest)
+
+    assert os.stat(dest / "Plugin/bin/ryzenadj").st_mode & 0o111 == 0o111
+    assert os.stat(dest / "Plugin/main.py").st_mode & 0o111 == 0
+
+
+def test_extract_zip_tolerates_missing_unix_mode(updater, tmp_path):
+    # A zip made by a tool that records no unix mode (external_attr high bits == 0,
+    # e.g. some Windows zippers) must still extract without error.
+    import zipfile
+
+    zpath = tmp_path / "nomodes.zip"
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.writestr("Plugin/main.py", b"x = 1\n")
+
+    dest = tmp_path / "out"
+    with zipfile.ZipFile(zpath) as zf:
+        updater._extract_zip(zf, dest)
+    assert (dest / "Plugin/main.py").read_text() == "x = 1\n"
+
+
 def test_check_404_is_benign(updater, monkeypatch):
     import urllib.error
 


### PR DESCRIPTION
## Qué arregla

En dispositivos que usan el camino ryzenadj (fallback genérico AMD, p. ej. OneXPlayer Apex) el límite de TDP no se aplicaba: el slider no capaba nada y el chip subía al techo del firmware (~50W).

## Causa

El actualizador interno extraía el zip de la release con `zipfile.extractall()`, que no restaura los permisos que guarda el archivo. El binario `bin/ryzenadj` quedaba sin permiso de ejecución (modo 0644), así que al ejecutarlo fallaba con `EACCES` y la escritura de TDP nunca ocurría. El zip de la release en sí es correcto; el problema estaba solo en la extracción.

Traza en el log del reporte:

```
TDP: write pl1=20W not confirmed (firmware holds NoneW) ryzenadj failed: [Errno 13] Permission denied: '.../bin/ryzenadj'
```

## Cambios

- El actualizador conserva los permisos que guarda el zip al extraer, de modo que el binario queda ejecutable.
- Autocorrección al cargar: se restaura el permiso de ejecución del binario empaquetado en cada arranque, para que las instalaciones que ya se actualizaron se recuperen solas (el actualizador que corre es el ya instalado, así que no basta con arreglar solo la extracción).

## Pruebas

- Tests nuevos para la preservación de permisos al extraer y para la autocorrección al resolver el binario.
- Suite completa en verde (1213 pytest), ruff limpio. Sin cambios de frontend.

Cierra los reportes de OneXPlayer Apex sobre el TDP que se dispara al máximo y no deja fijar el límite.
