### PR TITLE
feat(windows): add verified system volume control

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -1,8 +1,8 @@
 # Panel de Control para Xbox Game Bar
 
-La versión de Windows es experimental. La primera vertical ofrece un widget x64
-para Xbox Game Bar y un proceso auxiliar empaquetado que expone únicamente
-telemetría de lectura.
+La versión de Windows es experimental. Ofrece un widget x64 para Xbox Game Bar
+y un proceso auxiliar empaquetado con telemetría de lectura y ajuste verificado
+del volumen del sistema.
 
 ## Alcance inicial
 
@@ -10,18 +10,29 @@ telemetría de lectura.
 - Batería y estado de alimentación mediante la API de energía de Windows.
 - Carga y temperatura de CPU/GPU cuando LibreHardwareMonitor publica un sensor
   compatible.
+- Lectura y ajuste del volumen principal del dispositivo de audio predeterminado
+  mediante Windows Core Audio.
 - Estados explícitos para dato disponible, no disponible, permiso requerido y
-  fallo de lectura.
-- Comunicación local entre procesos mediante una tubería con nombre limitada al
-  mismo paquete.
+  fallo de lectura o control.
+- Canal de control independiente, limitado al paquete y al usuario actual, para
+  que una lectura lenta de hardware no bloquee el volumen.
+
+El volumen se confirma leyendo de nuevo el mismo endpoint después de cada
+escritura. Si no puede verificarse, el widget lo indica y no informa el cambio
+como aplicado. No hay reintento de una escritura cuyo resultado sea incierto.
+Tampoco hay control de mute, persistencia ni intervención sobre sesiones que
+usen audio en modo exclusivo.
 
 No se escriben valores de TDP, ventiladores, GPU, batería ni firmware. Un campo
-sin lectura verificable aparece como `Sin datos`; nunca se sustituye por un valor
-inventado.
+sin lectura verificable aparece como `Sin datos`; nunca se sustituye por un
+valor inventado.
 
 LibreHardwareMonitor solo se inicializa cuando el DMI coincide con la ROG Xbox
 Ally X. En cualquier otro equipo, el companion conserva únicamente la lectura
 estándar de batería/AC y marca el resto como dispositivo no compatible.
+El volumen no depende de esa identificación: se habilita por la capacidad
+estándar de Windows y por la disponibilidad de un endpoint de audio
+predeterminado.
 
 ## Compilar
 
@@ -44,9 +55,10 @@ El paquete generado no está firmado. Para una instalación reproducible fuera d
 Visual Studio hace falta firmarlo con un certificado cuya identidad coincida con
 el `Publisher` del manifiesto.
 
-## Prueba física obligatoria
+## Validación física pendiente
 
-Antes de declarar una lectura compatible en una ROG Xbox Ally X RC73XA:
+Esta validación no bloquea el desarrollo automatizado, pero sí cualquier
+declaración de compatibilidad física. En una ROG Xbox Ally X RC73XA:
 
 1. Instalar el paquete y abrir Xbox Game Bar con `Win+G`.
 2. Abrir **Panel de Control** desde el menú de widgets.
@@ -54,9 +66,15 @@ Antes de declarar una lectura compatible en una ROG Xbox Ally X RC73XA:
 4. Comparar fabricante y producto con `Win32_ComputerSystem`.
 5. Registrar qué lecturas aparecen, su proveedor y sus rangos durante batería,
    corriente, reposo y reanudación.
-6. Confirmar que cerrar el widget hace terminar el proceso auxiliar tras su
+6. Ajustar el volumen con teclado y mando, y comparar el valor mostrado con el
+   mezclador de Windows.
+7. Cambiar el dispositivo de audio predeterminado y confirmar que la siguiente
+   lectura usa el endpoint nuevo sin reaplicar valores anteriores.
+8. Comprobar que una aplicación en modo exclusivo no produce un falso estado de
+   éxito.
+9. Confirmar que cerrar el widget hace terminar el proceso auxiliar tras su
    periodo de inactividad.
-7. Confirmar que un sensor ausente aparece como `Sin datos` y que un valor real
+10. Confirmar que un sensor ausente aparece como `Sin datos` y que un valor real
    de cero se conserva.
 
 Hasta completar esta prueba, las lecturas de CPU y GPU son candidatas

--- a/windows/src/PanelDeControl.Core/Controls/ControlStatus.cs
+++ b/windows/src/PanelDeControl.Core/Controls/ControlStatus.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Serialization;
+
+namespace PanelDeControl.Core.Controls;
+
+[DataContract]
+public enum ControlStatus
+{
+    [EnumMember]
+    Available = 0,
+
+    [EnumMember]
+    Applied = 1,
+
+    [EnumMember]
+    Unavailable = 2,
+
+    [EnumMember]
+    PermissionRequired = 3,
+
+    [EnumMember]
+    Rejected = 4,
+
+    [EnumMember]
+    Unverifiable = 5,
+
+    [EnumMember]
+    Fault = 6,
+}

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
@@ -1,0 +1,77 @@
+using System.Runtime.Serialization;
+
+namespace PanelDeControl.Core.Controls;
+
+[DataContract]
+public enum VolumeControlOperation
+{
+    [EnumMember]
+    Get = 0,
+
+    [EnumMember]
+    Set = 1,
+}
+
+[DataContract]
+public sealed class VolumeControlRequest
+{
+    private VolumeControlRequest()
+    {
+    }
+
+    private VolumeControlRequest(
+        VolumeControlOperation operation,
+        double? requestedLevel)
+    {
+        Operation = operation;
+        RequestedLevel = requestedLevel;
+    }
+
+    [DataMember(Name = "operation", Order = 1)]
+    public VolumeControlOperation Operation { get; private set; }
+
+    [DataMember(Name = "requested_level", Order = 2, EmitDefaultValue = false)]
+    public double? RequestedLevel { get; private set; }
+
+    public static VolumeControlRequest Get()
+    {
+        return new VolumeControlRequest(VolumeControlOperation.Get, null);
+    }
+
+    public static VolumeControlRequest Set(double requestedLevel)
+    {
+        if (!IsValidLevel(requestedLevel))
+        {
+            throw new ArgumentOutOfRangeException(nameof(requestedLevel));
+        }
+
+        return new VolumeControlRequest(VolumeControlOperation.Set, requestedLevel);
+    }
+
+    internal void Validate()
+    {
+        if (!Enum.IsDefined(typeof(VolumeControlOperation), Operation))
+        {
+            throw new InvalidDataException("Volume operation is invalid.");
+        }
+
+        if (Operation == VolumeControlOperation.Get && RequestedLevel.HasValue)
+        {
+            throw new InvalidDataException("A get request cannot include a requested level.");
+        }
+
+        if (Operation == VolumeControlOperation.Set &&
+            (!RequestedLevel.HasValue || !IsValidLevel(RequestedLevel.Value)))
+        {
+            throw new InvalidDataException("A set request requires a level from zero to one.");
+        }
+    }
+
+    private static bool IsValidLevel(double level)
+    {
+        return !double.IsNaN(level) &&
+            !double.IsInfinity(level) &&
+            level >= 0 &&
+            level <= 1;
+    }
+}

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
@@ -1,0 +1,214 @@
+using System.Runtime.Serialization;
+
+namespace PanelDeControl.Core.Controls;
+
+[DataContract]
+public sealed class VolumeControlResponse
+{
+    private VolumeControlResponse()
+    {
+    }
+
+    private VolumeControlResponse(
+        ControlStatus status,
+        double? requestedLevel,
+        double? observedLevel,
+        string? errorCode)
+    {
+        Status = status;
+        RequestedLevel = requestedLevel;
+        ObservedLevel = observedLevel;
+        ErrorCode = errorCode;
+    }
+
+    [DataMember(Name = "status", Order = 1)]
+    public ControlStatus Status { get; private set; }
+
+    [DataMember(Name = "requested_level", Order = 2, EmitDefaultValue = false)]
+    public double? RequestedLevel { get; private set; }
+
+    [DataMember(Name = "observed_level", Order = 3, EmitDefaultValue = false)]
+    public double? ObservedLevel { get; private set; }
+
+    [DataMember(Name = "error_code", Order = 4, EmitDefaultValue = false)]
+    public string? ErrorCode { get; private set; }
+
+    public static VolumeControlResponse Applied(
+        double requestedLevel,
+        double observedLevel)
+    {
+        return new VolumeControlResponse(
+            ControlStatus.Applied,
+            RequireLevel(requestedLevel, nameof(requestedLevel)),
+            RequireLevel(observedLevel, nameof(observedLevel)),
+            null);
+    }
+
+    public static VolumeControlResponse Available(double observedLevel)
+    {
+        return new VolumeControlResponse(
+            ControlStatus.Available,
+            null,
+            RequireLevel(observedLevel, nameof(observedLevel)),
+            null);
+    }
+
+    public static VolumeControlResponse Unavailable(string errorCode)
+    {
+        return Failure(ControlStatus.Unavailable, errorCode);
+    }
+
+    public static VolumeControlResponse PermissionRequired(string errorCode)
+    {
+        return Failure(ControlStatus.PermissionRequired, errorCode);
+    }
+
+    public static VolumeControlResponse Rejected(string errorCode)
+    {
+        return Failure(ControlStatus.Rejected, errorCode);
+    }
+
+    public static VolumeControlResponse Unverifiable(
+        double requestedLevel,
+        double? observedLevel,
+        string errorCode)
+    {
+        return new VolumeControlResponse(
+            ControlStatus.Unverifiable,
+            RequireLevel(requestedLevel, nameof(requestedLevel)),
+            observedLevel.HasValue
+                ? RequireLevel(observedLevel.Value, nameof(observedLevel))
+                : null,
+            RequireText(errorCode, nameof(errorCode)));
+    }
+
+    public static VolumeControlResponse Fault(string errorCode)
+    {
+        return Failure(ControlStatus.Fault, errorCode);
+    }
+
+    internal void Validate()
+    {
+        if (!Enum.IsDefined(typeof(ControlStatus), Status))
+        {
+            throw new InvalidDataException("Volume control status is invalid.");
+        }
+
+        switch (Status)
+        {
+            case ControlStatus.Available:
+                RequireNoRequestedLevel();
+                RequireObservedLevel();
+                RequireNoError();
+                break;
+            case ControlStatus.Applied:
+                RequireRequestedLevel();
+                RequireObservedLevel();
+                RequireNoError();
+                break;
+            case ControlStatus.Unavailable:
+            case ControlStatus.PermissionRequired:
+            case ControlStatus.Rejected:
+            case ControlStatus.Fault:
+                RequireNoRequestedLevel();
+                RequireNoObservedLevel();
+                RequireError();
+                break;
+            case ControlStatus.Unverifiable:
+                RequireRequestedLevel();
+                if (ObservedLevel.HasValue)
+                {
+                    RequireLevel(ObservedLevel.Value, nameof(ObservedLevel));
+                }
+
+                RequireError();
+                break;
+        }
+    }
+
+    private static VolumeControlResponse Failure(
+        ControlStatus status,
+        string errorCode)
+    {
+        return new VolumeControlResponse(
+            status,
+            null,
+            null,
+            RequireText(errorCode, nameof(errorCode)));
+    }
+
+    private void RequireRequestedLevel()
+    {
+        if (!RequestedLevel.HasValue)
+        {
+            throw new InvalidDataException("Requested volume level is missing.");
+        }
+
+        RequireLevel(RequestedLevel.Value, nameof(RequestedLevel));
+    }
+
+    private void RequireObservedLevel()
+    {
+        if (!ObservedLevel.HasValue)
+        {
+            throw new InvalidDataException("Observed volume level is missing.");
+        }
+
+        RequireLevel(ObservedLevel.Value, nameof(ObservedLevel));
+    }
+
+    private void RequireNoRequestedLevel()
+    {
+        if (RequestedLevel.HasValue)
+        {
+            throw new InvalidDataException("Unexpected requested volume level.");
+        }
+    }
+
+    private void RequireNoObservedLevel()
+    {
+        if (ObservedLevel.HasValue)
+        {
+            throw new InvalidDataException("Unexpected observed volume level.");
+        }
+    }
+
+    private void RequireError()
+    {
+        if (string.IsNullOrWhiteSpace(ErrorCode))
+        {
+            throw new InvalidDataException("Volume error code is missing.");
+        }
+    }
+
+    private void RequireNoError()
+    {
+        if (!string.IsNullOrWhiteSpace(ErrorCode))
+        {
+            throw new InvalidDataException("Unexpected volume error code.");
+        }
+    }
+
+    private static double RequireLevel(double level, string parameterName)
+    {
+        if (double.IsNaN(level) ||
+            double.IsInfinity(level) ||
+            level < 0 ||
+            level > 1)
+        {
+            throw new ArgumentOutOfRangeException(parameterName);
+        }
+
+        return level;
+    }
+
+    private static string RequireText(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value must not be empty.", parameterName);
+        }
+
+        return value;
+    }
+}

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlWireCodec.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlWireCodec.cs
@@ -1,0 +1,74 @@
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace PanelDeControl.Core.Controls;
+
+public static class VolumeControlWireCodec
+{
+    private static readonly DataContractJsonSerializer RequestSerializer =
+        new(typeof(VolumeControlRequest));
+    private static readonly DataContractJsonSerializer ResponseSerializer =
+        new(typeof(VolumeControlResponse));
+
+    public static string SerializeRequest(VolumeControlRequest request)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        request.Validate();
+        using var stream = new MemoryStream();
+        RequestSerializer.WriteObject(stream, request);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    public static VolumeControlRequest DeserializeRequest(string payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            throw new ArgumentException("Payload must not be empty.", nameof(payload));
+        }
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        var request = RequestSerializer.ReadObject(stream) as VolumeControlRequest;
+        if (request is null)
+        {
+            throw new InvalidDataException("Control payload did not contain a request.");
+        }
+
+        request.Validate();
+        return request;
+    }
+
+    public static string SerializeResponse(VolumeControlResponse response)
+    {
+        if (response is null)
+        {
+            throw new ArgumentNullException(nameof(response));
+        }
+
+        response.Validate();
+        using var stream = new MemoryStream();
+        ResponseSerializer.WriteObject(stream, response);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    public static VolumeControlResponse DeserializeResponse(string payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            throw new ArgumentException("Payload must not be empty.", nameof(payload));
+        }
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        var response = ResponseSerializer.ReadObject(stream) as VolumeControlResponse;
+        if (response is null)
+        {
+            throw new InvalidDataException("Control payload did not contain a response.");
+        }
+
+        response.Validate();
+        return response;
+    }
+}

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
@@ -50,7 +50,7 @@
                 Height="44"
                 Padding="0"
                 IsTabStop="True"
