### PR TITLE
fix: recover GPD Win Mini TDP and fan control

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from fans import control as fan_control
 from fans import legion_ec
 from fans import oxp_ec
 from fans import expose as fan_expose
+from fans import gpd_recovery
 from fans import presets as fan_presets
 from fans import suggest as fan_suggest
 from fan_curves import FanCurveStore
@@ -1023,6 +1024,49 @@ class Plugin:
             return None
 
     # ---- Fan-curve control (global + per-game, persisted) -------------------
+    def _recover_gpd_fan_sync(self):
+        if getattr(self, "_gpd_fan_recovery_done", False):
+            return None
+        self._gpd_fan_recovery_done = True
+        if bool(getattr(self._fan_ctrl, "supported", False)):
+            return None
+
+        outcome = gpd_recovery.ensure_gpd_fan(self._device)
+        if outcome["eligible"] and outcome["abi_after"]:
+            try:
+                self._fan_ctrl = fan_control.select_fan_backend(
+                    self._device,
+                    temp_fn=self._driving_temp,
+                    experimental=bool(
+                        self._settings.get("fan_experimental", False)
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 — retain firmware-auto/null
+                outcome["error"] = type(exc).__name__
+
+        return {
+            **outcome,
+            "backend": getattr(self._fan_ctrl, "name", "null"),
+            "supported": bool(getattr(self._fan_ctrl, "supported", False)),
+        }
+
+    async def _recover_gpd_fan(self) -> None:
+        if (
+            getattr(self._fan_ctrl, "supported", False)
+            or getattr(self._device, "key", None) != "gpd_win_mini_2025"
+        ):
+            return
+        try:
+            outcome = await self._offload_call(self._recover_gpd_fan_sync)
+        except Exception as exc:  # noqa: BLE001 — startup must continue
+            decky.logger.warning("GPD fan recovery error=%s", type(exc).__name__)
+            return
+        if outcome is None or not outcome["eligible"]:
+            return
+        encoded = json.dumps(outcome, sort_keys=True, separators=(",", ":"))
+        log = decky.logger.info if outcome["supported"] else decky.logger.warning
+        log("GPD fan recovery %s", encoded)
+
     def _reapply_fans(self) -> None:
         """Push the effective fan curve off the event loop (Steam Deck's software-loop
         backend spawns a blocking systemctl). `done` (re)starts the curve loop on the
@@ -3707,6 +3751,7 @@ class Plugin:
         # expose_all_fans=Y — enable it (idempotent, no-op elsewhere, never raises).
         if fan_expose.ensure_fan_sensor():
             decky.logger.info("Legion fan sensor exposed (lenovo_wmi_other)")
+        await self._recover_gpd_fan()
         try:
             self._reapply_all()
             self._lifecycle.start()

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -1,0 +1,17 @@
+import os
+
+
+def _read_dmi(root: str, field: str) -> str:
+    try:
+        with open(os.path.join(root, "sys/class/dmi/id", field)) as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+def is_gpd_win_mini_2025(device, root: str = "/") -> bool:
+    return (
+        getattr(device, "key", None) == "gpd_win_mini_2025"
+        and _read_dmi(root, "sys_vendor").casefold() == "gpd"
+        and _read_dmi(root, "product_name").casefold() == "g1617-02"
+    )

--- a/py_modules/fans/gpd_recovery.py
+++ b/py_modules/fans/gpd_recovery.py
@@ -1,0 +1,91 @@
+"""Load ``gpd_fan`` only for the exact GPD Win Mini 2025 DMI."""
+
+import glob
+import os
+import subprocess
+import time
+
+from device_quirks import is_gpd_win_mini_2025
+
+
+_HWMON = "sys/class/hwmon"
+_CHIP_NAME = "gpdfan"
+_REQUIRED_NODES = ("fan1_input", "pwm1", "pwm1_enable")
+
+
+def _read(path: str) -> str:
+    try:
+        with open(path) as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+def gpdfan_abi_complete(root: str = "/") -> bool:
+    pattern = os.path.join(root, _HWMON, "hwmon*")
+    for directory in sorted(glob.glob(pattern)):
+        if _read(os.path.join(directory, "name")) != _CHIP_NAME:
+            continue
+        if all(os.path.exists(os.path.join(directory, node)) for node in _REQUIRED_NODES):
+            return True
+    return False
+
+
+def _default_run(command: list[str]):
+    from controllers.detect import clean_env, resolve_bin
+
+    argv = [resolve_bin(command[0]), *command[1:]]
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=clean_env(),
+    )
+
+
+def _wait_for_abi(check, *, timeout: float = 1.0, interval: float = 0.05) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if check():
+            return True
+        time.sleep(interval)
+    return check()
+
+
+def ensure_gpd_fan(
+    device,
+    *,
+    root: str = "/",
+    run=_default_run,
+    wait_for_abi=_wait_for_abi,
+) -> dict:
+    """Try once and return bounded diagnostics without process output."""
+    outcome = {
+        "eligible": False,
+        "abi_before": False,
+        "attempted": False,
+        "exit": None,
+        "error": None,
+        "abi_after": False,
+    }
+    outcome["eligible"] = is_gpd_win_mini_2025(device, root)
+    if not outcome["eligible"]:
+        return outcome
+
+    outcome["abi_before"] = gpdfan_abi_complete(root)
+    if outcome["abi_before"]:
+        outcome["abi_after"] = True
+        return outcome
+
+    outcome["attempted"] = True
+    try:
+        result = run(["modprobe", "gpd_fan"])
+        outcome["exit"] = int(getattr(result, "returncode", 0) or 0)
+        if outcome["exit"] == 0:
+            wait_for_abi(lambda: gpdfan_abi_complete(root))
+    except Exception as exc:  # noqa: BLE001 — recovery must never break plugin load
+        outcome["error"] = type(exc).__name__
+
+    outcome["abi_after"] = gpdfan_abi_complete(root)
+    return outcome

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -1,3 +1,4 @@
+from device_quirks import is_gpd_win_mini_2025
 from tdp.alib import AlibBackend
 from tdp.backend import NullBackend, TDPBackend
 from tdp.firmware_attr import FirmwareAttrBackend
@@ -61,9 +62,13 @@ def select_backend(device, root="/", ryzenadj_resolve=None) -> TDPBackend:
     fallback = TdpLimits.from_profile(device)
 
     def ryzenadj():
-        if ryzenadj_resolve is not None:
-            return RyzenadjBackend(fallback, resolve=ryzenadj_resolve, write_max=device.cooler_max)
-        return RyzenadjBackend(fallback, write_max=device.cooler_max)
+        kwargs = {"resolve": ryzenadj_resolve} if ryzenadj_resolve is not None else {}
+        return RyzenadjBackend(
+            fallback,
+            write_max=device.cooler_max,
+            power_only_retry=is_gpd_win_mini_2025(device, root),
+            **kwargs,
+        )
 
     trace = []
     for make in _candidates(device, fallback, root, ryzenadj):

--- a/py_modules/tdp/ryzenadj.py
+++ b/py_modules/tdp/ryzenadj.py
@@ -19,6 +19,17 @@ def _unreadable(applied):
     return applied is None or applied == 0
 
 
+def _matches(applied, target):
+    return not _unreadable(applied) and abs(applied - target) <= _READBACK_TOLERANCE_W
+
+
+def _gpd_detail(*, variant, primary_exit, exit_code, readback):
+    return (
+        f"gpd recovery variant={variant} primary_exit={int(primary_exit)} "
+        f"exit={int(exit_code)} readback={readback}"
+    )
+
+
 def _parse_stapm(out: str) -> int | None:
     m = _STAPM_RE.search(out)
     if not m:
@@ -68,12 +79,13 @@ class RyzenadjBackend(TDPBackend):
     read_tolerance_w = _READBACK_TOLERANCE_W
 
     def __init__(self, fallback: TdpLimits, resolve=_default_resolve, runner=subprocess.run,
-                 write_max: int | None = None):
+                 write_max: int | None = None, power_only_retry: bool = False):
         self._fallback = fallback
         # Writes clamp to the absolute ceiling (cooler_max); get_limits keeps the base.
         self._write_limits = fallback.with_cooler(write_max)
         self._runner = runner
         self._bin = resolve()
+        self._power_only_retry = power_only_retry
         self.supported = self._bin is not None
 
     def get_limits(self) -> TdpLimits:
@@ -95,31 +107,86 @@ class RyzenadjBackend(TDPBackend):
         applied = None
         for _ in range(2):
             try:
-                self._apply(target)
+                primary_exit = self._apply(target)
             except (OSError, subprocess.SubprocessError) as e:
+                if self._power_only_retry:
+                    return TdpResult(
+                        watts, None, False,
+                        f"ryzenadj primary failed ({type(e).__name__})",
+                    )
                 return TdpResult(watts, None, False, f"ryzenadj failed: {e}")
+            if self._power_only_retry and primary_exit:
+                return self._recover_gpd(watts, target, primary_exit)
             applied = self.read_applied()
             if _unreadable(applied):
                 continue  # re-assert once, then treat as unconfirmed
-            if abs(applied - target) <= _READBACK_TOLERANCE_W:
+            if _matches(applied, target):
                 return TdpResult(watts, applied, True, "")
         if _unreadable(applied):
             return TdpResult(watts, None, True, "applied (limit readback unavailable)")
         return TdpResult(watts, applied, False,
                          f"ryzenadj limit did not stick (wanted {target}, holds {applied})")
 
-    def _apply(self, target: int) -> None:
+    def _recover_gpd(self, watts: int, target: int, primary_exit: int) -> TdpResult:
+        applied = self._read_applied(require_zero_exit=True)
+        if _matches(applied, target):
+            return TdpResult(
+                watts,
+                applied,
+                True,
+                _gpd_detail(
+                    variant="primary",
+                    primary_exit=primary_exit,
+                    exit_code=primary_exit,
+                    readback="confirmed",
+                ),
+            )
+        try:
+            fallback_exit = self._apply(target, include_temp=False)
+        except (OSError, subprocess.SubprocessError) as e:
+            return TdpResult(
+                watts,
+                applied,
+                False,
+                f"ryzenadj power-only failed ({type(e).__name__}) "
+                f"primary_exit={int(primary_exit)}",
+            )
+        applied = self._read_applied(require_zero_exit=True)
+        if _unreadable(applied):
+            readback = "unavailable"
+        elif _matches(applied, target):
+            readback = "confirmed"
+        else:
+            readback = "mismatch"
+        detail = _gpd_detail(
+            variant="power-only",
+            primary_exit=primary_exit,
+            exit_code=fallback_exit,
+            readback=readback,
+        )
+        if fallback_exit:
+            return TdpResult(watts, applied, False, detail)
+        if _unreadable(applied):
+            return TdpResult(watts, None, True, detail)
+        return TdpResult(watts, applied, _matches(applied, target), detail)
+
+    def _apply(self, target: int, *, include_temp: bool = True) -> int:
         mw = str(target * 1000)
         argv = [
             self._bin,
             "--stapm-limit", mw,
             "--fast-limit", mw,
             "--slow-limit", mw,
-            "--tctl-temp", "90",
         ]
-        self._runner(argv, capture_output=True, text=True, timeout=5, env=_clean_env())
+        if include_temp:
+            argv.extend(["--tctl-temp", "90"])
+        res = self._runner(argv, capture_output=True, text=True, timeout=5, env=_clean_env())
+        return int(getattr(res, "returncode", 0) or 0)
 
     def read_applied(self) -> int | None:
+        return self._read_applied()
+
+    def _read_applied(self, *, require_zero_exit: bool = False) -> int | None:
         if not self.supported:
             return None
         try:
@@ -131,6 +198,8 @@ class RyzenadjBackend(TDPBackend):
                 env=_clean_env(),
             )
         except (OSError, subprocess.SubprocessError):
+            return None
+        if require_zero_exit and getattr(res, "returncode", 0):
             return None
         out = getattr(res, "stdout", "") or ""
         return _parse_stapm(out)

--- a/tests/test_device_quirks.py
+++ b/tests/test_device_quirks.py
@@ -1,0 +1,46 @@
+import os
+
+from device_profiles import DEVICE_TABLE, GENERIC
+from device_quirks import is_gpd_win_mini_2025
+
+
+def _profile(key):
+    return next(profile for profile in DEVICE_TABLE if profile.key == key)
+
+
+def _write_dmi(root: str, vendor: str, product: str) -> None:
+    base = os.path.join(root, "sys/class/dmi/id")
+    os.makedirs(base, exist_ok=True)
+    for name, value in (("sys_vendor", vendor), ("product_name", product)):
+        with open(os.path.join(base, name), "w") as handle:
+            handle.write(value)
+
+
+def test_exact_gpd_win_mini_2025_match_is_case_insensitive(tmp_path):
+    _write_dmi(str(tmp_path), "gPd", "g1617-02")
+
+    assert is_gpd_win_mini_2025(
+        _profile("gpd_win_mini_2025"),
+        str(tmp_path),
+    )
+
+
+def test_gpd_quirk_rejects_nearby_or_generic_identity(tmp_path):
+    cases = (
+        ("OTHER", "G1617-02", _profile("gpd_win_mini_2025")),
+        ("GPD", "G1617-01", _profile("gpd_win_mini_2025")),
+        ("GPD", "G1617-02-L", _profile("gpd_win_mini_2025")),
+        ("GPD", "prefix-G1617-02-suffix", _profile("gpd_win_mini_2025")),
+        ("GPD", "G1617-02", GENERIC),
+    )
+
+    for vendor, product, profile in cases:
+        _write_dmi(str(tmp_path), vendor, product)
+        assert not is_gpd_win_mini_2025(profile, str(tmp_path))
+
+
+def test_gpd_quirk_is_false_when_dmi_is_unreadable(tmp_path):
+    assert not is_gpd_win_mini_2025(
+        _profile("gpd_win_mini_2025"),
+        str(tmp_path),
+    )

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -114,6 +114,36 @@ def test_offload_call_dispatches_through_executor(tmp_path, monkeypatch):
     assert rec.count == 1  # went THROUGH the executor, not the inline branch
 
 
+def test_gpd_fan_recovery_dispatches_through_executor(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    rec = _RecordingExecutor()
+    calls = []
+    p._device = types.SimpleNamespace(key="gpd_win_mini_2025")
+    p._fan_ctrl = types.SimpleNamespace(supported=False)
+    p._apply_executor = rec
+    p._recover_gpd_fan_sync = lambda: calls.append("recover")
+
+    asyncio.run(p._recover_gpd_fan())
+
+    assert calls == ["recover"]
+    assert rec.count == 1
+
+
+def test_non_gpd_device_never_dispatches_fan_recovery(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    rec = _RecordingExecutor()
+    calls = []
+    p._device = types.SimpleNamespace(key="generic")
+    p._fan_ctrl = types.SimpleNamespace(supported=False)
+    p._apply_executor = rec
+    p._recover_gpd_fan_sync = lambda: calls.append("recover")
+
+    asyncio.run(p._recover_gpd_fan())
+
+    assert calls == []
+    assert rec.count == 0
+
+
 def test_offload_runs_off_the_loop_thread(tmp_path, monkeypatch):
     p, _ = _make_plugin(tmp_path, monkeypatch)
     ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/tests/test_fan_control_rpc.py
+++ b/tests/test_fan_control_rpc.py
@@ -10,13 +10,14 @@ Two scenarios are tested:
 """
 import asyncio
 import importlib
+import json
 import os
 import sys
 import types
 
 import pytest
 
-from fans.control import AsusFanCurveBackend
+from fans.control import AsusFanCurveBackend, NullFanBackend
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +104,150 @@ def _make_plugin_fixture(tmp_path, monkeypatch, fan_ctrl_override=None):
         monkeypatch.setattr(main.Plugin, "_init", patched_init)
 
     return main.Plugin
+
+
+def _recovered_gpd_fan():
+    return types.SimpleNamespace(supported=True, name="generic-pwm")
+
+
+_COMPLETE_GPD_OUTCOME = {
+    "eligible": True,
+    "abi_before": False,
+    "attempted": True,
+    "exit": 0,
+    "error": None,
+    "abi_after": True,
+}
+
+
+def test_recovery_reselects_existing_fan_factory_after_complete_abi(tmp_path, monkeypatch):
+    Plugin = _make_plugin_fixture(tmp_path, monkeypatch)
+    main = importlib.import_module("main")
+    recovered = _recovered_gpd_fan()
+    monkeypatch.setattr(
+        main.gpd_recovery,
+        "ensure_gpd_fan",
+        lambda device: dict(_COMPLETE_GPD_OUTCOME),
+    )
+    monkeypatch.setattr(
+        main.fan_control,
+        "select_fan_backend",
+        lambda device, **kwargs: recovered,
+    )
+    plugin = Plugin()
+    plugin._init()
+    plugin._fan_ctrl = NullFanBackend()
+
+    outcome = plugin._recover_gpd_fan_sync()
+
+    assert plugin._fan_ctrl is recovered
+    assert outcome["backend"] == "generic-pwm"
+    assert outcome["supported"] is True
+
+
+def test_supported_fan_backend_skips_gpd_recovery(tmp_path, monkeypatch):
+    Plugin = _make_plugin_fixture(tmp_path, monkeypatch)
+    main = importlib.import_module("main")
+    called = []
+    monkeypatch.setattr(
+        main.gpd_recovery,
+        "ensure_gpd_fan",
+        lambda device: called.append(device),
+    )
+    plugin = Plugin()
+    plugin._init()
+    plugin._fan_ctrl = _recovered_gpd_fan()
+
+    assert plugin._recover_gpd_fan_sync() is None
+    assert called == []
+
+
+def test_gpd_fan_recovery_is_attempted_only_once_per_plugin_life(tmp_path, monkeypatch):
+    Plugin = _make_plugin_fixture(tmp_path, monkeypatch)
+    main = importlib.import_module("main")
+    outcomes = []
+
+    def incomplete(device):
+        outcomes.append(device)
+        return {
+            **_COMPLETE_GPD_OUTCOME,
+            "exit": 1,
+            "abi_after": False,
+        }
+
+    monkeypatch.setattr(main.gpd_recovery, "ensure_gpd_fan", incomplete)
+    plugin = Plugin()
+    plugin._init()
+    plugin._fan_ctrl = NullFanBackend()
+
+    assert plugin._recover_gpd_fan_sync()["supported"] is False
+    assert plugin._recover_gpd_fan_sync() is None
+    assert len(outcomes) == 1
+
+
+def test_incomplete_gpd_abi_keeps_null_backend(tmp_path, monkeypatch):
+    Plugin = _make_plugin_fixture(tmp_path, monkeypatch)
+    main = importlib.import_module("main")
+    incomplete = {**_COMPLETE_GPD_OUTCOME, "exit": 1, "abi_after": False}
+    monkeypatch.setattr(
+        main.gpd_recovery,
+        "ensure_gpd_fan",
+        lambda device: dict(incomplete),
+    )
+    selected = []
+    monkeypatch.setattr(
+        main.fan_control,
+        "select_fan_backend",
+        lambda device, **kwargs: selected.append(device),
+    )
+    plugin = Plugin()
+    plugin._init()
+    plugin._fan_ctrl = NullFanBackend()
+    selected.clear()
+
+    outcome = plugin._recover_gpd_fan_sync()
+
+    assert isinstance(plugin._fan_ctrl, NullFanBackend)
+    assert selected == []
+    assert outcome["backend"] == "null"
+    assert outcome["supported"] is False
+
+
+def test_gpd_recovery_log_is_compact_and_structured(tmp_path, monkeypatch):
+    Plugin = _make_plugin_fixture(tmp_path, monkeypatch)
+    main = importlib.import_module("main")
+    logs = []
+    main.decky.logger = types.SimpleNamespace(
+        info=lambda *args: logs.append(("info", args)),
+        warning=lambda *args: logs.append(("warning", args)),
+        error=lambda *args: logs.append(("error", args)),
+    )
+    monkeypatch.setattr(
+        main.gpd_recovery,
+        "ensure_gpd_fan",
+        lambda device: dict(_COMPLETE_GPD_OUTCOME),
+    )
+    monkeypatch.setattr(
+        main.fan_control,
+        "select_fan_backend",
+        lambda device, **kwargs: _recovered_gpd_fan(),
+    )
+    plugin = Plugin()
+    plugin._init()
+    plugin._device = types.SimpleNamespace(key="gpd_win_mini_2025")
+    plugin._fan_ctrl = NullFanBackend()
+
+    asyncio.run(plugin._recover_gpd_fan())
+
+    level, (fmt, encoded) = logs[-1]
+    assert level == "info"
+    assert fmt == "GPD fan recovery %s"
+    assert "\n" not in encoded
+    assert json.loads(encoded)["backend"] == "generic-pwm"
+    assert all(
+        token not in encoded.casefold()
+        for token in ("stdout", "stderr", "/home/", "serial", "hostname")
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fans_gpd_recovery.py
+++ b/tests/test_fans_gpd_recovery.py
@@ -1,0 +1,154 @@
+import json
+import os
+from types import SimpleNamespace
+
+from device_profiles import DEVICE_TABLE, GENERIC
+from fans.gpd_recovery import ensure_gpd_fan, gpdfan_abi_complete
+
+
+GPD = next(profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025")
+
+
+def _write(path: str, content: str = "") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as handle:
+        handle.write(content)
+
+
+def _exact_gpd_root(tmp_path) -> str:
+    root = str(tmp_path)
+    base = os.path.join(root, "sys/class/dmi/id")
+    _write(os.path.join(base, "sys_vendor"), "GPD\n")
+    _write(os.path.join(base, "product_name"), "G1617-02\n")
+    return root
+
+
+def _make_gpdfan(root: str, *, complete: bool) -> None:
+    base = os.path.join(root, "sys/class/hwmon/hwmon7")
+    _write(os.path.join(base, "name"), "gpdfan\n")
+    _write(os.path.join(base, "fan1_input"), "2100\n")
+    _write(os.path.join(base, "pwm1"), "120\n")
+    if complete:
+        _write(os.path.join(base, "pwm1_enable"), "2\n")
+
+
+class _Runner:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+        self.calls = []
+
+    def __call__(self, command):
+        self.calls.append(command)
+        return SimpleNamespace(returncode=self.returncode)
+
+
+class _WaitThatCreatesAbi:
+    def __init__(self, root: str):
+        self.root = root
+        self.calls = 0
+
+    def __call__(self, check):
+        self.calls += 1
+        _make_gpdfan(self.root, complete=True)
+        return check()
+
+
+def test_other_model_never_runs_modprobe(tmp_path):
+    runner = _Runner(returncode=0)
+    outcome = ensure_gpd_fan(GENERIC, root=str(tmp_path), run=runner)
+    assert outcome["eligible"] is False
+    assert runner.calls == []
+
+
+def test_matching_profile_with_wrong_dmi_never_runs_modprobe(tmp_path):
+    root = str(tmp_path)
+    _write(os.path.join(root, "sys/class/dmi/id/sys_vendor"), "OTHER\n")
+    _write(os.path.join(root, "sys/class/dmi/id/product_name"), "G1617-02\n")
+    runner = _Runner(returncode=0)
+    outcome = ensure_gpd_fan(GPD, root=root, run=runner)
+    assert outcome["eligible"] is False
+    assert runner.calls == []
+
+
+def test_existing_complete_abi_is_noop(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+    _make_gpdfan(root, complete=True)
+    runner = _Runner(returncode=0)
+    outcome = ensure_gpd_fan(GPD, root=root, run=runner)
+    assert outcome["abi_before"] is True
+    assert outcome["attempted"] is False
+    assert outcome["abi_after"] is True
+    assert runner.calls == []
+
+
+def test_successful_modprobe_waits_for_complete_abi(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+    runner = _Runner(returncode=0)
+    wait = _WaitThatCreatesAbi(root)
+    outcome = ensure_gpd_fan(
+        GPD,
+        root=root,
+        run=runner,
+        wait_for_abi=wait,
+    )
+    assert runner.calls == [["modprobe", "gpd_fan"]]
+    assert wait.calls == 1
+    assert outcome["abi_after"] is True
+
+
+def test_nonzero_modprobe_stays_incomplete_without_waiting(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+    runner = _Runner(returncode=1)
+    wait_calls = []
+    outcome = ensure_gpd_fan(
+        GPD,
+        root=root,
+        run=runner,
+        wait_for_abi=lambda check: wait_calls.append(check),
+    )
+    assert outcome["exit"] == 1
+    assert outcome["abi_after"] is False
+    assert wait_calls == []
+
+
+def test_partial_abi_is_not_supported(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+    _make_gpdfan(root, complete=False)
+    assert gpdfan_abi_complete(root) is False
+
+
+def test_nodes_from_different_hwmon_chips_do_not_form_an_abi(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+    first = os.path.join(root, "sys/class/hwmon/hwmon1")
+    second = os.path.join(root, "sys/class/hwmon/hwmon2")
+    _write(os.path.join(first, "name"), "gpdfan\n")
+    _write(os.path.join(first, "fan1_input"), "2100\n")
+    _write(os.path.join(second, "name"), "gpdfan\n")
+    _write(os.path.join(second, "pwm1"), "120\n")
+    _write(os.path.join(second, "pwm1_enable"), "2\n")
+    assert gpdfan_abi_complete(root) is False
+
+
+def test_runner_exception_is_sanitized(tmp_path):
+    root = _exact_gpd_root(tmp_path)
+
+    def raise_private_error(command):
+        raise RuntimeError("/home/private stderr=secret")
+
+    outcome = ensure_gpd_fan(GPD, root=root, run=raise_private_error)
+    assert outcome["error"] == "RuntimeError"
+    encoded = json.dumps(outcome)
+    assert "private" not in encoded
+    assert "secret" not in encoded
+
+
+def test_outcome_schema_is_fixed_for_ineligible_device(tmp_path):
+    outcome = ensure_gpd_fan(GENERIC, root=str(tmp_path), run=_Runner(returncode=0))
+    assert set(outcome) == {
+        "eligible",
+        "abi_before",
+        "attempted",
+        "exit",
+        "error",
+        "abi_after",
+    }

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -30,6 +30,14 @@ def _mk_hwmon(root):
         f.write("15000000")
 
 
+def _mk_dmi(root, vendor, product):
+    base = os.path.join(root, "sys/class/dmi/id")
+    os.makedirs(base, exist_ok=True)
+    for name, value in (("sys_vendor", vendor), ("product_name", product)):
+        with open(os.path.join(base, name), "w") as f:
+            f.write(value)
+
+
 _NO_RYZENADJ = lambda: None  # noqa: E731
 
 
@@ -88,6 +96,38 @@ def test_generic_amd_uses_ryzenadj_when_present(tmp_path):
         "msi",
         "ryzenadj",
     ]
+
+
+def test_only_exact_gpd_enables_ryzenadj_power_only_retry(tmp_path):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", "G1617-02")
+
+    exact = select_backend(
+        _p("gpd_win_mini_2025"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+    )
+    other = select_backend(
+        _p("onexplayer_f1pro"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+    )
+
+    assert exact._power_only_retry is True
+    assert other._power_only_retry is False
+
+
+def test_gpd_profile_with_different_dmi_keeps_default_ryzenadj(tmp_path):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", "G1617-02-L")
+
+    backend = select_backend(
+        _p("gpd_win_mini_2025"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+    )
+
+    assert backend._power_only_retry is False
 
 
 def test_backend_probe_failure_is_recorded_and_falls_through(tmp_path, monkeypatch):

--- a/tests/test_tdp_ryzenadj.py
+++ b/tests/test_tdp_ryzenadj.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 from tdp import ryzenadj
 from tdp.ryzenadj import RyzenadjBackend
@@ -149,6 +150,251 @@ class StickyRun:
     @property
     def write_count(self):
         return sum(1 for c in self.calls if "--stapm-limit" in c[0])
+
+
+class ScriptedRun:
+    def __init__(
+        self,
+        *,
+        write_rcs,
+        infos,
+        info_rcs=None,
+        write_stdout="",
+        write_stderr="",
+    ):
+        self.calls = []
+        self._write_rcs = list(write_rcs)
+        self._infos = list(infos)
+        self._info_rcs = list(info_rcs or [0] * len(self._infos))
+        self._write_stdout = write_stdout
+        self._write_stderr = write_stderr
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append((argv, kwargs))
+        if "-i" in argv or "--info" in argv:
+            return SimpleNamespace(
+                returncode=self._info_rcs.pop(0),
+                stdout=self._infos.pop(0),
+                stderr="",
+            )
+        return SimpleNamespace(
+            returncode=self._write_rcs.pop(0),
+            stdout=self._write_stdout,
+            stderr=self._write_stderr,
+        )
+
+    @property
+    def writes(self):
+        return [call[0] for call in self.calls if "--stapm-limit" in call[0]]
+
+
+def _stapm(watts):
+    return f"| STAPM LIMIT | {watts}.000 | stapm-limit |\n"
+
+
+def _unreadable_info():
+    return "| Name | Value | Parameter |\n| PPT FAST | 20.000 | fast-limit |\n"
+
+
+def test_non_gpd_preserves_nonzero_exit_semantics():
+    fake = FakeRun(info=_unreadable_info(), rc=1)
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w is None
+    assert "readback unavailable" in result.detail
+    assert sum(1 for argv, _kwargs in fake.calls if "--stapm-limit" in argv) == 2
+
+
+def test_gpd_primary_success_never_uses_power_only():
+    fake = ScriptedRun(write_rcs=[0], infos=[_stapm(20)])
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True and result.applied_w == 20
+    assert len(fake.writes) == 1
+    assert "--tctl-temp" in fake.writes[0]
+
+
+def test_gpd_primary_zero_with_no_readback_keeps_historical_reassert():
+    fake = ScriptedRun(
+        write_rcs=[0, 0],
+        infos=[_unreadable_info(), _unreadable_info()],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True and result.applied_w is None
+    assert len(fake.writes) == 2
+    assert all("--tctl-temp" in write for write in fake.writes)
+    assert "readback unavailable" in result.detail
+
+
+def test_gpd_primary_nonzero_with_confirmed_readback_succeeds_without_retry():
+    fake = ScriptedRun(write_rcs=[1], infos=[_stapm(20)])
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True and result.applied_w == 20
+    assert len(fake.writes) == 1
+    assert "variant=primary" in result.detail
+    assert "primary_exit=1" in result.detail
+    assert "readback=confirmed" in result.detail
+
+
+def test_gpd_retries_power_only_after_primary_failure():
+    fake = ScriptedRun(
+        write_rcs=[1, 0],
+        infos=[_unreadable_info(), _stapm(20)],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True and result.applied_w == 20
+    assert len(fake.writes) == 2
+    assert "--tctl-temp" in fake.writes[0]
+    assert fake.writes[1] == [
+        "/usr/bin/ryzenadj",
+        "--stapm-limit", "20000",
+        "--fast-limit", "20000",
+        "--slow-limit", "20000",
+    ]
+    assert "variant=power-only" in result.detail
+
+
+def test_gpd_nonzero_info_exit_cannot_confirm_primary_write():
+    fake = ScriptedRun(
+        write_rcs=[1, 0],
+        infos=[_stapm(20), _stapm(20)],
+        info_rcs=[1, 0],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True and result.applied_w == 20
+    assert len(fake.writes) == 2
+    assert "variant=power-only" in result.detail
+
+
+def test_gpd_power_only_success_without_readback_is_unverifiable():
+    fake = ScriptedRun(
+        write_rcs=[1, 0],
+        infos=[_unreadable_info(), _unreadable_info()],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w is None
+    assert len(fake.writes) == 2
+    assert "variant=power-only" in result.detail
+    assert "readback=unavailable" in result.detail
+
+
+def test_gpd_power_only_nonzero_is_rejected_without_raw_output():
+    fake = ScriptedRun(
+        write_rcs=[1, 2],
+        infos=[_unreadable_info(), _unreadable_info()],
+        write_stdout="/home/private-user/device-serial",
+        write_stderr="hostname=private-host",
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w is None
+    assert "primary_exit=1" in result.detail
+    assert "exit=2" in result.detail
+    assert "private-user" not in result.detail
+    assert "device-serial" not in result.detail
+    assert "private-host" not in result.detail
+
+
+def test_gpd_power_only_nonzero_rejects_even_if_readback_matches():
+    fake = ScriptedRun(
+        write_rcs=[1, 2],
+        infos=[_unreadable_info(), _stapm(20)],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w == 20
+    assert "exit=2" in result.detail
+    assert "readback=confirmed" in result.detail
+
+
+def test_gpd_power_only_mismatch_reports_real_value():
+    fake = ScriptedRun(
+        write_rcs=[1, 0],
+        infos=[_stapm(10), _stapm(12)],
+    )
+    backend = RyzenadjBackend(
+        FALLBACK,
+        resolve=lambda: "/usr/bin/ryzenadj",
+        runner=fake,
+        power_only_retry=True,
+    )
+
+    result = backend.set_tdp(20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w == 12
+    assert "readback=mismatch" in result.detail
 
 
 def test_set_tdp_not_ok_when_write_clamped_to_other_value():


### PR DESCRIPTION
## Summary

- scope the workaround strictly to the reported GPD Win Mini 2025 (`GPD` / `G1617-02` / `gpd_win_mini_2025`)
- retry RyzenAdj once with power rails only when the normal command fails and its result cannot be confirmed
- recover the historical `gpd_fan` path once per plugin lifetime when the complete `gpdfan` hwmon ABI is missing
- keep firmware-auto/unsupported behavior when recovery is unavailable or incomplete, with bounded sanitized diagnostics

## Compatibility and safety

- machines outside the exact DMI/profile gate keep the existing TDP and fan paths unchanged
- older kernels that already expose the complete `gpdfan` ABI keep using the existing generic-PWM backend without loading anything
- the recovery path does not write PWM, access raw EC ports, remove modules, or install kernel components
- the existing TDP reconciler, profile persistence, RPC contract, and UI are unchanged
- this is defensive support without physical access to the reported machine; a follow-up report will retain enough sanitized detail to distinguish the remaining kernel/firmware outcomes

## Verification

- 1352 pytest tests passed
- 7086 Vitest tests passed
- Ruff passed
- TypeScript typecheck passed
- Rollup API production build passed
- `git diff --check` and public-surface hygiene passed
- regression crosscheck covered exact-model old/new kernel paths plus unrelated AMD, Intel, Steam Deck, and generic fallbacks

Refs #316