-                AutomationProperties.Name="Actualizar telemetría"
+                AutomationProperties.Name="Actualizar telemetría y volumen"
                 Click="RefreshButton_Click"
                 CornerRadius="12"
                 Background="#FF313A48"
@@ -104,6 +104,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -137,8 +138,53 @@
                 </Border>
 
                 <Border
-                    x:Name="CpuCard"
+                    x:Name="VolumeCard"
                     Grid.Row="1"
+                    Grid.ColumnSpan="2"
+                    Margin="0,12,0,0"
+                    Padding="18"
+                    Background="{StaticResource CardBackgroundBrush}"
+                    CornerRadius="16">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="VOLUMEN DEL SISTEMA" Style="{StaticResource TelemetryLabelStyle}" />
+                            <TextBlock
+                                x:Name="VolumeValue"
+                                Grid.Column="1"
+                                Text="—"
+                                FontSize="18"
+                                FontWeight="SemiBold"
+                                Foreground="White" />
+                        </Grid>
+                        <Slider
+                            x:Name="VolumeSlider"
+                            Margin="0,12,0,0"
+                            Minimum="0"
+                            Maximum="100"
+                            StepFrequency="5"
+                            SmallChange="5"
+                            IsEnabled="False"
+                            IsTabStop="True"
+                            AutomationProperties.Name="Volumen del sistema"
+                            AutomationProperties.HelpText="Ajusta el volumen del dispositivo de audio predeterminado"
+                            ValueChanged="VolumeSlider_ValueChanged" />
+                        <TextBlock
+                            x:Name="VolumeStatus"
+                            Margin="0,6,0,0"
+                            Text="Comprobando audio predeterminado…"
+                            FontSize="12"
+                            Foreground="#FF8591A3"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </Border>
+
+                <Border
+                    x:Name="CpuCard"
+                    Grid.Row="2"
                     Grid.Column="0"
                     Margin="0,12,6,0"
                     Padding="18"
@@ -153,7 +199,7 @@
 
                 <Border
                     x:Name="GpuCard"
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Grid.Column="1"
                     Margin="6,12,0,0"
                     Padding="18"
@@ -171,7 +217,7 @@
         <TextBlock
             Grid.Row="3"
             Margin="0,16,0,0"
-            Text="Solo lectura · Los controles de potencia y ventiladores llegarán después de la validación física."
+            Text="Volumen del sistema con verificación · Telemetría experimental de solo lectura · Sin control de potencia ni ventiladores."
             FontSize="11"
             Foreground="#FF6F7B8C"
             TextWrapping="Wrap" />

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Gaming.XboxGameBar;
+using PanelDeControl.Core.Controls;
 using PanelDeControl.Core.Telemetry;
 using Windows.UI;
 using Windows.UI.Core;
@@ -24,8 +26,14 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         Interval = TimeSpan.FromSeconds(2),
     };
     private readonly TelemetryClient telemetryClient = new();
+    private readonly VolumeControlClient volumeClient = new();
     private XboxGameBarWidget? gameBarWidget;
+    private CancellationTokenSource? volumeDebounce;
+    private long volumeGeneration;
     private bool refreshInProgress;
+    private bool applyingVolumeReadback;
+    private bool volumeReady;
+    private bool volumeWritePending;
     private bool disposed;
 
     public ControlPanelWidget()
@@ -56,6 +64,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
 
         disposed = true;
         refreshTimer.Stop();
+        CancelPendingVolumeWrite();
         refreshTimer.Tick -= OnRefreshTimerTick;
         if (gameBarWidget is not null)
         {
@@ -79,6 +88,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
     private void OnUnloaded(object sender, RoutedEventArgs args)
     {
         refreshTimer.Stop();
+        CancelPendingVolumeWrite();
     }
 
     private async void OnRefreshTimerTick(object sender, object args)
@@ -109,6 +119,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         else
         {
             refreshTimer.Stop();
+            CancelPendingVolumeWrite();
         }
     }
 
@@ -127,10 +138,18 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         refreshInProgress = true;
         try
         {
-            var snapshot = await telemetryClient.GetSnapshotAsync();
+            var volumeRefreshGeneration = volumeGeneration;
+            var snapshotTask = telemetryClient.GetSnapshotAsync();
+            var volumeTask = volumeClient.GetAsync();
+            await Task.WhenAll(snapshotTask, volumeTask);
             if (!disposed)
             {
-                ApplySnapshot(snapshot);
+                ApplySnapshot(snapshotTask.Result);
+                if (!volumeWritePending &&
+                    volumeRefreshGeneration == volumeGeneration)
+                {
+                    ApplyVolumeResponse(volumeTask.Result);
+                }
             }
         }
         finally
@@ -152,16 +171,125 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
 
         var available = snapshot.Readings.Any(
             reading => reading.Status == ReadingStatus.Available);
-        var unsupported = snapshot.Readings.Any(
-            reading => reading.ErrorCode == "device_not_supported");
-        ConnectionStatus.Text = unsupported
-            ? "Dispositivo no compatible"
-            : available
-                ? "Telemetría Windows conectada"
-                : StatusText(snapshot.Readings.FirstOrDefault());
-        ConnectionDot.Fill = available && !unsupported
+        ConnectionStatus.Text = available
+            ? "Telemetría Windows conectada"
+            : StatusText(snapshot.Readings.FirstOrDefault());
+        ConnectionDot.Fill = available
             ? ConnectedBrush
             : DisconnectedBrush;
+    }
+
+    private async void VolumeSlider_ValueChanged(
+        object sender,
+        Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs args)
+    {
+        if (disposed || applyingVolumeReadback || !volumeReady)
+        {
+            return;
+        }
+
+        VolumeValue.Text = $"{Math.Round(args.NewValue):0} %";
+        VolumeStatus.Text = "Aplicando y verificando…";
+
+        volumeDebounce?.Cancel();
+        volumeDebounce?.Dispose();
+        var debounce = new CancellationTokenSource();
+        volumeDebounce = debounce;
+        var generation = ++volumeGeneration;
+        volumeWritePending = true;
+
+        try
+        {
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(150),
+                debounce.Token);
+            var response = await volumeClient.SetAsync(args.NewValue / 100);
+            if (!disposed && generation == volumeGeneration)
+            {
+                ApplyVolumeResponse(response);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            if (generation == volumeGeneration)
+            {
+                volumeWritePending = false;
+                volumeDebounce = null;
+                debounce.Dispose();
+            }
+        }
+    }
+
+    private void ApplyVolumeResponse(VolumeControlResponse response)
+    {
+        switch (response.Status)
+        {
+            case ControlStatus.Available:
+            case ControlStatus.Applied:
+                ApplyObservedVolume(response.ObservedLevel!.Value);
+                VolumeSlider.IsEnabled = true;
+                volumeReady = true;
+                VolumeStatus.Text = response.Status == ControlStatus.Applied
+                    ? "Cambio aplicado y verificado"
+                    : "Audio predeterminado disponible";
+                break;
+            case ControlStatus.Unverifiable:
+                if (response.ObservedLevel.HasValue)
+                {
+                    ApplyObservedVolume(response.ObservedLevel.Value);
+                }
+
+                VolumeSlider.IsEnabled = true;
+                volumeReady = true;
+                VolumeStatus.Text = "No se pudo verificar el cambio";
+                break;
+            case ControlStatus.PermissionRequired:
+                DisableVolumeControl("Windows requiere permiso para controlar el audio");
+                break;
+            case ControlStatus.Unavailable:
+                DisableVolumeControl("No hay un dispositivo de audio predeterminado");
+                break;
+            case ControlStatus.Rejected:
+                VolumeStatus.Text = "Windows rechazó el cambio";
+                break;
+            default:
+                DisableVolumeControl("No se pudo conectar con el control de audio");
+                break;
+        }
+    }
+
+    private void ApplyObservedVolume(double level)
+    {
+        applyingVolumeReadback = true;
+        try
+        {
+            var percentage = Math.Round(level * 100);
+            VolumeSlider.Value = percentage;
+            VolumeValue.Text = $"{percentage:0} %";
+        }
+        finally
+        {
+            applyingVolumeReadback = false;
+        }
+    }
+
+    private void DisableVolumeControl(string status)
+    {
+        volumeReady = false;
+        VolumeSlider.IsEnabled = false;
+        VolumeStatus.Text = status;
+    }
+
+    private void CancelPendingVolumeWrite()
+    {
+        volumeGeneration++;
+        volumeWritePending = false;
+        volumeDebounce?.Cancel();
+        volumeDebounce?.Dispose();
+        volumeDebounce = null;
     }
 
     private static string Format(

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -171,10 +171,14 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
 
         var available = snapshot.Readings.Any(
             reading => reading.Status == ReadingStatus.Available);
-        ConnectionStatus.Text = available
-            ? "Telemetría Windows conectada"
-            : StatusText(snapshot.Readings.FirstOrDefault());
-        ConnectionDot.Fill = available
+        var unsupported = snapshot.Readings.Any(
+            reading => reading.ErrorCode == "device_not_supported");
+        ConnectionStatus.Text = unsupported
+            ? "Dispositivo no compatible"
+            : available
+                ? "Telemetría Windows conectada"
+                : StatusText(snapshot.Readings.FirstOrDefault());
+        ConnectionDot.Fill = available && !unsupported
             ? ConnectedBrush
             : DisconnectedBrush;
     }

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -141,14 +141,15 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
             var volumeRefreshGeneration = volumeGeneration;
             var snapshotTask = telemetryClient.GetSnapshotAsync();
             var volumeTask = volumeClient.GetAsync();
-            await Task.WhenAll(snapshotTask, volumeTask);
+            var snapshot = await snapshotTask;
+            var volume = await volumeTask;
             if (!disposed)
             {
-                ApplySnapshot(snapshotTask.Result);
+                ApplySnapshot(snapshot);
                 if (!volumeWritePending &&
                     volumeRefreshGeneration == volumeGeneration)
                 {
-                    ApplyVolumeResponse(volumeTask.Result);
+                    ApplyVolumeResponse(volume);
                 }
             }
         }

--- a/windows/src/PanelDeControl.GameBar/HardwareBrokerLauncher.cs
+++ b/windows/src/PanelDeControl.GameBar/HardwareBrokerLauncher.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
+
+namespace PanelDeControl.GameBar;
+
+internal static class HardwareBrokerLauncher
+{
+    private static readonly object SyncRoot = new();
+    private static Task? launchInProgress;
+
+    public static Task EnsureStartedAsync()
+    {
+        lock (SyncRoot)
+        {
+            launchInProgress ??= LaunchAndResetAsync();
+            return launchInProgress;
+        }
+    }
+
+    private static async Task LaunchAndResetAsync()
+    {
+        try
+        {
+            await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync(
+                "HardwareBroker");
+            await Task.Delay(250);
+        }
+        finally
+        {
+            lock (SyncRoot)
+            {
+                launchInProgress = null;
+            }
+        }
+    }
+}

--- a/windows/src/PanelDeControl.GameBar/Package.appxmanifest
+++ b/windows/src/PanelDeControl.GameBar/Package.appxmanifest
@@ -43,7 +43,7 @@
         DisplayName="Panel de Control"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="Telemetría experimental para handhelds desde Xbox Game Bar"
+        Description="Volumen del sistema y telemetría experimental desde Xbox Game Bar"
         BackgroundColor="#171b22">
         <uap:SplashScreen Image="Assets\SplashScreen.png" BackgroundColor="#171b22" />
       </uap:VisualElements>
@@ -53,7 +53,7 @@
             Name="microsoft.gameBarUIExtension"
             Id="PanelDeControl"
             DisplayName="Panel de Control"
-            Description="Telemetría experimental del handheld"
+            Description="Volumen del sistema y telemetría experimental"
             PublicFolder="GameBar\PanelDeControl">
             <uap3:Properties>
               <GameBarWidget Type="Standard">

--- a/windows/src/PanelDeControl.GameBar/PanelDeControl.GameBar.csproj
+++ b/windows/src/PanelDeControl.GameBar/PanelDeControl.GameBar.csproj
@@ -52,7 +52,9 @@
     <Compile Include="ControlPanelWidget.xaml.cs">
       <DependentUpon>ControlPanelWidget.xaml</DependentUpon>
     </Compile>
+    <Compile Include="HardwareBrokerLauncher.cs" />
     <Compile Include="TelemetryClient.cs" />
+    <Compile Include="VolumeControlClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 

--- a/windows/src/PanelDeControl.GameBar/TelemetryClient.cs
+++ b/windows/src/PanelDeControl.GameBar/TelemetryClient.cs
@@ -4,7 +4,6 @@ using System.IO.Pipes;
 using System.Text;
 using System.Threading.Tasks;
 using PanelDeControl.Core.Telemetry;
-using Windows.ApplicationModel;
 
 namespace PanelDeControl.GameBar;
 
@@ -24,9 +23,7 @@ public sealed class TelemetryClient
 
         try
         {
-            await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync(
-                "HardwareBroker");
-            await Task.Delay(250);
+            await HardwareBrokerLauncher.EnsureStartedAsync();
         }
         catch
         {

--- a/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
+++ b/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
@@ -32,7 +32,7 @@ public sealed class VolumeControlClient
             return attempt.Response;
         }
 
-        if (!attempt.RequestSent)
+        if (!attempt.RequestWriteStarted)
         {
             try
             {
@@ -52,7 +52,7 @@ public sealed class VolumeControlClient
 
         return TransportFailure(
             request,
-            attempt.RequestSent
+            attempt.RequestWriteStarted
                 ? "control_response_unavailable"
                 : "broker_unreachable");
     }
@@ -60,7 +60,7 @@ public sealed class VolumeControlClient
     private static async Task<TransportAttempt> TrySendAsync(
         VolumeControlRequest request)
     {
-        var requestSent = false;
+        var requestWriteStarted = false;
         try
         {
             using var pipe = new NamedPipeClientStream(
@@ -84,29 +84,29 @@ public sealed class VolumeControlClient
                 AutoFlush = true,
             };
 
+            requestWriteStarted = true;
             await writer.WriteLineAsync(
                 VolumeControlWireCodec.SerializeRequest(request));
-            requestSent = true;
 
             var readTask = reader.ReadLineAsync();
             if (await Task.WhenAny(readTask, Task.Delay(ResponseTimeout)) != readTask)
             {
-                return new TransportAttempt(null, requestSent);
+                return new TransportAttempt(null, requestWriteStarted);
             }
 
             var payload = await readTask;
             if (string.IsNullOrWhiteSpace(payload))
             {
-                return new TransportAttempt(null, requestSent);
+                return new TransportAttempt(null, requestWriteStarted);
             }
 
             return new TransportAttempt(
                 VolumeControlWireCodec.DeserializeResponse(payload),
-                requestSent);
+                requestWriteStarted);
         }
         catch
         {
-            return new TransportAttempt(null, requestSent);
+            return new TransportAttempt(null, requestWriteStarted);
         }
     }
 
@@ -126,14 +126,14 @@ public sealed class VolumeControlClient
     {
         public TransportAttempt(
             VolumeControlResponse? response,
-            bool requestSent)
+            bool requestWriteStarted)
         {
             Response = response;
-            RequestSent = requestSent;
+            RequestWriteStarted = requestWriteStarted;
         }
 
         public VolumeControlResponse? Response { get; }
 
-        public bool RequestSent { get; }
+        public bool RequestWriteStarted { get; }
     }
 }

--- a/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
+++ b/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading.Tasks;
+using PanelDeControl.Core.Controls;
+
+namespace PanelDeControl.GameBar;
+
+public sealed class VolumeControlClient
+{
+    private const string PipeName = @"LOCAL\PanelDeControl.Control";
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(5);
+
+    public Task<VolumeControlResponse> GetAsync()
+    {
+        return SendAsync(VolumeControlRequest.Get());
+    }
+
+    public Task<VolumeControlResponse> SetAsync(double requestedLevel)
+    {
+        return SendAsync(VolumeControlRequest.Set(requestedLevel));
+    }
+
+    private static async Task<VolumeControlResponse> SendAsync(
+        VolumeControlRequest request)
+    {
+        var attempt = await TrySendAsync(request);
+        if (attempt.Response is not null)
+        {
+            return attempt.Response;
+        }
+
+        if (!attempt.RequestSent)
+        {
+            try
+            {
+                await HardwareBrokerLauncher.EnsureStartedAsync();
+            }
+            catch
+            {
+                return TransportFailure(request, "broker_launch_failed");
+            }
+
+            attempt = await TrySendAsync(request);
+            if (attempt.Response is not null)
+            {
+                return attempt.Response;
+            }
+        }
+
+        return TransportFailure(
+            request,
+            attempt.RequestSent
+                ? "control_response_unavailable"
+                : "broker_unreachable");
+    }
+
+    private static async Task<TransportAttempt> TrySendAsync(
+        VolumeControlRequest request)
+    {
+        var requestSent = false;
+        try
+        {
+            using var pipe = new NamedPipeClientStream(
+                ".",
+                PipeName,
+                PipeDirection.InOut,
+                PipeOptions.Asynchronous);
+            await pipe.ConnectAsync((int)ConnectTimeout.TotalMilliseconds);
+            using var reader = new StreamReader(
+                pipe,
+                new UTF8Encoding(false),
+                false,
+                256,
+                leaveOpen: true);
+            using var writer = new StreamWriter(
+                pipe,
+                new UTF8Encoding(false),
+                256,
+                leaveOpen: true)
+            {
+                AutoFlush = true,
+            };
+
+            await writer.WriteLineAsync(
+                VolumeControlWireCodec.SerializeRequest(request));
+            requestSent = true;
+
+            var readTask = reader.ReadLineAsync();
+            if (await Task.WhenAny(readTask, Task.Delay(ResponseTimeout)) != readTask)
+            {
+                return new TransportAttempt(null, requestSent);
+            }
+
+            var payload = await readTask;
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return new TransportAttempt(null, requestSent);
+            }
+
+            return new TransportAttempt(
+                VolumeControlWireCodec.DeserializeResponse(payload),
+                requestSent);
+        }
+        catch
+        {
+            return new TransportAttempt(null, requestSent);
+        }
+    }
+
+    private static VolumeControlResponse TransportFailure(
+        VolumeControlRequest request,
+        string errorCode)
+    {
+        return request.Operation == VolumeControlOperation.Set
+            ? VolumeControlResponse.Unverifiable(
+                request.RequestedLevel!.Value,
+                null,
+                errorCode)
+            : VolumeControlResponse.Fault(errorCode);
+    }
+
+    private sealed class TransportAttempt
+    {
+        public TransportAttempt(
+            VolumeControlResponse? response,
+            bool requestSent)
+        {
+            Response = response;
+            RequestSent = requestSent;
+        }
+
+        public VolumeControlResponse? Response { get; }
+
+        public bool RequestSent { get; }
+    }
+}

--- a/windows/src/PanelDeControl.Hardware/CoreAudioEndpointVolumeProvider.cs
+++ b/windows/src/PanelDeControl.Hardware/CoreAudioEndpointVolumeProvider.cs
@@ -1,0 +1,240 @@
+using System.Runtime.InteropServices;
+
+namespace PanelDeControl.Hardware;
+
+public sealed class CoreAudioEndpointVolumeProvider : IAudioEndpointVolumeProvider
+{
+    private const uint ClassContextAll = 23;
+
+    public IAudioEndpointVolumeSession OpenDefaultRenderEndpoint()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        var enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
+        IMMDevice? endpointDevice = null;
+        object? endpointVolumeObject = null;
+        try
+        {
+            Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(
+                DataFlow.Render,
+                Role.Console,
+                out var resolvedEndpoint));
+            endpointDevice = resolvedEndpoint;
+
+            var endpointVolumeInterface = typeof(IAudioEndpointVolume).GUID;
+            Marshal.ThrowExceptionForHR(endpointDevice.Activate(
+                ref endpointVolumeInterface,
+                ClassContextAll,
+                IntPtr.Zero,
+                out endpointVolumeObject));
+
+            return new CoreAudioEndpointVolumeSession(
+                (IAudioEndpointVolume)endpointVolumeObject,
+                endpointDevice);
+        }
+        catch
+        {
+            ReleaseComObject(endpointVolumeObject);
+            ReleaseComObject(endpointDevice);
+            throw;
+        }
+        finally
+        {
+            ReleaseComObject(enumerator);
+        }
+    }
+
+    private static void ReleaseComObject(object? instance)
+    {
+        if (OperatingSystem.IsWindows() &&
+            instance is not null &&
+            Marshal.IsComObject(instance))
+        {
+            Marshal.FinalReleaseComObject(instance);
+        }
+    }
+
+    private sealed class CoreAudioEndpointVolumeSession :
+        IAudioEndpointVolumeSession
+    {
+        private IAudioEndpointVolume? endpointVolume;
+        private IMMDevice? endpointDevice;
+
+        public CoreAudioEndpointVolumeSession(
+            IAudioEndpointVolume endpointVolume,
+            IMMDevice endpointDevice)
+        {
+            this.endpointVolume = endpointVolume;
+            this.endpointDevice = endpointDevice;
+        }
+
+        public double GetMasterVolumeLevel()
+        {
+            var volume = endpointVolume ?? throw new ObjectDisposedException(
+                nameof(CoreAudioEndpointVolumeSession));
+            Marshal.ThrowExceptionForHR(
+                volume.GetMasterVolumeLevelScalar(out var level));
+            return level;
+        }
+
+        public void SetMasterVolumeLevel(double requestedLevel)
+        {
+            var volume = endpointVolume ?? throw new ObjectDisposedException(
+                nameof(CoreAudioEndpointVolumeSession));
+            Marshal.ThrowExceptionForHR(
+                volume.SetMasterVolumeLevelScalar(
+                    (float)requestedLevel,
+                    IntPtr.Zero));
+        }
+
+        public void Dispose()
+        {
+            ReleaseComObject(endpointVolume);
+            endpointVolume = null;
+            ReleaseComObject(endpointDevice);
+            endpointDevice = null;
+        }
+    }
+
+    private enum DataFlow
+    {
+        Render = 0,
+    }
+
+    private enum Role
+    {
+        Console = 0,
+    }
+
+    [ComImport]
+    [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+    private class MMDeviceEnumeratorComObject
+    {
+    }
+
+    [ComImport]
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDeviceEnumerator
+    {
+        [PreserveSig]
+        int EnumAudioEndpoints(
+            DataFlow dataFlow,
+            uint stateMask,
+            out IntPtr devices);
+
+        [PreserveSig]
+        int GetDefaultAudioEndpoint(
+            DataFlow dataFlow,
+            Role role,
+            out IMMDevice endpoint);
+
+        [PreserveSig]
+        int GetDevice(
+            [MarshalAs(UnmanagedType.LPWStr)] string id,
+            out IMMDevice device);
+
+        [PreserveSig]
+        int RegisterEndpointNotificationCallback(IntPtr client);
+
+        [PreserveSig]
+        int UnregisterEndpointNotificationCallback(IntPtr client);
+    }
+
+    [ComImport]
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDevice
+    {
+        [PreserveSig]
+        int Activate(
+            ref Guid interfaceId,
+            uint classContext,
+            IntPtr activationParameters,
+            [MarshalAs(UnmanagedType.IUnknown)] out object activatedInterface);
+
+        [PreserveSig]
+        int OpenPropertyStore(uint access, out IntPtr properties);
+
+        [PreserveSig]
+        int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+
+        [PreserveSig]
+        int GetState(out uint state);
+    }
+
+    // Method order and signatures must match the Endpointvolume.h COM vtable.
+    [ComImport]
+    [Guid("5CDF2C82-841E-4546-9722-0CF74078229A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IAudioEndpointVolume
+    {
+        [PreserveSig]
+        int RegisterControlChangeNotify(IntPtr notify);
+
+        [PreserveSig]
+        int UnregisterControlChangeNotify(IntPtr notify);
+
+        [PreserveSig]
+        int GetChannelCount(out uint channelCount);
+
+        [PreserveSig]
+        int SetMasterVolumeLevel(float level, IntPtr eventContext);
+
+        [PreserveSig]
+        int SetMasterVolumeLevelScalar(float level, IntPtr eventContext);
+
+        [PreserveSig]
+        int GetMasterVolumeLevel(out float level);
+
+        [PreserveSig]
+        int GetMasterVolumeLevelScalar(out float level);
+
+        [PreserveSig]
+        int SetChannelVolumeLevel(
+            uint channelNumber,
+            float level,
+            IntPtr eventContext);
+
+        [PreserveSig]
+        int SetChannelVolumeLevelScalar(
+            uint channelNumber,
+            float level,
+            IntPtr eventContext);
+
+        [PreserveSig]
+        int GetChannelVolumeLevel(uint channelNumber, out float level);
+
+        [PreserveSig]
+        int GetChannelVolumeLevelScalar(uint channelNumber, out float level);
+
+        [PreserveSig]
+        int SetMute(
+            [MarshalAs(UnmanagedType.Bool)] bool muted,
+            IntPtr eventContext);
+
+        [PreserveSig]
+        int GetMute([MarshalAs(UnmanagedType.Bool)] out bool muted);
+
+        [PreserveSig]
+        int GetVolumeStepInfo(out uint step, out uint stepCount);
+
+        [PreserveSig]
+        int VolumeStepUp(IntPtr eventContext);
+
+        [PreserveSig]
+        int VolumeStepDown(IntPtr eventContext);
+
+        [PreserveSig]
+        int QueryHardwareSupport(out uint hardwareSupportMask);
+
+        [PreserveSig]
+        int GetVolumeRange(
+            out float minimumDecibels,
+            out float maximumDecibels,
+            out float incrementDecibels);
+    }
+}

--- a/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
+++ b/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
@@ -1,0 +1,109 @@
+using System.Runtime.InteropServices;
+using PanelDeControl.Core.Controls;
+
+namespace PanelDeControl.Hardware;
+
+public sealed class CoreAudioVolumeController
+{
+    private const int HResultEndpointNotFound = unchecked((int)0x80070490);
+
+    private readonly IAudioEndpointVolumeProvider endpointProvider;
+
+    public CoreAudioVolumeController(IAudioEndpointVolumeProvider endpointProvider)
+    {
+        this.endpointProvider = endpointProvider;
+    }
+
+    public VolumeControlResponse Get()
+    {
+        try
+        {
+            using var endpoint = endpointProvider.OpenDefaultRenderEndpoint();
+            return VolumeControlResponse.Available(endpoint.GetMasterVolumeLevel());
+        }
+        catch (COMException exception) when (exception.HResult == HResultEndpointNotFound)
+        {
+            return VolumeControlResponse.Unavailable("audio_endpoint_unavailable");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return VolumeControlResponse.PermissionRequired("audio_permission_required");
+        }
+        catch
+        {
+            return VolumeControlResponse.Fault("volume_provider_failed");
+        }
+    }
+
+    public VolumeControlResponse Set(double requestedLevel)
+    {
+        if (double.IsNaN(requestedLevel) ||
+            double.IsInfinity(requestedLevel) ||
+            requestedLevel < 0 ||
+            requestedLevel > 1)
+        {
+            return VolumeControlResponse.Rejected("invalid_volume_level");
+        }
+
+        IAudioEndpointVolumeSession endpoint;
+        try
+        {
+            endpoint = endpointProvider.OpenDefaultRenderEndpoint();
+        }
+        catch (COMException exception) when (exception.HResult == HResultEndpointNotFound)
+        {
+            return VolumeControlResponse.Unavailable("audio_endpoint_unavailable");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return VolumeControlResponse.PermissionRequired("audio_permission_required");
+        }
+        catch
+        {
+            return VolumeControlResponse.Fault("volume_provider_failed");
+        }
+
+        using (endpoint)
+        {
+            try
+            {
+                endpoint.SetMasterVolumeLevel(requestedLevel);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return VolumeControlResponse.PermissionRequired("audio_permission_required");
+            }
+            catch
+            {
+                return VolumeControlResponse.Fault("volume_provider_failed");
+            }
+
+            return ReadBack(endpoint, requestedLevel);
+        }
+    }
+
+    private static VolumeControlResponse ReadBack(
+        IAudioEndpointVolumeSession endpoint,
+        double requestedLevel)
+    {
+        double observedLevel;
+        try
+        {
+            observedLevel = endpoint.GetMasterVolumeLevel();
+        }
+        catch
+        {
+            return VolumeControlResponse.Unverifiable(
+                requestedLevel,
+                null,
+                "volume_readback_failed");
+        }
+
+        return Math.Abs(observedLevel - requestedLevel) <= 0.01
+            ? VolumeControlResponse.Applied(requestedLevel, observedLevel)
+            : VolumeControlResponse.Unverifiable(
+                requestedLevel,
+                observedLevel,
+                "volume_readback_mismatch");
+    }
+}

--- a/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
+++ b/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
@@ -3,7 +3,7 @@ using PanelDeControl.Core.Controls;
 
 namespace PanelDeControl.Hardware;
 
-public sealed class CoreAudioVolumeController
+public sealed class CoreAudioVolumeController : ISystemVolumeController
 {
     private const int HResultEndpointNotFound = unchecked((int)0x80070490);
 

--- a/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
+++ b/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
@@ -27,6 +27,18 @@ public interface IHardwareSnapshotProvider
     HardwareSnapshot Capture();
 }
 
+public interface IAudioEndpointVolumeProvider
+{
+    IAudioEndpointVolumeSession OpenDefaultRenderEndpoint();
+}
+
+public interface IAudioEndpointVolumeSession : IDisposable
+{
+    double GetMasterVolumeLevel();
+
+    void SetMasterVolumeLevel(double requestedLevel);
+}
+
 public sealed class SystemClock : IClock
 {
     public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;

--- a/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
+++ b/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
@@ -1,3 +1,4 @@
+using PanelDeControl.Core.Controls;
 using PanelDeControl.Core.Telemetry;
 
 namespace PanelDeControl.Hardware;
@@ -37,6 +38,13 @@ public interface IAudioEndpointVolumeSession : IDisposable
     double GetMasterVolumeLevel();
 
     void SetMasterVolumeLevel(double requestedLevel);
+}
+
+public interface ISystemVolumeController
+{
+    VolumeControlResponse Get();
+
+    VolumeControlResponse Set(double requestedLevel);
 }
 
 public sealed class SystemClock : IClock

--- a/windows/src/PanelDeControl.Hardware/PackageNamedPipeServerFactory.cs
+++ b/windows/src/PanelDeControl.Hardware/PackageNamedPipeServerFactory.cs
@@ -14,16 +14,32 @@ public static class PackageNamedPipeServerFactory
 
     public static NamedPipeServerStream Create(string pipeName)
     {
+        return Create(pipeName, includeWorldAccess: true);
+    }
+
+    public static NamedPipeServerStream CreateControl(string pipeName)
+    {
+        return Create(pipeName, includeWorldAccess: false);
+    }
+
+    private static NamedPipeServerStream Create(
+        string pipeName,
+        bool includeWorldAccess)
+    {
         if (!OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException();
         }
 
         var security = new PipeSecurity();
-        AddRule(
-            security,
-            new SecurityIdentifier(WellKnownSidType.WorldSid, null),
-            PipeAccessRights.ReadWrite);
+        if (includeWorldAccess)
+        {
+            AddRule(
+                security,
+                new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                PipeAccessRights.ReadWrite);
+        }
+
         AddRule(security, ReadCurrentPackageSid(), PipeAccessRights.ReadWrite);
 
         var currentUser = WindowsIdentity.GetCurrent().User

--- a/windows/src/PanelDeControl.Hardware/Program.cs
+++ b/windows/src/PanelDeControl.Hardware/Program.cs
@@ -17,11 +17,36 @@ public static class Program
                 new DeviceIdentityReader(),
                 new LibreHardwareReader(),
                 new PowerStatusReader());
-            var server = new SnapshotPipeServer(
+            var snapshotServer = new SnapshotPipeServer(
                 SnapshotPipeServer.PackagedPipeName,
                 collector,
                 PackageNamedPipeServerFactory.Create);
-            await server.RunAsync(CancellationToken.None).ConfigureAwait(false);
+            var volumeController = new CoreAudioVolumeController(
+                new CoreAudioEndpointVolumeProvider());
+            var volumeServer = new VolumeControlPipeServer(
+                VolumeControlPipeServer.PackagedPipeName,
+                volumeController,
+                PackageNamedPipeServerFactory.CreateControl);
+
+            using var brokerLifetime = new CancellationTokenSource();
+            var snapshotTask = snapshotServer.RunAsync(brokerLifetime.Token);
+            var volumeTask = volumeServer.RunUntilCancelledAsync(
+                brokerLifetime.Token);
+            try
+            {
+                var completedTask = await Task
+                    .WhenAny(snapshotTask, volumeTask)
+                    .ConfigureAwait(false);
+                await completedTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                brokerLifetime.Cancel();
+                await Task
+                    .WhenAll(snapshotTask, volumeTask)
+                    .ConfigureAwait(false);
+            }
+
             return 0;
         }
         catch

--- a/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
+++ b/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
@@ -1,0 +1,216 @@
+using System.IO.Pipes;
+using System.Text;
+using PanelDeControl.Core.Controls;
+
+namespace PanelDeControl.Hardware;
+
+public sealed class VolumeControlPipeServer
+{
+    private const int MaximumRequestLength = 256;
+
+    public const string PackagedPipeName = @"LOCAL\PanelDeControl.Control";
+
+    private readonly string pipeName;
+    private readonly ISystemVolumeController volumeController;
+    private readonly Func<string, NamedPipeServerStream> pipeFactory;
+    private readonly TimeSpan operationTimeout;
+    private Task<VolumeControlResponse>? activeOperation;
+
+    public VolumeControlPipeServer(
+        string pipeName,
+        ISystemVolumeController volumeController,
+        Func<string, NamedPipeServerStream> pipeFactory,
+        TimeSpan? operationTimeout = null)
+    {
+        var effectiveOperationTimeout =
+            operationTimeout ?? TimeSpan.FromSeconds(2);
+        if (effectiveOperationTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(operationTimeout));
+        }
+
+        this.pipeName = pipeName;
+        this.volumeController = volumeController;
+        this.pipeFactory = pipeFactory;
+        this.operationTimeout = effectiveOperationTimeout;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        await RunAsync(TimeSpan.FromSeconds(30), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task RunAsync(
+        TimeSpan idleTimeout,
+        CancellationToken cancellationToken)
+    {
+        if (idleTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(idleTimeout));
+        }
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            using var idleCancellation =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            idleCancellation.CancelAfter(idleTimeout);
+            try
+            {
+                await RunOnceAsync(idleCancellation.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+                when (!cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+        }
+    }
+
+    public async Task RunOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var server = pipeFactory(pipeName);
+        await server.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        using var reader = new StreamReader(
+            server,
+            new UTF8Encoding(false),
+            false,
+            256,
+            leaveOpen: true);
+        await using var writer = new StreamWriter(
+            server,
+            new UTF8Encoding(false),
+            256,
+            leaveOpen: true)
+        {
+            AutoFlush = true,
+        };
+
+        var payload = await ReadRequestAsync(reader, cancellationToken).ConfigureAwait(false);
+        if (payload.Disconnected)
+        {
+            return;
+        }
+
+        VolumeControlResponse response;
+        if (payload.TooLong)
+        {
+            response = VolumeControlResponse.Rejected("control_request_too_long");
+        }
+        else
+        {
+            response = await HandleRequestAsync(
+                payload.Value ?? string.Empty,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        await writer
+            .WriteLineAsync(VolumeControlWireCodec.SerializeResponse(response))
+            .ConfigureAwait(false);
+    }
+
+    private async Task<VolumeControlResponse> HandleRequestAsync(
+        string payload,
+        CancellationToken cancellationToken)
+    {
+        VolumeControlRequest request;
+        try
+        {
+            request = VolumeControlWireCodec.DeserializeRequest(payload);
+        }
+        catch
+        {
+            return VolumeControlResponse.Rejected("invalid_control_request");
+        }
+
+        if (activeOperation is { IsCompleted: false })
+        {
+            return PendingOperation(request, "volume_control_busy");
+        }
+
+        activeOperation = Task.Run(() => Dispatch(request));
+        var currentOperation = activeOperation;
+        var timeout = Task.Delay(operationTimeout, cancellationToken);
+        if (await Task.WhenAny(currentOperation, timeout).ConfigureAwait(false) !=
+            currentOperation)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return PendingOperation(request, "volume_control_timeout");
+        }
+
+        activeOperation = null;
+        return await currentOperation.ConfigureAwait(false);
+    }
+
+    private VolumeControlResponse Dispatch(VolumeControlRequest request)
+    {
+        try
+        {
+            return request.Operation switch
+            {
+                VolumeControlOperation.Get => volumeController.Get(),
+                VolumeControlOperation.Set => volumeController.Set(
+                    request.RequestedLevel!.Value),
+                _ => VolumeControlResponse.Rejected(
+                    "unsupported_control_operation"),
+            };
+        }
+        catch
+        {
+            return VolumeControlResponse.Fault("volume_control_failed");
+        }
+    }
+
+    private static VolumeControlResponse PendingOperation(
+        VolumeControlRequest request,
+        string errorCode)
+    {
+        return request.Operation == VolumeControlOperation.Set
+            ? VolumeControlResponse.Unverifiable(
+                request.RequestedLevel!.Value,
+                null,
+                errorCode)
+            : VolumeControlResponse.Fault(errorCode);
+    }
+
+    private static async Task<PipeRequest> ReadRequestAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken)
+    {
+        var request = new StringBuilder(MaximumRequestLength);
+        var character = new char[1];
+        while (true)
+        {
+            var count = await reader
+                .ReadAsync(character.AsMemory(0, 1), cancellationToken)
+                .ConfigureAwait(false);
+            if (count == 0)
+            {
+                return new PipeRequest(null, false, true);
+            }
+
+            if (character[0] == '\n')
+            {
+                return new PipeRequest(request.ToString(), false, false);
+            }
+
+            if (character[0] == '\r')
+            {
+                continue;
+            }
+
+            if (request.Length == MaximumRequestLength)
+            {
+                return new PipeRequest(null, true, false);
+            }
+
+            request.Append(character[0]);
+        }
+    }
+
+    private readonly record struct PipeRequest(
+        string? Value,
+        bool TooLong,
+        bool Disconnected);
+}

--- a/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
+++ b/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
@@ -41,6 +41,21 @@ public sealed class VolumeControlPipeServer
             .ConfigureAwait(false);
     }
 
+    public async Task RunUntilCancelledAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await RunOnceAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+            when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
     public async Task RunAsync(
         TimeSpan idleTimeout,
         CancellationToken cancellationToken)
@@ -78,7 +93,7 @@ public sealed class VolumeControlPipeServer
             false,
             256,
             leaveOpen: true);
-        await using var writer = new StreamWriter(
+        var writer = new StreamWriter(
             server,
             new UTF8Encoding(false),
             256,
@@ -87,27 +102,66 @@ public sealed class VolumeControlPipeServer
             AutoFlush = true,
         };
 
-        var payload = await ReadRequestAsync(reader, cancellationToken).ConfigureAwait(false);
-        if (payload.Disconnected)
+        try
         {
-            return;
-        }
+            var payload = await ReadRequestAsync(reader, cancellationToken)
+                .ConfigureAwait(false);
+            if (payload.Disconnected)
+            {
+                return;
+            }
 
-        VolumeControlResponse response;
-        if (payload.TooLong)
-        {
-            response = VolumeControlResponse.Rejected("control_request_too_long");
-        }
-        else
-        {
-            response = await HandleRequestAsync(
-                payload.Value ?? string.Empty,
-                cancellationToken).ConfigureAwait(false);
-        }
+            VolumeControlResponse response;
+            if (payload.TooLong)
+            {
+                response = VolumeControlResponse.Rejected(
+                    "control_request_too_long");
+            }
+            else
+            {
+                response = await HandleRequestAsync(
+                    payload.Value ?? string.Empty,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
-        await writer
-            .WriteLineAsync(VolumeControlWireCodec.SerializeResponse(response))
-            .ConfigureAwait(false);
+            await TryWriteResponseAsync(writer, response).ConfigureAwait(false);
+        }
+        finally
+        {
+            await TryDisposeWriterAsync(writer).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task TryWriteResponseAsync(
+        StreamWriter writer,
+        VolumeControlResponse response)
+    {
+        try
+        {
+            await writer
+                .WriteLineAsync(VolumeControlWireCodec.SerializeResponse(response))
+                .ConfigureAwait(false);
+        }
+        catch (IOException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private static async Task TryDisposeWriterAsync(StreamWriter writer)
+    {
+        try
+        {
+            await writer.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (IOException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
     private async Task<VolumeControlResponse> HandleRequestAsync(

--- a/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
+++ b/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
@@ -35,12 +35,6 @@ public sealed class VolumeControlPipeServer
         this.operationTimeout = effectiveOperationTimeout;
     }
 
-    public async Task RunAsync(CancellationToken cancellationToken)
-    {
-        await RunAsync(TimeSpan.FromSeconds(30), cancellationToken)
-            .ConfigureAwait(false);
-    }
-
     public async Task RunUntilCancelledAsync(CancellationToken cancellationToken)
     {
         try
@@ -53,32 +47,6 @@ public sealed class VolumeControlPipeServer
         catch (OperationCanceledException)
             when (cancellationToken.IsCancellationRequested)
         {
-        }
-    }
-
-    public async Task RunAsync(
-        TimeSpan idleTimeout,
-        CancellationToken cancellationToken)
-    {
-        if (idleTimeout <= TimeSpan.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(idleTimeout));
-        }
-
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            using var idleCancellation =
-                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            idleCancellation.CancelAfter(idleTimeout);
-            try
-            {
-                await RunOnceAsync(idleCancellation.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-                when (!cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
         }
     }
 

--- a/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
+++ b/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
@@ -1,0 +1,152 @@
+using PanelDeControl.Core.Controls;
+using Xunit;
+
+namespace PanelDeControl.Core.Tests;
+
+public sealed class VolumeControlContractTests
+{
+    [Fact]
+    public void GetRequestRoundTripsWithoutInventingARequestedLevel()
+    {
+        var request = VolumeControlRequest.Get();
+
+        var payload = VolumeControlWireCodec.SerializeRequest(request);
+        var roundTrip = VolumeControlWireCodec.DeserializeRequest(payload);
+
+        Assert.Equal(VolumeControlOperation.Get, roundTrip.Operation);
+        Assert.Null(roundTrip.RequestedLevel);
+    }
+
+    [Fact]
+    public void SetRequestRoundTripsWithoutChangingTheRequestedLevel()
+    {
+        var request = VolumeControlRequest.Set(0.45);
+
+        var payload = VolumeControlWireCodec.SerializeRequest(request);
+        var roundTrip = VolumeControlWireCodec.DeserializeRequest(payload);
+
+        Assert.Equal(VolumeControlOperation.Set, roundTrip.Operation);
+        Assert.Equal(0.45, roundTrip.RequestedLevel);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void SetRequestRejectsLevelsThatWindowsCannotApply(double requestedLevel)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => VolumeControlRequest.Set(requestedLevel));
+    }
+
+    [Fact]
+    public void DeserializationRejectsAnOutOfRangeSetLevel()
+    {
+        const string payload = """
+            {"operation":1,"requested_level":1.5}
+            """;
+
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeRequest(payload));
+    }
+
+    [Fact]
+    public void DeserializationRejectsAGetRequestThatContainsAWriteValue()
+    {
+        const string payload = """
+            {"operation":0,"requested_level":0.5}
+            """;
+
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeRequest(payload));
+    }
+
+    [Fact]
+    public void DeserializationRejectsAnUnknownOperation()
+    {
+        const string payload = """
+            {"operation":99}
+            """;
+
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeRequest(payload));
+    }
+
+    [Fact]
+    public void AppliedResponseRoundTripsRequestedAndObservedLevels()
+    {
+        var response = VolumeControlResponse.Applied(0.50, 0.498);
+
+        var payload = VolumeControlWireCodec.SerializeResponse(response);
+        var roundTrip = VolumeControlWireCodec.DeserializeResponse(payload);
+
+        Assert.Equal(ControlStatus.Applied, roundTrip.Status);
+        Assert.Equal(0.50, roundTrip.RequestedLevel);
+        Assert.Equal(0.498, roundTrip.ObservedLevel);
+        Assert.Null(roundTrip.ErrorCode);
+    }
+
+    [Fact]
+    public void AvailableResponseRoundTripsOnlyTheObservedLevel()
+    {
+        var response = VolumeControlResponse.Available(0.72);
+
+        var roundTrip = RoundTrip(response);
+
+        Assert.Equal(ControlStatus.Available, roundTrip.Status);
+        Assert.Null(roundTrip.RequestedLevel);
+        Assert.Equal(0.72, roundTrip.ObservedLevel);
+        Assert.Null(roundTrip.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(ControlStatus.Unavailable, "audio_endpoint_unavailable")]
+    [InlineData(ControlStatus.PermissionRequired, "audio_permission_required")]
+    [InlineData(ControlStatus.Rejected, "invalid_volume_request")]
+    [InlineData(ControlStatus.Fault, "volume_provider_failed")]
+    public void FailureResponseRoundTripsWithoutInventingALevel(
+        ControlStatus status,
+        string errorCode)
+    {
+        var response = status switch
+        {
+            ControlStatus.Unavailable => VolumeControlResponse.Unavailable(errorCode),
+            ControlStatus.PermissionRequired =>
+                VolumeControlResponse.PermissionRequired(errorCode),
+            ControlStatus.Rejected => VolumeControlResponse.Rejected(errorCode),
+            ControlStatus.Fault => VolumeControlResponse.Fault(errorCode),
+            _ => throw new InvalidOperationException(),
+        };
+
+        var roundTrip = RoundTrip(response);
+
+        Assert.Equal(status, roundTrip.Status);
+        Assert.Null(roundTrip.RequestedLevel);
+        Assert.Null(roundTrip.ObservedLevel);
+        Assert.Equal(errorCode, roundTrip.ErrorCode);
+    }
+
+    [Fact]
+    public void UnverifiableResponseKeepsObservedReadbackVisible()
+    {
+        var response = VolumeControlResponse.Unverifiable(
+            0.50,
+            0.42,
+            "volume_readback_mismatch");
+
+        var roundTrip = RoundTrip(response);
+
+        Assert.Equal(ControlStatus.Unverifiable, roundTrip.Status);
+        Assert.Equal(0.50, roundTrip.RequestedLevel);
+        Assert.Equal(0.42, roundTrip.ObservedLevel);
+        Assert.Equal("volume_readback_mismatch", roundTrip.ErrorCode);
+    }
+
+    private static VolumeControlResponse RoundTrip(VolumeControlResponse response)
+    {
+        return VolumeControlWireCodec.DeserializeResponse(
+            VolumeControlWireCodec.SerializeResponse(response));
+    }
+}

--- a/windows/tests/PanelDeControl.Hardware.Tests/CoreAudioVolumeControllerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/CoreAudioVolumeControllerTests.cs
@@ -1,0 +1,277 @@
+using System.Runtime.InteropServices;
+using PanelDeControl.Core.Controls;
+using PanelDeControl.Hardware;
+using Xunit;
+
+namespace PanelDeControl.Hardware.Tests;
+
+public sealed class CoreAudioVolumeControllerTests
+{
+    [Fact]
+    public void DefaultProviderFailsClosedOutsideWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var provider = new CoreAudioEndpointVolumeProvider();
+
+        Assert.Throws<PlatformNotSupportedException>(
+            provider.OpenDefaultRenderEndpoint);
+    }
+
+    [Fact]
+    public void GetReturnsTheObservedDefaultEndpointLevel()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(0.30));
+
+        var response = controller.Get();
+
+        Assert.Equal(ControlStatus.Available, response.Status);
+        Assert.Equal(0.30, response.ObservedLevel);
+        Assert.Null(response.RequestedLevel);
+    }
+
+    [Fact]
+    public void SetReportsAppliedOnlyAfterReadingTheRequestedLevelBack()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(0.30));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.Applied, response.Status);
+        Assert.Equal(0.55, response.RequestedLevel);
+        Assert.Equal(0.55, response.ObservedLevel);
+    }
+
+    [Fact]
+    public void SetReportsUnverifiableWhenTheEndpointReadbackDoesNotMatch()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(0.30, forcedReadback: 0.42));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.Equal(0.55, response.RequestedLevel);
+        Assert.Equal(0.42, response.ObservedLevel);
+        Assert.Equal("volume_readback_mismatch", response.ErrorCode);
+    }
+
+    [Fact]
+    public void GetMapsAMissingDefaultEndpointToUnavailable()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new COMException(
+                    "private endpoint identifier",
+                    unchecked((int)0x80070490))));
+
+        var response = controller.Get();
+
+        Assert.Equal(ControlStatus.Unavailable, response.Status);
+        Assert.Equal("audio_endpoint_unavailable", response.ErrorCode);
+        Assert.DoesNotContain(
+            "private endpoint identifier",
+            VolumeControlWireCodec.SerializeResponse(response));
+    }
+
+    [Fact]
+    public void GetMapsAccessDenialToPermissionRequired()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new UnauthorizedAccessException("private account")));
+
+        var response = controller.Get();
+
+        Assert.Equal(ControlStatus.PermissionRequired, response.Status);
+        Assert.Equal("audio_permission_required", response.ErrorCode);
+    }
+
+    [Fact]
+    public void GetMapsUnexpectedProviderFailureWithoutLeakingItsMessage()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new InvalidOperationException("private endpoint identifier")));
+
+        var response = controller.Get();
+
+        Assert.Equal(ControlStatus.Fault, response.Status);
+        Assert.Equal("volume_provider_failed", response.ErrorCode);
+        Assert.DoesNotContain(
+            "private endpoint identifier",
+            VolumeControlWireCodec.SerializeResponse(response));
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void SetRejectsLevelsOutsideTheCoreAudioScalarRange(double requestedLevel)
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(0.30));
+
+        var response = controller.Set(requestedLevel);
+
+        Assert.Equal(ControlStatus.Rejected, response.Status);
+        Assert.Equal("invalid_volume_level", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetReportsUnverifiableWhenReadbackFailsAfterTheWrite()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                readExceptionAfterSet:
+                    new InvalidOperationException("private endpoint identifier")));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.Equal(0.55, response.RequestedLevel);
+        Assert.Null(response.ObservedLevel);
+        Assert.Equal("volume_readback_failed", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMapsAccessDenialToPermissionRequired()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                setException: new UnauthorizedAccessException("private account")));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.PermissionRequired, response.Status);
+        Assert.Equal("audio_permission_required", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMapsAMissingDefaultEndpointToUnavailable()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new COMException(
+                    "private endpoint identifier",
+                    unchecked((int)0x80070490))));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.Unavailable, response.Status);
+        Assert.Equal("audio_endpoint_unavailable", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMapsUnexpectedWriteFailureToFault()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                setException:
+                    new InvalidOperationException("private endpoint identifier")));
+
+        var response = controller.Set(0.55);
+
+        Assert.Equal(ControlStatus.Fault, response.Status);
+        Assert.Equal("volume_provider_failed", response.ErrorCode);
+    }
+
+    private sealed class FixedEndpointProvider : IAudioEndpointVolumeProvider
+    {
+        private readonly double level;
+        private readonly double? forcedReadback;
+        private readonly Exception? readExceptionAfterSet;
+        private readonly Exception? setException;
+
+        public FixedEndpointProvider(
+            double level,
+            double? forcedReadback = null,
+            Exception? readExceptionAfterSet = null,
+            Exception? setException = null)
+        {
+            this.level = level;
+            this.forcedReadback = forcedReadback;
+            this.readExceptionAfterSet = readExceptionAfterSet;
+            this.setException = setException;
+        }
+
+        public IAudioEndpointVolumeSession OpenDefaultRenderEndpoint()
+        {
+            return new FixedEndpointSession(
+                level,
+                forcedReadback,
+                readExceptionAfterSet,
+                setException);
+        }
+    }
+
+    private sealed class FixedEndpointSession : IAudioEndpointVolumeSession
+    {
+        private double level;
+        private readonly double? forcedReadback;
+        private readonly Exception? readExceptionAfterSet;
+        private readonly Exception? setException;
+        private bool setCalled;
+
+        public FixedEndpointSession(
+            double level,
+            double? forcedReadback,
+            Exception? readExceptionAfterSet,
+            Exception? setException)
+        {
+            this.level = level;
+            this.forcedReadback = forcedReadback;
+            this.readExceptionAfterSet = readExceptionAfterSet;
+            this.setException = setException;
+        }
+
+        public double GetMasterVolumeLevel()
+        {
+            if (setCalled && readExceptionAfterSet is not null)
+            {
+                throw readExceptionAfterSet;
+            }
+
+            return level;
+        }
+
+        public void SetMasterVolumeLevel(double requestedLevel)
+        {
+            if (setException is not null)
+            {
+                throw setException;
+            }
+
+            setCalled = true;
+            level = forcedReadback ?? requestedLevel;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ThrowingEndpointProvider : IAudioEndpointVolumeProvider
+    {
+        private readonly Exception exception;
+
+        public ThrowingEndpointProvider(Exception exception)
+        {
+            this.exception = exception;
+        }
+
+        public IAudioEndpointVolumeSession OpenDefaultRenderEndpoint()
+        {
+            throw exception;
+        }
+    }
+}

--- a/windows/tests/PanelDeControl.Hardware.Tests/PackageNamedPipeServerFactoryTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/PackageNamedPipeServerFactoryTests.cs
@@ -1,0 +1,21 @@
+using System.Runtime.Versioning;
+using PanelDeControl.Hardware;
+using Xunit;
+
+namespace PanelDeControl.Hardware.Tests;
+
+public sealed class PackageNamedPipeServerFactoryTests
+{
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public void ControlFactoryFailsClosedOutsideWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Assert.Throws<PlatformNotSupportedException>(
+            () => PackageNamedPipeServerFactory.CreateControl("test-control"));
+    }
+}

--- a/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
@@ -1,0 +1,354 @@
+using System.IO.Pipes;
+using PanelDeControl.Core.Controls;
+using PanelDeControl.Hardware;
+using Xunit;
+
+namespace PanelDeControl.Hardware.Tests;
+
+public sealed class VolumeControlPipeServerTests
+{
+    [Fact]
+    public async Task GetRequestReturnsTheControllerReadback()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            new FixedVolumeController(0.64),
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Get(),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Available, response.Status);
+        Assert.Equal(0.64, response.ObservedLevel);
+    }
+
+    [Fact]
+    public async Task SetRequestReturnsTheControllerReadback()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            new FixedVolumeController(0.20),
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Set(0.70),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Applied, response.Status);
+        Assert.Equal(0.70, response.RequestedLevel);
+        Assert.Equal(0.70, response.ObservedLevel);
+    }
+
+    [Fact]
+    public async Task MalformedRequestFailsClosedWithoutCallingTheController()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var controller = new CountingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestRawAsync(
+            pipeName,
+            "not-json",
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Rejected, response.Status);
+        Assert.Equal("invalid_control_request", response.ErrorCode);
+        Assert.Equal(0, controller.GetCount);
+        Assert.Equal(0, controller.SetCount);
+    }
+
+    [Fact]
+    public async Task OversizedRequestIsRejectedBeforeControllerAccess()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var controller = new CountingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestRawAsync(
+            pipeName,
+            new string('x', 257),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Rejected, response.Status);
+        Assert.Equal("control_request_too_long", response.ErrorCode);
+        Assert.Equal(0, controller.GetCount);
+        Assert.Equal(0, controller.SetCount);
+    }
+
+    [Fact]
+    public async Task ControllerFailureReturnsSanitizedFault()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            new ThrowingVolumeController(),
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Get(),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Fault, response.Status);
+        Assert.Equal("volume_control_failed", response.ErrorCode);
+        Assert.DoesNotContain(
+            "private endpoint identifier",
+            VolumeControlWireCodec.SerializeResponse(response));
+    }
+
+    [Fact]
+    public async Task ServerStopsAfterAnIdlePeriod()
+    {
+        var server = new VolumeControlPipeServer(
+            $"pvc-{Guid.NewGuid():N}",
+            new CountingVolumeController(),
+            CreateTestPipe);
+
+        await server.RunAsync(TimeSpan.FromMilliseconds(30), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SlowControllerReturnsBoundedFaultWithoutStartingAnotherCall()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        using var controller = new BlockingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe,
+            TimeSpan.FromMilliseconds(30));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var firstServerTask = server.RunOnceAsync(timeout.Token);
+        var firstResponse = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Get(),
+            timeout.Token);
+        await firstServerTask;
+
+        Assert.Equal(ControlStatus.Fault, firstResponse.Status);
+        Assert.Equal("volume_control_timeout", firstResponse.ErrorCode);
+        Assert.Equal(1, controller.GetCount);
+
+        var secondServerTask = server.RunOnceAsync(timeout.Token);
+        var secondResponse = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Get(),
+            timeout.Token);
+        await secondServerTask;
+
+        Assert.Equal(ControlStatus.Fault, secondResponse.Status);
+        Assert.Equal("volume_control_busy", secondResponse.ErrorCode);
+        Assert.Equal(1, controller.GetCount);
+        controller.Release();
+    }
+
+    [Fact]
+    public async Task TimedOutSetIsUnverifiableAndNeverReportedAsApplied()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        using var controller = new BlockingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe,
+            TimeSpan.FromMilliseconds(30));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.Set(0.75),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.Equal(0.75, response.RequestedLevel);
+        Assert.Null(response.ObservedLevel);
+        Assert.Equal("volume_control_timeout", response.ErrorCode);
+        Assert.Equal(1, controller.SetCount);
+        controller.Release();
+    }
+
+    [Fact]
+    public async Task ClientDisconnectDoesNotCrashTheBrokerLoop()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            new CountingVolumeController(),
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        await using (var client = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous))
+        {
+            await client.ConnectAsync(timeout.Token);
+        }
+
+        await serverTask;
+    }
+
+    private static NamedPipeServerStream CreateTestPipe(string pipeName)
+    {
+        return new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+    }
+
+    private static async Task<VolumeControlResponse> RequestAsync(
+        string pipeName,
+        VolumeControlRequest request,
+        CancellationToken cancellationToken)
+    {
+        return await RequestRawAsync(
+            pipeName,
+            VolumeControlWireCodec.SerializeRequest(request),
+            cancellationToken);
+    }
+
+    private static async Task<VolumeControlResponse> RequestRawAsync(
+        string pipeName,
+        string payload,
+        CancellationToken cancellationToken)
+    {
+        await using var client = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous);
+        await client.ConnectAsync(cancellationToken);
+        await using var writer = new StreamWriter(client, leaveOpen: true)
+        {
+            AutoFlush = true,
+        };
+        using var reader = new StreamReader(client, leaveOpen: true);
+
+        await writer.WriteLineAsync(payload);
+        var responsePayload = await reader.ReadLineAsync(cancellationToken);
+        Assert.NotNull(responsePayload);
+        return VolumeControlWireCodec.DeserializeResponse(responsePayload);
+    }
+
+    private sealed class FixedVolumeController : ISystemVolumeController
+    {
+        private double level;
+
+        public FixedVolumeController(double level)
+        {
+            this.level = level;
+        }
+
+        public VolumeControlResponse Get()
+        {
+            return VolumeControlResponse.Available(level);
+        }
+
+        public VolumeControlResponse Set(double requestedLevel)
+        {
+            level = requestedLevel;
+            return VolumeControlResponse.Applied(requestedLevel, level);
+        }
+    }
+
+    private sealed class CountingVolumeController : ISystemVolumeController
+    {
+        public int GetCount { get; private set; }
+
+        public int SetCount { get; private set; }
+
+        public VolumeControlResponse Get()
+        {
+            GetCount++;
+            return VolumeControlResponse.Available(0.50);
+        }
+
+        public VolumeControlResponse Set(double requestedLevel)
+        {
+            SetCount++;
+            return VolumeControlResponse.Applied(requestedLevel, requestedLevel);
+        }
+    }
+
+    private sealed class ThrowingVolumeController : ISystemVolumeController
+    {
+        public VolumeControlResponse Get()
+        {
+            throw new InvalidOperationException("private endpoint identifier");
+        }
+
+        public VolumeControlResponse Set(double requestedLevel)
+        {
+            throw new InvalidOperationException("private endpoint identifier");
+        }
+    }
+
+    private sealed class BlockingVolumeController :
+        ISystemVolumeController,
+        IDisposable
+    {
+        private readonly ManualResetEventSlim release = new();
+
+        public int GetCount { get; private set; }
+
+        public int SetCount { get; private set; }
+
+        public VolumeControlResponse Get()
+        {
+            GetCount++;
+            release.Wait();
+            return VolumeControlResponse.Available(0.50);
+        }
+
+        public VolumeControlResponse Set(double requestedLevel)
+        {
+            SetCount++;
+            release.Wait();
+            return VolumeControlResponse.Applied(requestedLevel, requestedLevel);
+        }
+
+        public void Release()
+        {
+            release.Set();
+        }
+
+        public void Dispose()
+        {
+            release.Set();
+            release.Dispose();
+        }
+    }
+}

--- a/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
@@ -219,6 +219,39 @@ public sealed class VolumeControlPipeServerTests
         await serverTask;
     }
 
+    [Fact]
+    public async Task ClientDisconnectAfterSendingDoesNotCrashTheBrokerLoop()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        using var controller = new BlockingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        await using (var client = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous))
+        {
+            await client.ConnectAsync(timeout.Token);
+            await using var writer = new StreamWriter(client, leaveOpen: true)
+            {
+                AutoFlush = true,
+            };
+            await writer.WriteLineAsync(
+                VolumeControlWireCodec.SerializeRequest(
+                    VolumeControlRequest.Set(0.80)));
+            Assert.True(controller.WaitUntilEntered(TimeSpan.FromSeconds(1)));
+        }
+
+        controller.Release();
+        await serverTask;
+    }
+
     private static NamedPipeServerStream CreateTestPipe(string pipeName)
     {
         return new NamedPipeServerStream(
@@ -321,6 +354,7 @@ public sealed class VolumeControlPipeServerTests
         IDisposable
     {
         private readonly ManualResetEventSlim release = new();
+        private readonly ManualResetEventSlim entered = new();
 
         public int GetCount { get; private set; }
 
@@ -329,6 +363,7 @@ public sealed class VolumeControlPipeServerTests
         public VolumeControlResponse Get()
         {
             GetCount++;
+            entered.Set();
             release.Wait();
             return VolumeControlResponse.Available(0.50);
         }
@@ -336,6 +371,7 @@ public sealed class VolumeControlPipeServerTests
         public VolumeControlResponse Set(double requestedLevel)
         {
             SetCount++;
+            entered.Set();
             release.Wait();
             return VolumeControlResponse.Applied(requestedLevel, requestedLevel);
         }
@@ -345,9 +381,15 @@ public sealed class VolumeControlPipeServerTests
             release.Set();
         }
 
+        public bool WaitUntilEntered(TimeSpan timeout)
+        {
+            return entered.Wait(timeout);
+        }
+
         public void Dispose()
         {
             release.Set();
+            entered.Dispose();
             release.Dispose();
         }
     }

--- a/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
@@ -123,14 +123,16 @@ public sealed class VolumeControlPipeServerTests
     }
 
     [Fact]
-    public async Task ServerStopsAfterAnIdlePeriod()
+    public async Task RunLoopStopsWhenCancelled()
     {
         var server = new VolumeControlPipeServer(
             $"pvc-{Guid.NewGuid():N}",
             new CountingVolumeController(),
             CreateTestPipe);
+        using var cancellation = new CancellationTokenSource(
+            TimeSpan.FromMilliseconds(30));
 
-        await server.RunAsync(TimeSpan.FromMilliseconds(30), CancellationToken.None);
+        await server.RunUntilCancelledAsync(cancellation.Token);
     }
 
     [Fact]

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -344,10 +344,7 @@ class GameBarProjectTests(unittest.TestCase):
         self.assertIn("volumeGeneration", code)
         self.assertIn("TimeSpan.FromMilliseconds(150)", code)
         self.assertIn("ControlStatus.Unverifiable", code)
-        self.assertNotIn(
-            'unsupported ? "Dispositivo no compatible"',
-            code,
-        )
+        self.assertIn("ApplyVolumeResponse(volumeTask.Result)", code)
 
     def test_project_compiles_shared_broker_launcher_and_volume_client(self):
         root = ElementTree.parse(PROJECT).getroot()
@@ -365,7 +362,10 @@ class GameBarProjectTests(unittest.TestCase):
     def test_volume_client_never_retries_an_indeterminate_write(self):
         code = VOLUME_CLIENT.read_text(encoding="utf-8")
 
-        self.assertIn("RequestSent", code)
+        write_started = code.index("requestWriteStarted = true;")
+        write_call = code.index("await writer.WriteLineAsync(")
+        self.assertLess(write_started, write_call)
+        self.assertIn("if (!attempt.RequestWriteStarted)", code)
         self.assertIn("control_response_unavailable", code)
         self.assertIn("VolumeControlResponse.Unverifiable", code)
         self.assertNotIn("Task.Run", code)
@@ -424,6 +424,8 @@ class GameBarProjectTests(unittest.TestCase):
 
         self.assertIn('"device_not_supported"', code)
         self.assertIn('"Dispositivo no compatible"', code)
+        self.assertIn("var unsupported = snapshot.Readings.Any(", code)
+        self.assertIn("available && !unsupported", code)
 
     def test_broker_uses_package_scoped_pipe_acl(self):
         factory = PIPE_FACTORY.read_text(encoding="utf-8")

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -13,9 +13,13 @@ WIDGET = PROJECT_DIR / "ControlPanelWidget.xaml"
 WIDGET_CODE = PROJECT_DIR / "ControlPanelWidget.xaml.cs"
 APP_CODE = PROJECT_DIR / "App.xaml.cs"
 TELEMETRY_CLIENT = PROJECT_DIR / "TelemetryClient.cs"
+VOLUME_CLIENT = PROJECT_DIR / "VolumeControlClient.cs"
+BROKER_LAUNCHER = PROJECT_DIR / "HardwareBrokerLauncher.cs"
 HARDWARE_DIR = ROOT / "windows" / "src" / "PanelDeControl.Hardware"
 PIPE_SERVER = HARDWARE_DIR / "SnapshotPipeServer.cs"
+CONTROL_PIPE_SERVER = HARDWARE_DIR / "VolumeControlPipeServer.cs"
 PIPE_FACTORY = HARDWARE_DIR / "PackageNamedPipeServerFactory.cs"
+BROKER_PROGRAM = HARDWARE_DIR / "Program.cs"
 ROOT_LICENSE = ROOT / "LICENSE"
 ROOT_NOTICES = ROOT / "THIRD_PARTY_NOTICES.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "windows-ci.yml"
@@ -305,6 +309,62 @@ class GameBarProjectTests(unittest.TestCase):
             ),
         )
 
+    def test_widget_has_accessible_system_volume_control(self):
+        root = ElementTree.parse(WIDGET).getroot()
+        xaml_name = "{http://schemas.microsoft.com/winfx/2006/xaml}Name"
+        slider = next(
+            node
+            for node in root.iter()
+            if node.attrib.get(xaml_name) == "VolumeSlider"
+        )
+        names = {
+            node.attrib.get(xaml_name)
+            for node in root.iter()
+        }
+
+        self.assertTrue({"VolumeCard", "VolumeValue", "VolumeStatus"}.issubset(names))
+        self.assertEqual("0", slider.attrib["Minimum"])
+        self.assertEqual("100", slider.attrib["Maximum"])
+        self.assertEqual("5", slider.attrib["StepFrequency"])
+        self.assertEqual("True", slider.attrib["IsTabStop"])
+        self.assertEqual(
+            "Volumen del sistema",
+            slider.attrib["AutomationProperties.Name"],
+        )
+
+    def test_widget_debounces_volume_writes_and_ignores_stale_responses(self):
+        code = WIDGET_CODE.read_text(encoding="utf-8")
+
+        self.assertIn("VolumeSlider_ValueChanged", code)
+        self.assertIn("volumeGeneration", code)
+        self.assertIn("TimeSpan.FromMilliseconds(150)", code)
+        self.assertIn("ControlStatus.Unverifiable", code)
+        self.assertNotIn(
+            'unsupported ? "Dispositivo no compatible"',
+            code,
+        )
+
+    def test_project_compiles_shared_broker_launcher_and_volume_client(self):
+        root = ElementTree.parse(PROJECT).getroot()
+        namespace = {"msbuild": "http://schemas.microsoft.com/developer/msbuild/2003"}
+        sources = {
+            node.attrib["Include"]
+            for node in root.findall(".//msbuild:Compile", namespace)
+        }
+
+        self.assertIn("HardwareBrokerLauncher.cs", sources)
+        self.assertIn("VolumeControlClient.cs", sources)
+        self.assertTrue(BROKER_LAUNCHER.is_file())
+        self.assertTrue(VOLUME_CLIENT.is_file())
+
+    def test_volume_client_never_retries_an_indeterminate_write(self):
+        code = VOLUME_CLIENT.read_text(encoding="utf-8")
+
+        self.assertIn("RequestSent", code)
+        self.assertIn("control_response_unavailable", code)
+        self.assertIn("VolumeControlResponse.Unverifiable", code)
+        self.assertNotIn("Task.Run", code)
+
     def test_required_package_images_are_real_png_files(self):
         expected_sizes = {
             "Square44x44Logo.png": (44, 44),
@@ -376,6 +436,21 @@ class GameBarProjectTests(unittest.TestCase):
         self.assertEqual(3, factory.count("ExactSpelling = true"))
         self.assertNotIn("new NamedPipeServerStream(", server)
         self.assertIn("catch (IOException)", server)
+
+    def test_broker_hosts_volume_on_a_dedicated_strict_pipe(self):
+        factory = PIPE_FACTORY.read_text(encoding="utf-8")
+        control_server = CONTROL_PIPE_SERVER.read_text(encoding="utf-8")
+        program = BROKER_PROGRAM.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "return Create(pipeName, includeWorldAccess: false);",
+            factory,
+        )
+        self.assertIn("if (includeWorldAccess)", factory)
+        self.assertIn(r'@"LOCAL\PanelDeControl.Control"', control_server)
+        self.assertIn("new VolumeControlPipeServer(", program)
+        self.assertIn("PackageNamedPipeServerFactory.CreateControl", program)
+        self.assertIn("new CoreAudioEndpointVolumeProvider()", program)
 
 
 if __name__ == "__main__":

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -344,7 +344,7 @@ class GameBarProjectTests(unittest.TestCase):
         self.assertIn("volumeGeneration", code)
         self.assertIn("TimeSpan.FromMilliseconds(150)", code)
         self.assertIn("ControlStatus.Unverifiable", code)
-        self.assertIn("ApplyVolumeResponse(volumeTask.Result)", code)
+        self.assertIn("ApplyVolumeResponse(volume)", code)
 
     def test_project_compiles_shared_broker_launcher_and_volume_client(self):
         root = ElementTree.parse(PROJECT).getroot()

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -180,7 +180,7 @@ class GameBarProjectTests(unittest.TestCase):
             nuget_config.find("./fallbackPackageFolders/clear"),
         )
 
-    def test_manifest_registers_widget_and_read_only_full_trust_broker(self):
+    def test_manifest_registers_widget_and_scoped_full_trust_broker(self):
         root = ElementTree.parse(MANIFEST).getroot()
         namespaces = {
             "foundation": "http://schemas.microsoft.com/appx/manifest/foundation/windows10",
@@ -219,13 +219,18 @@ class GameBarProjectTests(unittest.TestCase):
             for node in root.findall(".//rescap:Capability", namespaces)
         }
         self.assertEqual({"runFullTrust"}, capabilities)
-        self.assertNotIn(
-            "control",
-            root.find(".//uap:VisualElements", {
-                "uap": "http://schemas.microsoft.com/appx/manifest/uap/windows10",
-            }).attrib["Description"].casefold(),
-        )
-        self.assertNotIn("control", widget.attrib["Description"].casefold())
+        app_description = root.find(
+            ".//uap:VisualElements",
+            {
+                "uap": (
+                    "http://schemas.microsoft.com/appx/manifest/"
+                    "uap/windows10"
+                ),
+            },
+        ).attrib["Description"].casefold()
+        self.assertIn("volumen", app_description)
+        self.assertIn("telemetría", app_description)
+        self.assertIn("volumen", widget.attrib["Description"].casefold())
 
     def test_broker_payload_metadata_is_bound_to_published_files(self):
         root = ElementTree.parse(PROJECT).getroot()


### PR DESCRIPTION
## What does this change?

Adds the first writable Windows capability to the experimental Xbox Game Bar widget: verified control of the default system audio endpoint.

- Adds a shared, validated get/set volume contract with explicit unavailable, permission, rejected, unverifiable, and fault states.
- Uses Windows Core Audio with the default `eRender` / `eConsole` endpoint.
- Reports a change as applied only after reading back the same endpoint within the accepted tolerance.
- Adds a dedicated control pipe restricted to the current package and user, while preserving the existing telemetry transport.
- Prevents automatic retries after a volume write has started and its outcome is uncertain.
- Adds an accessible, controller-friendly slider with debounced writes and stale-response protection.
- Keeps volume availability independent from DMI-based LibreHardwareMonitor support.

The ROG Xbox Ally X RC73XA remains the initial physical validation target. The volume capability itself is selected through the standard Windows audio endpoint rather than device identity.

Windows remains experimental.

## Architecture

Xbox Game Bar widget → shared volume contract → dedicated named pipe → full-trust broker → Windows Core Audio → same-endpoint readback.

Telemetry continues on its previous independent path, so a slow hardware capture cannot block volume requests.

## How was it tested?

Local:

- `PanelDeControl.Core.Tests` Release: 29/29 passed.
- `PanelDeControl.Hardware.Tests` Release: 44/44 passed.
- Game Bar packaging and workflow-isolation regression: 23/23 passed.
- Final diff, privacy, conventional commits, and cross-device gate verified.

GitHub Actions:

- Windows CI: passed.
- UWP/Appx build: passed.
- Locked-package verification: passed.
- Published artifact: `panel-de-control-gamebar-x64`.
- General path-isolation CI: passed.

Windows CI run: https://github.com/Hooandee/panel-de-control/actions/runs/30534034084

## Known limitations

- Physical installation and validation on the ROG Xbox Ally X RC73XA remain follow-up work and do not block this experimental phase.
- The generated Appx is unsigned.
- Controls only the current default master render endpoint.
- No mute, per-application volume, persistence, or automatic reapplication.
- An unverifiable write remains explicitly uncertain and is never reported as successful.
- Effective behavior for applications using exclusive audio mode is not claimed without physical validation.

## Cross-platform impact

Linux, Decky, OpenGamepadUI, and all other device paths are unchanged.

## Checklist

- [x] The commit messages follow Conventional Commits.
- [ ] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` — not run because the diff is restricted to `windows/**`; Decky CI correctly classified these paths as unchanged.
- [ ] `ruff check py_modules main.py tests` and `python -m pytest` — not run for the same path-isolation reason.
- [x] No secrets, tokens, personal data, private project knowledge, or internal tooling references are included.
- [x] No new third-party dependencies were added.
