### PR TITLE
feat(windows): add verified master mute control

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -12,16 +12,27 @@ del volumen del sistema.
   compatible.
 - Lectura y ajuste del volumen principal del dispositivo de audio predeterminado
   mediante Windows Core Audio.
+- Lectura y ajuste del silencio principal del mismo dispositivo mediante la
+  capacidad estándar de Windows Core Audio.
 - Estados explícitos para dato disponible, no disponible, permiso requerido y
   fallo de lectura o control.
 - Canal de control independiente, limitado al paquete y al usuario actual, para
   que una lectura lenta de hardware no bloquee el volumen.
 
-El volumen se confirma leyendo de nuevo el mismo endpoint después de cada
-escritura. Si no puede verificarse, el widget lo indica y no informa el cambio
-como aplicado. No hay reintento de una escritura cuyo resultado sea incierto.
-Tampoco hay control de mute, persistencia ni intervención sobre sesiones que
-usen audio en modo exclusivo.
+Cada operación abre el endpoint de reproducción predeterminado actual
+(`eRender`/`eConsole`). El volumen y el silencio principal se leen con Core
+Audio y el silencio se cambia con `GetMute`/`SetMute`. Después de una escritura,
+el companion vuelve a leer el valor en esa misma sesión: el volumen solo se da
+por aplicado dentro de una tolerancia de 0,01 y el silencio solo cuando el valor
+observado coincide exactamente con el solicitado. Si el readback falla o no
+coincide, el widget conserva el estado observado cuando existe y muestra el
+cambio como no verificable, nunca como aplicado.
+
+No hay reintento después de una escritura, incluida una cuyo resultado sea
+incierto. Tampoco se persiste ni reaplica la intención de volumen o silencio,
+ni se controla el audio o el silencio por aplicación. El control corresponde al
+endpoint principal de Windows; una aplicación en modo exclusivo puede impedir
+la verificación y se informa como tal.
 
 No se escriben valores de TDP, ventiladores, GPU, batería ni firmware. Un campo
 sin lectura verificable aparece como `Sin datos`; nunca se sustituye por un
@@ -66,16 +77,18 @@ declaración de compatibilidad física. En una ROG Xbox Ally X RC73XA:
 4. Comparar fabricante y producto con `Win32_ComputerSystem`.
 5. Registrar qué lecturas aparecen, su proveedor y sus rangos durante batería,
    corriente, reposo y reanudación.
-6. Ajustar el volumen con teclado y mando, y comparar el valor mostrado con el
-   mezclador de Windows.
+6. Ajustar el volumen y activar/desactivar el silencio principal con teclado y
+   mando; comparar ambos estados con el mezclador de Windows.
 7. Cambiar el dispositivo de audio predeterminado y confirmar que la siguiente
    lectura usa el endpoint nuevo sin reaplicar valores anteriores.
-8. Comprobar que una aplicación en modo exclusivo no produce un falso estado de
-   éxito.
-9. Confirmar que cerrar el widget hace terminar el proceso auxiliar tras su
-   periodo de inactividad.
+8. Comprobar con una aplicación en modo exclusivo que un readback bloqueado o
+   discordante no produce un falso estado de éxito.
+9. Ocultar y volver a mostrar el widget durante una operación de silencio y
+   confirmar que no reaplica la intención anterior; confirmar además que al
+   cerrar el widget el proceso auxiliar termina tras su periodo de inactividad.
 10. Confirmar que un sensor ausente aparece como `Sin datos` y que un valor real
-   de cero se conserva.
+    de cero se conserva.
 
 Hasta completar esta prueba, las lecturas de CPU y GPU son candidatas
-experimentales, no soporte de hardware confirmado.
+experimentales y el control de volumen/silencio no tiene compatibilidad física
+confirmada.

--- a/windows/README.md
+++ b/windows/README.md
@@ -41,8 +41,8 @@ valor inventado.
 LibreHardwareMonitor solo se inicializa cuando el DMI coincide con la ROG Xbox
 Ally X. En cualquier otro equipo, el companion conserva únicamente la lectura
 estándar de batería/AC y marca el resto como dispositivo no compatible.
-El volumen no depende de esa identificación: se habilita por la capacidad
-estándar de Windows y por la disponibilidad de un endpoint de audio
+El volumen y el silencio no dependen de esa identificación: se habilitan por la
+capacidad estándar de Windows y por la disponibilidad de un endpoint de audio
 predeterminado.
 
 ## Compilar

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
@@ -32,7 +32,7 @@ public sealed class VolumeControlRequest
         RequestedMuted = requestedMuted;
     }
 
-    [DataMember(Name = "operation", Order = 1)]
+    [DataMember(Name = "operation", Order = 1, IsRequired = true)]
     public VolumeControlOperation Operation { get; private set; }
 
     [DataMember(Name = "requested_level", Order = 2, EmitDefaultValue = false)]

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlRequest.cs
@@ -10,6 +10,9 @@ public enum VolumeControlOperation
 
     [EnumMember]
     Set = 1,
+
+    [EnumMember]
+    SetMute = 2,
 }
 
 [DataContract]
@@ -21,10 +24,12 @@ public sealed class VolumeControlRequest
 
     private VolumeControlRequest(
         VolumeControlOperation operation,
-        double? requestedLevel)
+        double? requestedLevel,
+        bool? requestedMuted)
     {
         Operation = operation;
         RequestedLevel = requestedLevel;
+        RequestedMuted = requestedMuted;
     }
 
     [DataMember(Name = "operation", Order = 1)]
@@ -33,9 +38,12 @@ public sealed class VolumeControlRequest
     [DataMember(Name = "requested_level", Order = 2, EmitDefaultValue = false)]
     public double? RequestedLevel { get; private set; }
 
+    [DataMember(Name = "requested_muted", Order = 3, EmitDefaultValue = false)]
+    public bool? RequestedMuted { get; private set; }
+
     public static VolumeControlRequest Get()
     {
-        return new VolumeControlRequest(VolumeControlOperation.Get, null);
+        return new VolumeControlRequest(VolumeControlOperation.Get, null, null);
     }
 
     public static VolumeControlRequest Set(double requestedLevel)
@@ -45,7 +53,15 @@ public sealed class VolumeControlRequest
             throw new ArgumentOutOfRangeException(nameof(requestedLevel));
         }
 
-        return new VolumeControlRequest(VolumeControlOperation.Set, requestedLevel);
+        return new VolumeControlRequest(VolumeControlOperation.Set, requestedLevel, null);
+    }
+
+    public static VolumeControlRequest SetMute(bool requestedMuted)
+    {
+        return new VolumeControlRequest(
+            VolumeControlOperation.SetMute,
+            null,
+            requestedMuted);
     }
 
     internal void Validate()
@@ -55,15 +71,24 @@ public sealed class VolumeControlRequest
             throw new InvalidDataException("Volume operation is invalid.");
         }
 
-        if (Operation == VolumeControlOperation.Get && RequestedLevel.HasValue)
+        if (Operation == VolumeControlOperation.Get &&
+            (RequestedLevel.HasValue || RequestedMuted.HasValue))
         {
-            throw new InvalidDataException("A get request cannot include a requested level.");
+            throw new InvalidDataException("A get request cannot include a requested value.");
         }
 
         if (Operation == VolumeControlOperation.Set &&
-            (!RequestedLevel.HasValue || !IsValidLevel(RequestedLevel.Value)))
+            (!RequestedLevel.HasValue ||
+            !IsValidLevel(RequestedLevel.Value) ||
+            RequestedMuted.HasValue))
         {
             throw new InvalidDataException("A set request requires a level from zero to one.");
+        }
+
+        if (Operation == VolumeControlOperation.SetMute &&
+            (!RequestedMuted.HasValue || RequestedLevel.HasValue))
+        {
+            throw new InvalidDataException("A mute request requires only a requested mute state.");
         }
     }
 

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
@@ -25,7 +25,7 @@ public sealed class VolumeControlResponse
         ErrorCode = errorCode;
     }
 
-    [DataMember(Name = "status", Order = 1)]
+    [DataMember(Name = "status", Order = 1, IsRequired = true)]
     public ControlStatus Status { get; private set; }
 
     [DataMember(Name = "requested_level", Order = 2, EmitDefaultValue = false)]

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
@@ -56,14 +56,16 @@ public sealed class VolumeControlResponse
             null);
     }
 
-    public static VolumeControlResponse Available(double observedLevel)
+    public static VolumeControlResponse Available(
+        double observedLevel,
+        bool observedMuted)
     {
         return new VolumeControlResponse(
             ControlStatus.Available,
             null,
             RequireLevel(observedLevel, nameof(observedLevel)),
             null,
-            null,
+            observedMuted,
             null);
     }
 
@@ -142,7 +144,8 @@ public sealed class VolumeControlResponse
             case ControlStatus.Available:
                 RequireNoRequestedLevel();
                 RequireObservedLevel();
-                RequireNoMuted();
+                RequireNoRequestedMuted();
+                RequireObservedMuted();
                 RequireNoError();
                 break;
             case ControlStatus.Applied:
@@ -266,6 +269,14 @@ public sealed class VolumeControlResponse
         if (!ObservedMuted.HasValue)
         {
             throw new InvalidDataException("Observed mute state is missing.");
+        }
+    }
+
+    private void RequireNoRequestedMuted()
+    {
+        if (RequestedMuted.HasValue)
+        {
+            throw new InvalidDataException("Unexpected requested mute state.");
         }
     }
 

--- a/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
+++ b/windows/src/PanelDeControl.Core/Controls/VolumeControlResponse.cs
@@ -13,11 +13,15 @@ public sealed class VolumeControlResponse
         ControlStatus status,
         double? requestedLevel,
         double? observedLevel,
+        bool? requestedMuted,
+        bool? observedMuted,
         string? errorCode)
     {
         Status = status;
         RequestedLevel = requestedLevel;
         ObservedLevel = observedLevel;
+        RequestedMuted = requestedMuted;
+        ObservedMuted = observedMuted;
         ErrorCode = errorCode;
     }
 
@@ -30,7 +34,13 @@ public sealed class VolumeControlResponse
     [DataMember(Name = "observed_level", Order = 3, EmitDefaultValue = false)]
     public double? ObservedLevel { get; private set; }
 
-    [DataMember(Name = "error_code", Order = 4, EmitDefaultValue = false)]
+    [DataMember(Name = "requested_muted", Order = 4, EmitDefaultValue = false)]
+    public bool? RequestedMuted { get; private set; }
+
+    [DataMember(Name = "observed_muted", Order = 5, EmitDefaultValue = false)]
+    public bool? ObservedMuted { get; private set; }
+
+    [DataMember(Name = "error_code", Order = 6, EmitDefaultValue = false)]
     public string? ErrorCode { get; private set; }
 
     public static VolumeControlResponse Applied(
@@ -41,6 +51,8 @@ public sealed class VolumeControlResponse
             ControlStatus.Applied,
             RequireLevel(requestedLevel, nameof(requestedLevel)),
             RequireLevel(observedLevel, nameof(observedLevel)),
+            null,
+            null,
             null);
     }
 
@@ -50,6 +62,8 @@ public sealed class VolumeControlResponse
             ControlStatus.Available,
             null,
             RequireLevel(observedLevel, nameof(observedLevel)),
+            null,
+            null,
             null);
     }
 
@@ -79,6 +93,35 @@ public sealed class VolumeControlResponse
             observedLevel.HasValue
                 ? RequireLevel(observedLevel.Value, nameof(observedLevel))
                 : null,
+            null,
+            null,
+            RequireText(errorCode, nameof(errorCode)));
+    }
+
+    public static VolumeControlResponse MuteApplied(
+        bool requestedMuted,
+        bool observedMuted)
+    {
+        return new VolumeControlResponse(
+            ControlStatus.Applied,
+            null,
+            null,
+            requestedMuted,
+            observedMuted,
+            null);
+    }
+
+    public static VolumeControlResponse MuteUnverifiable(
+        bool requestedMuted,
+        bool? observedMuted,
+        string errorCode)
+    {
+        return new VolumeControlResponse(
+            ControlStatus.Unverifiable,
+            null,
+            null,
+            requestedMuted,
+            observedMuted,
             RequireText(errorCode, nameof(errorCode)));
     }
 
@@ -99,11 +142,11 @@ public sealed class VolumeControlResponse
             case ControlStatus.Available:
                 RequireNoRequestedLevel();
                 RequireObservedLevel();
+                RequireNoMuted();
                 RequireNoError();
                 break;
             case ControlStatus.Applied:
-                RequireRequestedLevel();
-                RequireObservedLevel();
+                RequireAppliedValues();
                 RequireNoError();
                 break;
             case ControlStatus.Unavailable:
@@ -112,15 +155,11 @@ public sealed class VolumeControlResponse
             case ControlStatus.Fault:
                 RequireNoRequestedLevel();
                 RequireNoObservedLevel();
+                RequireNoMuted();
                 RequireError();
                 break;
             case ControlStatus.Unverifiable:
-                RequireRequestedLevel();
-                if (ObservedLevel.HasValue)
-                {
-                    RequireLevel(ObservedLevel.Value, nameof(ObservedLevel));
-                }
-
+                RequireUnverifiableValues();
                 RequireError();
                 break;
         }
@@ -134,7 +173,42 @@ public sealed class VolumeControlResponse
             status,
             null,
             null,
+            null,
+            null,
             RequireText(errorCode, nameof(errorCode)));
+    }
+
+    private void RequireAppliedValues()
+    {
+        if (RequestedLevel.HasValue)
+        {
+            RequireRequestedLevel();
+            RequireObservedLevel();
+            RequireNoMuted();
+            return;
+        }
+
+        RequireNoLevels();
+        RequireRequestedMuted();
+        RequireObservedMuted();
+    }
+
+    private void RequireUnverifiableValues()
+    {
+        if (RequestedLevel.HasValue)
+        {
+            RequireRequestedLevel();
+            if (ObservedLevel.HasValue)
+            {
+                RequireLevel(ObservedLevel.Value, nameof(ObservedLevel));
+            }
+
+            RequireNoMuted();
+            return;
+        }
+
+        RequireNoLevels();
+        RequireRequestedMuted();
     }
 
     private void RequireRequestedLevel()
@@ -170,6 +244,36 @@ public sealed class VolumeControlResponse
         if (ObservedLevel.HasValue)
         {
             throw new InvalidDataException("Unexpected observed volume level.");
+        }
+    }
+
+    private void RequireNoLevels()
+    {
+        RequireNoRequestedLevel();
+        RequireNoObservedLevel();
+    }
+
+    private void RequireRequestedMuted()
+    {
+        if (!RequestedMuted.HasValue)
+        {
+            throw new InvalidDataException("Requested mute state is missing.");
+        }
+    }
+
+    private void RequireObservedMuted()
+    {
+        if (!ObservedMuted.HasValue)
+        {
+            throw new InvalidDataException("Observed mute state is missing.");
+        }
+    }
+
+    private void RequireNoMuted()
+    {
+        if (RequestedMuted.HasValue || ObservedMuted.HasValue)
+        {
+            throw new InvalidDataException("Unexpected mute state.");
         }
     }
 

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
@@ -179,6 +179,33 @@
                             FontSize="12"
                             Foreground="#FF8591A3"
                             TextWrapping="Wrap" />
+                        <Grid Margin="0,16,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel VerticalAlignment="Center">
+                                <TextBlock Text="SILENCIAR" Style="{StaticResource TelemetryLabelStyle}" />
+                                <TextBlock
+                                    x:Name="MuteStatus"
+                                    Margin="0,5,16,0"
+                                    Text="Comprobando estado de silencio…"
+                                    FontSize="12"
+                                    Foreground="#FF8591A3"
+                                    TextWrapping="Wrap" />
+                            </StackPanel>
+                            <ToggleSwitch
+                                x:Name="MuteToggle"
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                IsEnabled="False"
+                                IsTabStop="True"
+                                OffContent="Con sonido"
+                                OnContent="Silenciado"
+                                AutomationProperties.Name="Silenciar audio del sistema"
+                                AutomationProperties.HelpText="Activa o desactiva el silencio del dispositivo de audio predeterminado y verifica el estado leído"
+                                Toggled="MuteToggle_Toggled" />
+                        </Grid>
                     </StackPanel>
                 </Border>
 

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml
@@ -192,6 +192,7 @@
                                     Text="Comprobando estado de silencio…"
                                     FontSize="12"
                                     Foreground="#FF8591A3"
+                                    AutomationProperties.LiveSetting="Polite"
                                     TextWrapping="Wrap" />
                             </StackPanel>
                             <ToggleSwitch

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -147,6 +147,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         {
             var volumeRefreshGeneration = volumeGeneration;
             var muteRefreshGeneration = muteGeneration;
+            var volumeWriteWasPendingAtRefreshStart = volumeWritePending;
             var muteWriteWasPendingAtRefreshStart = muteWritePending;
             var snapshotTask = telemetryClient.GetSnapshotAsync();
             var volumeTask = volumeClient.GetAsync();
@@ -156,7 +157,8 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
                 currentRefreshGeneration == refreshGeneration)
             {
                 ApplySnapshot(snapshot);
-                if (!volumeWritePending &&
+                if (!volumeWriteWasPendingAtRefreshStart &&
+                    !volumeWritePending &&
                     volumeRefreshGeneration == volumeGeneration)
                 {
                     ApplyVolumeResponse(volume);

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -344,17 +344,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
                     : "Estado de silencio disponible";
                 break;
             case ControlStatus.Unverifiable:
-                if (response.ObservedMuted.HasValue)
-                {
-                    ApplyObservedMute(response.ObservedMuted.Value);
-                }
-                else if (lastObservedMuted.HasValue)
-                {
-                    ApplyObservedMute(lastObservedMuted.Value);
-                }
-
-                muteReady = lastObservedMuted.HasValue;
-                MuteToggle.IsEnabled = muteReady && !muteWritePending;
+                RestoreKnownMuteState(response.ObservedMuted);
                 MuteStatus.Text = "No se pudo verificar el cambio";
                 break;
             case ControlStatus.PermissionRequired:
@@ -364,13 +354,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
                 DisableMuteControl("No hay un dispositivo de audio predeterminado");
                 break;
             case ControlStatus.Rejected:
-                if (lastObservedMuted.HasValue)
-                {
-                    ApplyObservedMute(lastObservedMuted.Value);
-                }
-
-                muteReady = lastObservedMuted.HasValue;
-                MuteToggle.IsEnabled = muteReady && !muteWritePending;
+                RestoreKnownMuteState(null);
                 MuteStatus.Text = "Windows rechazó el cambio";
                 break;
             default:
@@ -406,6 +390,21 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         {
             applyingMuteReadback = false;
         }
+    }
+
+    private void RestoreKnownMuteState(bool? observedMuted)
+    {
+        if (observedMuted.HasValue)
+        {
+            ApplyObservedMute(observedMuted.Value);
+        }
+        else if (lastObservedMuted.HasValue)
+        {
+            ApplyObservedMute(lastObservedMuted.Value);
+        }
+
+        muteReady = lastObservedMuted.HasValue;
+        MuteToggle.IsEnabled = muteReady && !muteWritePending;
     }
 
     private void DisableVolumeControl(string status)

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -147,6 +147,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         {
             var volumeRefreshGeneration = volumeGeneration;
             var muteRefreshGeneration = muteGeneration;
+            var muteWriteWasPendingAtRefreshStart = muteWritePending;
             var snapshotTask = telemetryClient.GetSnapshotAsync();
             var volumeTask = volumeClient.GetAsync();
             var snapshot = await snapshotTask;
@@ -161,7 +162,8 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
                     ApplyVolumeResponse(volume);
                 }
 
-                if (!muteWritePending &&
+                if (!muteWriteWasPendingAtRefreshStart &&
+                    !muteWritePending &&
                     muteRefreshGeneration == muteGeneration)
                 {
                     ApplyMuteResponse(volume);

--- a/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
+++ b/windows/src/PanelDeControl.GameBar/ControlPanelWidget.xaml.cs
@@ -29,11 +29,17 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
     private readonly VolumeControlClient volumeClient = new();
     private XboxGameBarWidget? gameBarWidget;
     private CancellationTokenSource? volumeDebounce;
+    private long refreshGeneration;
     private long volumeGeneration;
+    private long muteGeneration;
     private bool refreshInProgress;
     private bool applyingVolumeReadback;
+    private bool applyingMuteReadback;
     private bool volumeReady;
+    private bool muteReady;
     private bool volumeWritePending;
+    private bool muteWritePending;
+    private bool? lastObservedMuted;
     private bool disposed;
 
     public ControlPanelWidget()
@@ -64,7 +70,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
 
         disposed = true;
         refreshTimer.Stop();
-        CancelPendingVolumeWrite();
+        InvalidatePendingOperations();
         refreshTimer.Tick -= OnRefreshTimerTick;
         if (gameBarWidget is not null)
         {
@@ -88,7 +94,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
     private void OnUnloaded(object sender, RoutedEventArgs args)
     {
         refreshTimer.Stop();
-        CancelPendingVolumeWrite();
+        InvalidatePendingOperations();
     }
 
     private async void OnRefreshTimerTick(object sender, object args)
@@ -119,7 +125,7 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         else
         {
             refreshTimer.Stop();
-            CancelPendingVolumeWrite();
+            InvalidatePendingOperations();
         }
     }
 
@@ -135,15 +141,18 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
             return;
         }
 
+        var currentRefreshGeneration = refreshGeneration;
         refreshInProgress = true;
         try
         {
             var volumeRefreshGeneration = volumeGeneration;
+            var muteRefreshGeneration = muteGeneration;
             var snapshotTask = telemetryClient.GetSnapshotAsync();
             var volumeTask = volumeClient.GetAsync();
             var snapshot = await snapshotTask;
             var volume = await volumeTask;
-            if (!disposed)
+            if (!disposed &&
+                currentRefreshGeneration == refreshGeneration)
             {
                 ApplySnapshot(snapshot);
                 if (!volumeWritePending &&
@@ -151,11 +160,20 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
                 {
                     ApplyVolumeResponse(volume);
                 }
+
+                if (!muteWritePending &&
+                    muteRefreshGeneration == muteGeneration)
+                {
+                    ApplyMuteResponse(volume);
+                }
             }
         }
         finally
         {
-            refreshInProgress = false;
+            if (currentRefreshGeneration == refreshGeneration)
+            {
+                refreshInProgress = false;
+            }
         }
     }
 
@@ -228,6 +246,42 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         }
     }
 
+    private async void MuteToggle_Toggled(
+        object sender,
+        RoutedEventArgs args)
+    {
+        if (disposed ||
+            applyingMuteReadback ||
+            !muteReady ||
+            muteWritePending)
+        {
+            return;
+        }
+
+        var requestedMuted = MuteToggle.IsOn;
+        MuteStatus.Text = "Aplicando y verificando…";
+        MuteToggle.IsEnabled = false;
+        var generation = ++muteGeneration;
+        muteWritePending = true;
+
+        try
+        {
+            var response = await volumeClient.SetMuteAsync(requestedMuted);
+            if (!disposed && generation == muteGeneration)
+            {
+                ApplyMuteResponse(response);
+            }
+        }
+        finally
+        {
+            if (generation == muteGeneration)
+            {
+                muteWritePending = false;
+                MuteToggle.IsEnabled = muteReady;
+            }
+        }
+    }
+
     private void ApplyVolumeResponse(VolumeControlResponse response)
     {
         switch (response.Status)
@@ -266,6 +320,61 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         }
     }
 
+    private void ApplyMuteResponse(VolumeControlResponse response)
+    {
+        switch (response.Status)
+        {
+            case ControlStatus.Available:
+            case ControlStatus.Applied:
+                if (!response.ObservedMuted.HasValue)
+                {
+                    DisableMuteControl("No se pudo leer el estado de silencio");
+                    break;
+                }
+
+                ApplyObservedMute(response.ObservedMuted.Value);
+                muteReady = true;
+                MuteToggle.IsEnabled = !muteWritePending;
+                MuteStatus.Text = response.Status == ControlStatus.Applied
+                    ? "Cambio aplicado y verificado"
+                    : "Estado de silencio disponible";
+                break;
+            case ControlStatus.Unverifiable:
+                if (response.ObservedMuted.HasValue)
+                {
+                    ApplyObservedMute(response.ObservedMuted.Value);
+                }
+                else if (lastObservedMuted.HasValue)
+                {
+                    ApplyObservedMute(lastObservedMuted.Value);
+                }
+
+                muteReady = lastObservedMuted.HasValue;
+                MuteToggle.IsEnabled = muteReady && !muteWritePending;
+                MuteStatus.Text = "No se pudo verificar el cambio";
+                break;
+            case ControlStatus.PermissionRequired:
+                DisableMuteControl("Windows requiere permiso para silenciar el audio");
+                break;
+            case ControlStatus.Unavailable:
+                DisableMuteControl("No hay un dispositivo de audio predeterminado");
+                break;
+            case ControlStatus.Rejected:
+                if (lastObservedMuted.HasValue)
+                {
+                    ApplyObservedMute(lastObservedMuted.Value);
+                }
+
+                muteReady = lastObservedMuted.HasValue;
+                MuteToggle.IsEnabled = muteReady && !muteWritePending;
+                MuteStatus.Text = "Windows rechazó el cambio";
+                break;
+            default:
+                DisableMuteControl("No se pudo conectar con el control de audio");
+                break;
+        }
+    }
+
     private void ApplyObservedVolume(double level)
     {
         applyingVolumeReadback = true;
@@ -281,11 +390,45 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         }
     }
 
+    private void ApplyObservedMute(bool muted)
+    {
+        lastObservedMuted = muted;
+        applyingMuteReadback = true;
+        try
+        {
+            MuteToggle.IsOn = muted;
+        }
+        finally
+        {
+            applyingMuteReadback = false;
+        }
+    }
+
     private void DisableVolumeControl(string status)
     {
         volumeReady = false;
         VolumeSlider.IsEnabled = false;
         VolumeStatus.Text = status;
+    }
+
+    private void DisableMuteControl(string status)
+    {
+        if (lastObservedMuted.HasValue)
+        {
+            ApplyObservedMute(lastObservedMuted.Value);
+        }
+
+        muteReady = false;
+        MuteToggle.IsEnabled = false;
+        MuteStatus.Text = status;
+    }
+
+    private void InvalidatePendingOperations()
+    {
+        refreshGeneration++;
+        refreshInProgress = false;
+        CancelPendingVolumeWrite();
+        CancelPendingMuteWrite();
     }
 
     private void CancelPendingVolumeWrite()
@@ -295,6 +438,15 @@ public sealed partial class ControlPanelWidget : Page, IDisposable
         volumeDebounce?.Cancel();
         volumeDebounce?.Dispose();
         volumeDebounce = null;
+    }
+
+    private void CancelPendingMuteWrite()
+    {
+        muteGeneration++;
+        muteWritePending = false;
+        muteReady = false;
+        MuteToggle.IsEnabled = false;
+        MuteStatus.Text = "Comprobando estado de silencio…";
     }
 
     private static string Format(

--- a/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
+++ b/windows/src/PanelDeControl.GameBar/VolumeControlClient.cs
@@ -23,6 +23,11 @@ public sealed class VolumeControlClient
         return SendAsync(VolumeControlRequest.Set(requestedLevel));
     }
 
+    public Task<VolumeControlResponse> SetMuteAsync(bool requestedMuted)
+    {
+        return SendAsync(VolumeControlRequest.SetMute(requestedMuted));
+    }
+
     private static async Task<VolumeControlResponse> SendAsync(
         VolumeControlRequest request)
     {
@@ -114,12 +119,19 @@ public sealed class VolumeControlClient
         VolumeControlRequest request,
         string errorCode)
     {
-        return request.Operation == VolumeControlOperation.Set
-            ? VolumeControlResponse.Unverifiable(
+        return request.Operation switch
+        {
+            VolumeControlOperation.Set => VolumeControlResponse.Unverifiable(
                 request.RequestedLevel!.Value,
                 null,
-                errorCode)
-            : VolumeControlResponse.Fault(errorCode);
+                errorCode),
+            VolumeControlOperation.SetMute =>
+                VolumeControlResponse.MuteUnverifiable(
+                    request.RequestedMuted!.Value,
+                    null,
+                    errorCode),
+            _ => VolumeControlResponse.Fault(errorCode),
+        };
     }
 
     private sealed class TransportAttempt

--- a/windows/src/PanelDeControl.Hardware/CoreAudioEndpointVolumeProvider.cs
+++ b/windows/src/PanelDeControl.Hardware/CoreAudioEndpointVolumeProvider.cs
@@ -90,6 +90,21 @@ public sealed class CoreAudioEndpointVolumeProvider : IAudioEndpointVolumeProvid
                     IntPtr.Zero));
         }
 
+        public bool GetMute()
+        {
+            var volume = endpointVolume ?? throw new ObjectDisposedException(
+                nameof(CoreAudioEndpointVolumeSession));
+            Marshal.ThrowExceptionForHR(volume.GetMute(out var muted));
+            return muted;
+        }
+
+        public void SetMute(bool requestedMuted)
+        {
+            var volume = endpointVolume ?? throw new ObjectDisposedException(
+                nameof(CoreAudioEndpointVolumeSession));
+            Marshal.ThrowExceptionForHR(volume.SetMute(requestedMuted, IntPtr.Zero));
+        }
+
         public void Dispose()
         {
             ReleaseComObject(endpointVolume);

--- a/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
+++ b/windows/src/PanelDeControl.Hardware/CoreAudioVolumeController.cs
@@ -19,7 +19,9 @@ public sealed class CoreAudioVolumeController : ISystemVolumeController
         try
         {
             using var endpoint = endpointProvider.OpenDefaultRenderEndpoint();
-            return VolumeControlResponse.Available(endpoint.GetMasterVolumeLevel());
+            return VolumeControlResponse.Available(
+                endpoint.GetMasterVolumeLevel(),
+                endpoint.GetMute());
         }
         catch (COMException exception) when (exception.HResult == HResultEndpointNotFound)
         {
@@ -82,6 +84,45 @@ public sealed class CoreAudioVolumeController : ISystemVolumeController
         }
     }
 
+    public VolumeControlResponse SetMute(bool requestedMuted)
+    {
+        IAudioEndpointVolumeSession endpoint;
+        try
+        {
+            endpoint = endpointProvider.OpenDefaultRenderEndpoint();
+        }
+        catch (COMException exception) when (exception.HResult == HResultEndpointNotFound)
+        {
+            return VolumeControlResponse.Unavailable("audio_endpoint_unavailable");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return VolumeControlResponse.PermissionRequired("audio_permission_required");
+        }
+        catch
+        {
+            return VolumeControlResponse.Fault("volume_provider_failed");
+        }
+
+        using (endpoint)
+        {
+            try
+            {
+                endpoint.SetMute(requestedMuted);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return VolumeControlResponse.PermissionRequired("audio_permission_required");
+            }
+            catch
+            {
+                return VolumeControlResponse.Fault("volume_provider_failed");
+            }
+
+            return ReadMuteBack(endpoint, requestedMuted);
+        }
+    }
+
     private static VolumeControlResponse ReadBack(
         IAudioEndpointVolumeSession endpoint,
         double requestedLevel)
@@ -105,5 +146,30 @@ public sealed class CoreAudioVolumeController : ISystemVolumeController
                 requestedLevel,
                 observedLevel,
                 "volume_readback_mismatch");
+    }
+
+    private static VolumeControlResponse ReadMuteBack(
+        IAudioEndpointVolumeSession endpoint,
+        bool requestedMuted)
+    {
+        bool observedMuted;
+        try
+        {
+            observedMuted = endpoint.GetMute();
+        }
+        catch
+        {
+            return VolumeControlResponse.MuteUnverifiable(
+                requestedMuted,
+                null,
+                "mute_readback_failed");
+        }
+
+        return observedMuted == requestedMuted
+            ? VolumeControlResponse.MuteApplied(requestedMuted, observedMuted)
+            : VolumeControlResponse.MuteUnverifiable(
+                requestedMuted,
+                observedMuted,
+                "mute_readback_mismatch");
     }
 }

--- a/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
+++ b/windows/src/PanelDeControl.Hardware/HardwareAbstractions.cs
@@ -38,6 +38,10 @@ public interface IAudioEndpointVolumeSession : IDisposable
     double GetMasterVolumeLevel();
 
     void SetMasterVolumeLevel(double requestedLevel);
+
+    bool GetMute();
+
+    void SetMute(bool requestedMuted);
 }
 
 public interface ISystemVolumeController
@@ -45,6 +49,8 @@ public interface ISystemVolumeController
     VolumeControlResponse Get();
 
     VolumeControlResponse Set(double requestedLevel);
+
+    VolumeControlResponse SetMute(bool requestedMuted);
 }
 
 public sealed class SystemClock : IClock

--- a/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
+++ b/windows/src/PanelDeControl.Hardware/VolumeControlPipeServer.cs
@@ -174,6 +174,8 @@ public sealed class VolumeControlPipeServer
                 VolumeControlOperation.Get => volumeController.Get(),
                 VolumeControlOperation.Set => volumeController.Set(
                     request.RequestedLevel!.Value),
+                VolumeControlOperation.SetMute => volumeController.SetMute(
+                    request.RequestedMuted!.Value),
                 _ => VolumeControlResponse.Rejected(
                     "unsupported_control_operation"),
             };
@@ -188,12 +190,19 @@ public sealed class VolumeControlPipeServer
         VolumeControlRequest request,
         string errorCode)
     {
-        return request.Operation == VolumeControlOperation.Set
-            ? VolumeControlResponse.Unverifiable(
+        return request.Operation switch
+        {
+            VolumeControlOperation.Set => VolumeControlResponse.Unverifiable(
                 request.RequestedLevel!.Value,
                 null,
-                errorCode)
-            : VolumeControlResponse.Fault(errorCode);
+                errorCode),
+            VolumeControlOperation.SetMute =>
+                VolumeControlResponse.MuteUnverifiable(
+                    request.RequestedMuted!.Value,
+                    null,
+                    errorCode),
+            _ => VolumeControlResponse.Fault(errorCode),
+        };
     }
 
     private static async Task<PipeRequest> ReadRequestAsync(

--- a/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
+++ b/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Serialization;
 using PanelDeControl.Core.Controls;
 using Xunit;
 
@@ -98,6 +99,13 @@ public sealed class VolumeControlContractTests
     }
 
     [Fact]
+    public void DeserializationRejectsARequestMissingItsOperation()
+    {
+        Assert.Throws<SerializationException>(
+            () => VolumeControlWireCodec.DeserializeRequest("{}"));
+    }
+
+    [Fact]
     public void AppliedResponseRoundTripsRequestedAndObservedLevels()
     {
         var response = VolumeControlResponse.Applied(0.50, 0.498);
@@ -133,6 +141,17 @@ public sealed class VolumeControlContractTests
         string payload)
     {
         Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeResponse(payload));
+    }
+
+    [Fact]
+    public void DeserializationRejectsAResponseMissingItsStatus()
+    {
+        const string payload = """
+            {"observed_level":0.72,"observed_muted":true}
+            """;
+
+        Assert.Throws<SerializationException>(
             () => VolumeControlWireCodec.DeserializeResponse(payload));
     }
 

--- a/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
+++ b/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
@@ -29,6 +29,29 @@ public sealed class VolumeControlContractTests
         Assert.Equal(0.45, roundTrip.RequestedLevel);
     }
 
+    [Fact]
+    public void SetMuteRequestRoundTripsWithoutInventingALevel()
+    {
+        var request = VolumeControlRequest.SetMute(true);
+
+        var payload = VolumeControlWireCodec.SerializeRequest(request);
+        var roundTrip = VolumeControlWireCodec.DeserializeRequest(payload);
+
+        Assert.Equal(VolumeControlOperation.SetMute, roundTrip.Operation);
+        Assert.True(roundTrip.RequestedMuted);
+        Assert.Null(roundTrip.RequestedLevel);
+    }
+
+    [Theory]
+    [InlineData("{\"operation\":2}")]
+    [InlineData("{\"operation\":2,\"requested_level\":0.5,\"requested_muted\":true}")]
+    [InlineData("{\"operation\":1,\"requested_muted\":true,\"requested_level\":0.5}")]
+    public void DeserializationRejectsMuteRequestsWithAnInvalidShape(string payload)
+    {
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeRequest(payload));
+    }
+
     [Theory]
     [InlineData(-0.01)]
     [InlineData(1.01)]
@@ -142,6 +165,49 @@ public sealed class VolumeControlContractTests
         Assert.Equal(0.50, roundTrip.RequestedLevel);
         Assert.Equal(0.42, roundTrip.ObservedLevel);
         Assert.Equal("volume_readback_mismatch", roundTrip.ErrorCode);
+    }
+
+    [Fact]
+    public void MuteAppliedResponseRoundTripsRequestedAndObservedMuteState()
+    {
+        var response = VolumeControlResponse.MuteApplied(true, true);
+
+        var roundTrip = RoundTrip(response);
+
+        Assert.Equal(ControlStatus.Applied, roundTrip.Status);
+        Assert.True(roundTrip.RequestedMuted);
+        Assert.True(roundTrip.ObservedMuted);
+        Assert.Null(roundTrip.RequestedLevel);
+        Assert.Null(roundTrip.ObservedLevel);
+        Assert.Null(roundTrip.ErrorCode);
+    }
+
+    [Fact]
+    public void MuteUnverifiableResponseKeepsTheAvailableReadbackVisible()
+    {
+        var response = VolumeControlResponse.MuteUnverifiable(
+            false,
+            true,
+            "mute_readback_mismatch");
+
+        var roundTrip = RoundTrip(response);
+
+        Assert.Equal(ControlStatus.Unverifiable, roundTrip.Status);
+        Assert.False(roundTrip.RequestedMuted);
+        Assert.True(roundTrip.ObservedMuted);
+        Assert.Null(roundTrip.RequestedLevel);
+        Assert.Null(roundTrip.ObservedLevel);
+        Assert.Equal("mute_readback_mismatch", roundTrip.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("{\"status\":1,\"requested_level\":0.5,\"observed_level\":0.5,\"requested_muted\":true,\"observed_muted\":true}")]
+    [InlineData("{\"status\":1,\"requested_muted\":true}")]
+    [InlineData("{\"status\":5,\"requested_muted\":false,\"observed_level\":0.5,\"error_code\":\"mute_readback_mismatch\"}")]
+    public void DeserializationRejectsResponsesThatMixOrOmitControlValues(string payload)
+    {
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeResponse(payload));
     }
 
     private static VolumeControlResponse RoundTrip(VolumeControlResponse response)

--- a/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
+++ b/windows/tests/PanelDeControl.Core.Tests/VolumeControlContractTests.cs
@@ -112,16 +112,28 @@ public sealed class VolumeControlContractTests
     }
 
     [Fact]
-    public void AvailableResponseRoundTripsOnlyTheObservedLevel()
+    public void AvailableResponseRoundTripsBothEndpointObservations()
     {
-        var response = VolumeControlResponse.Available(0.72);
+        var response = VolumeControlResponse.Available(0.72, true);
 
         var roundTrip = RoundTrip(response);
 
         Assert.Equal(ControlStatus.Available, roundTrip.Status);
         Assert.Null(roundTrip.RequestedLevel);
         Assert.Equal(0.72, roundTrip.ObservedLevel);
+        Assert.Null(roundTrip.RequestedMuted);
+        Assert.True(roundTrip.ObservedMuted);
         Assert.Null(roundTrip.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("{\"status\":0,\"observed_level\":0.72}")]
+    [InlineData("{\"status\":0,\"observed_muted\":true}")]
+    public void DeserializationRejectsAvailableResponsesMissingAnObservation(
+        string payload)
+    {
+        Assert.Throws<InvalidDataException>(
+            () => VolumeControlWireCodec.DeserializeResponse(payload));
     }
 
     [Theory]

--- a/windows/tests/PanelDeControl.Hardware.Tests/CoreAudioVolumeControllerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/CoreAudioVolumeControllerTests.cs
@@ -22,16 +22,19 @@ public sealed class CoreAudioVolumeControllerTests
     }
 
     [Fact]
-    public void GetReturnsTheObservedDefaultEndpointLevel()
+    public void GetReturnsTheObservedDefaultEndpointLevelAndMuteState()
     {
-        var controller = new CoreAudioVolumeController(
-            new FixedEndpointProvider(0.30));
+        var provider = new FixedEndpointProvider(0.30, muted: true);
+        var controller = new CoreAudioVolumeController(provider);
 
         var response = controller.Get();
 
         Assert.Equal(ControlStatus.Available, response.Status);
         Assert.Equal(0.30, response.ObservedLevel);
+        Assert.True(response.ObservedMuted);
         Assert.Null(response.RequestedLevel);
+        Assert.Null(response.RequestedMuted);
+        Assert.Equal(1, provider.OpenCount);
     }
 
     [Fact]
@@ -59,6 +62,101 @@ public sealed class CoreAudioVolumeControllerTests
         Assert.Equal(0.55, response.RequestedLevel);
         Assert.Equal(0.42, response.ObservedLevel);
         Assert.Equal("volume_readback_mismatch", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMuteReportsAppliedOnlyAfterReadingTheExactRequestedMuteStateBack()
+    {
+        var provider = new FixedEndpointProvider(0.30, muted: false);
+        var controller = new CoreAudioVolumeController(provider);
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.Applied, response.Status);
+        Assert.True(response.RequestedMuted);
+        Assert.True(response.ObservedMuted);
+        Assert.Null(response.RequestedLevel);
+        Assert.Null(response.ObservedLevel);
+        Assert.Equal(1, provider.OpenCount);
+    }
+
+    [Fact]
+    public void SetMuteReportsUnverifiableWhenTheEndpointReadbackDoesNotMatch()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                muted: false,
+                forcedMuteReadback: false));
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.True(response.RequestedMuted);
+        Assert.False(response.ObservedMuted);
+        Assert.Equal("mute_readback_mismatch", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMuteReportsUnverifiableWhenReadbackFailsAfterTheWrite()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                readMuteExceptionAfterSet:
+                    new InvalidOperationException("private endpoint identifier")));
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.True(response.RequestedMuted);
+        Assert.Null(response.ObservedMuted);
+        Assert.Equal("mute_readback_failed", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMuteMapsAccessDenialToPermissionRequired()
+    {
+        var controller = new CoreAudioVolumeController(
+            new FixedEndpointProvider(
+                0.30,
+                setMuteException: new UnauthorizedAccessException("private account")));
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.PermissionRequired, response.Status);
+        Assert.Equal("audio_permission_required", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMuteMapsAMissingDefaultEndpointToUnavailable()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new COMException(
+                    "private endpoint identifier",
+                    unchecked((int)0x80070490))));
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.Unavailable, response.Status);
+        Assert.Equal("audio_endpoint_unavailable", response.ErrorCode);
+    }
+
+    [Fact]
+    public void SetMuteMapsUnexpectedProviderFailureWithoutLeakingItsMessage()
+    {
+        var controller = new CoreAudioVolumeController(
+            new ThrowingEndpointProvider(
+                new InvalidOperationException("private endpoint identifier")));
+
+        var response = controller.SetMute(true);
+
+        Assert.Equal(ControlStatus.Fault, response.Status);
+        Assert.Equal("volume_provider_failed", response.ErrorCode);
+        Assert.DoesNotContain(
+            "private endpoint identifier",
+            VolumeControlWireCodec.SerializeResponse(response));
     }
 
     [Fact]
@@ -188,50 +286,82 @@ public sealed class CoreAudioVolumeControllerTests
     private sealed class FixedEndpointProvider : IAudioEndpointVolumeProvider
     {
         private readonly double level;
+        private readonly bool muted;
         private readonly double? forcedReadback;
         private readonly Exception? readExceptionAfterSet;
         private readonly Exception? setException;
+        private readonly bool? forcedMuteReadback;
+        private readonly Exception? readMuteExceptionAfterSet;
+        private readonly Exception? setMuteException;
+
+        public int OpenCount { get; private set; }
 
         public FixedEndpointProvider(
             double level,
+            bool muted = false,
             double? forcedReadback = null,
             Exception? readExceptionAfterSet = null,
-            Exception? setException = null)
+            Exception? setException = null,
+            bool? forcedMuteReadback = null,
+            Exception? readMuteExceptionAfterSet = null,
+            Exception? setMuteException = null)
         {
             this.level = level;
+            this.muted = muted;
             this.forcedReadback = forcedReadback;
             this.readExceptionAfterSet = readExceptionAfterSet;
             this.setException = setException;
+            this.forcedMuteReadback = forcedMuteReadback;
+            this.readMuteExceptionAfterSet = readMuteExceptionAfterSet;
+            this.setMuteException = setMuteException;
         }
 
         public IAudioEndpointVolumeSession OpenDefaultRenderEndpoint()
         {
+            OpenCount++;
             return new FixedEndpointSession(
                 level,
+                muted,
                 forcedReadback,
                 readExceptionAfterSet,
-                setException);
+                setException,
+                forcedMuteReadback,
+                readMuteExceptionAfterSet,
+                setMuteException);
         }
     }
 
     private sealed class FixedEndpointSession : IAudioEndpointVolumeSession
     {
         private double level;
+        private bool muted;
         private readonly double? forcedReadback;
         private readonly Exception? readExceptionAfterSet;
         private readonly Exception? setException;
+        private readonly bool? forcedMuteReadback;
+        private readonly Exception? readMuteExceptionAfterSet;
+        private readonly Exception? setMuteException;
         private bool setCalled;
+        private bool setMuteCalled;
 
         public FixedEndpointSession(
             double level,
+            bool muted,
             double? forcedReadback,
             Exception? readExceptionAfterSet,
-            Exception? setException)
+            Exception? setException,
+            bool? forcedMuteReadback,
+            Exception? readMuteExceptionAfterSet,
+            Exception? setMuteException)
         {
             this.level = level;
+            this.muted = muted;
             this.forcedReadback = forcedReadback;
             this.readExceptionAfterSet = readExceptionAfterSet;
             this.setException = setException;
+            this.forcedMuteReadback = forcedMuteReadback;
+            this.readMuteExceptionAfterSet = readMuteExceptionAfterSet;
+            this.setMuteException = setMuteException;
         }
 
         public double GetMasterVolumeLevel()
@@ -253,6 +383,27 @@ public sealed class CoreAudioVolumeControllerTests
 
             setCalled = true;
             level = forcedReadback ?? requestedLevel;
+        }
+
+        public bool GetMute()
+        {
+            if (setMuteCalled && readMuteExceptionAfterSet is not null)
+            {
+                throw readMuteExceptionAfterSet;
+            }
+
+            return muted;
+        }
+
+        public void SetMute(bool requestedMuted)
+        {
+            if (setMuteException is not null)
+            {
+                throw setMuteException;
+            }
+
+            setMuteCalled = true;
+            muted = forcedMuteReadback ?? requestedMuted;
         }
 
         public void Dispose()

--- a/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
@@ -51,6 +51,31 @@ public sealed class VolumeControlPipeServerTests
     }
 
     [Fact]
+    public async Task SetMuteRequestReturnsTheControllerReadback()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        var controller = new CountingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.SetMute(true),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Applied, response.Status);
+        Assert.True(response.RequestedMuted);
+        Assert.True(response.ObservedMuted);
+        Assert.Equal(1, controller.SetMuteCount);
+        Assert.True(controller.Muted);
+    }
+
+    [Fact]
     public async Task MalformedRequestFailsClosedWithoutCallingTheController()
     {
         var pipeName = $"pvc-{Guid.NewGuid():N}";
@@ -199,6 +224,70 @@ public sealed class VolumeControlPipeServerTests
     }
 
     [Fact]
+    public async Task TimedOutSetMuteIsUnverifiableAndKeepsTheRequestedState()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        using var controller = new BlockingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe,
+            TimeSpan.FromMilliseconds(30));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var serverTask = server.RunOnceAsync(timeout.Token);
+        var response = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.SetMute(true),
+            timeout.Token);
+        await serverTask;
+
+        Assert.Equal(ControlStatus.Unverifiable, response.Status);
+        Assert.True(response.RequestedMuted);
+        Assert.Null(response.ObservedMuted);
+        Assert.Equal("volume_control_timeout", response.ErrorCode);
+        Assert.Equal(1, controller.SetMuteCount);
+        controller.Release();
+    }
+
+    [Fact]
+    public async Task BusySetMuteIsUnverifiableAndKeepsTheRequestedState()
+    {
+        var pipeName = $"pvc-{Guid.NewGuid():N}";
+        using var controller = new BlockingVolumeController();
+        var server = new VolumeControlPipeServer(
+            pipeName,
+            controller,
+            CreateTestPipe,
+            TimeSpan.FromMilliseconds(30));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var firstServerTask = server.RunOnceAsync(timeout.Token);
+        var firstResponse = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.SetMute(true),
+            timeout.Token);
+        await firstServerTask;
+
+        var secondServerTask = server.RunOnceAsync(timeout.Token);
+        var secondResponse = await RequestAsync(
+            pipeName,
+            VolumeControlRequest.SetMute(false),
+            timeout.Token);
+        await secondServerTask;
+
+        Assert.Equal(ControlStatus.Unverifiable, firstResponse.Status);
+        Assert.True(firstResponse.RequestedMuted);
+        Assert.Equal("volume_control_timeout", firstResponse.ErrorCode);
+        Assert.Equal(ControlStatus.Unverifiable, secondResponse.Status);
+        Assert.False(secondResponse.RequestedMuted);
+        Assert.Null(secondResponse.ObservedMuted);
+        Assert.Equal("volume_control_busy", secondResponse.ErrorCode);
+        Assert.Equal(1, controller.SetMuteCount);
+        controller.Release();
+    }
+
+    [Fact]
     public async Task ClientDisconnectDoesNotCrashTheBrokerLoop()
     {
         var pipeName = $"pvc-{Guid.NewGuid():N}";
@@ -332,6 +421,10 @@ public sealed class VolumeControlPipeServerTests
 
         public int SetCount { get; private set; }
 
+        public int SetMuteCount { get; private set; }
+
+        public bool Muted { get; private set; }
+
         public VolumeControlResponse Get()
         {
             GetCount++;
@@ -346,7 +439,9 @@ public sealed class VolumeControlPipeServerTests
 
         public VolumeControlResponse SetMute(bool requestedMuted)
         {
-            return VolumeControlResponse.MuteApplied(requestedMuted, requestedMuted);
+            SetMuteCount++;
+            Muted = requestedMuted;
+            return VolumeControlResponse.MuteApplied(requestedMuted, Muted);
         }
     }
 
@@ -379,6 +474,8 @@ public sealed class VolumeControlPipeServerTests
 
         public int SetCount { get; private set; }
 
+        public int SetMuteCount { get; private set; }
+
         public VolumeControlResponse Get()
         {
             GetCount++;
@@ -397,6 +494,7 @@ public sealed class VolumeControlPipeServerTests
 
         public VolumeControlResponse SetMute(bool requestedMuted)
         {
+            SetMuteCount++;
             entered.Set();
             release.Wait();
             return VolumeControlResponse.MuteApplied(requestedMuted, requestedMuted);

--- a/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
+++ b/windows/tests/PanelDeControl.Hardware.Tests/VolumeControlPipeServerTests.cs
@@ -301,6 +301,7 @@ public sealed class VolumeControlPipeServerTests
     private sealed class FixedVolumeController : ISystemVolumeController
     {
         private double level;
+        private bool muted;
 
         public FixedVolumeController(double level)
         {
@@ -309,13 +310,19 @@ public sealed class VolumeControlPipeServerTests
 
         public VolumeControlResponse Get()
         {
-            return VolumeControlResponse.Available(level);
+            return VolumeControlResponse.Available(level, muted);
         }
 
         public VolumeControlResponse Set(double requestedLevel)
         {
             level = requestedLevel;
             return VolumeControlResponse.Applied(requestedLevel, level);
+        }
+
+        public VolumeControlResponse SetMute(bool requestedMuted)
+        {
+            muted = requestedMuted;
+            return VolumeControlResponse.MuteApplied(requestedMuted, muted);
         }
     }
 
@@ -328,13 +335,18 @@ public sealed class VolumeControlPipeServerTests
         public VolumeControlResponse Get()
         {
             GetCount++;
-            return VolumeControlResponse.Available(0.50);
+            return VolumeControlResponse.Available(0.50, false);
         }
 
         public VolumeControlResponse Set(double requestedLevel)
         {
             SetCount++;
             return VolumeControlResponse.Applied(requestedLevel, requestedLevel);
+        }
+
+        public VolumeControlResponse SetMute(bool requestedMuted)
+        {
+            return VolumeControlResponse.MuteApplied(requestedMuted, requestedMuted);
         }
     }
 
@@ -346,6 +358,11 @@ public sealed class VolumeControlPipeServerTests
         }
 
         public VolumeControlResponse Set(double requestedLevel)
+        {
+            throw new InvalidOperationException("private endpoint identifier");
+        }
+
+        public VolumeControlResponse SetMute(bool requestedMuted)
         {
             throw new InvalidOperationException("private endpoint identifier");
         }
@@ -367,7 +384,7 @@ public sealed class VolumeControlPipeServerTests
             GetCount++;
             entered.Set();
             release.Wait();
-            return VolumeControlResponse.Available(0.50);
+            return VolumeControlResponse.Available(0.50, false);
         }
 
         public VolumeControlResponse Set(double requestedLevel)
@@ -376,6 +393,13 @@ public sealed class VolumeControlPipeServerTests
             entered.Set();
             release.Wait();
             return VolumeControlResponse.Applied(requestedLevel, requestedLevel);
+        }
+
+        public VolumeControlResponse SetMute(bool requestedMuted)
+        {
+            entered.Set();
+            release.Wait();
+            return VolumeControlResponse.MuteApplied(requestedMuted, requestedMuted);
         }
 
         public void Release()

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -346,6 +346,53 @@ class GameBarProjectTests(unittest.TestCase):
         self.assertIn("ControlStatus.Unverifiable", code)
         self.assertIn("ApplyVolumeResponse(volume)", code)
 
+    def test_widget_has_accessible_focusable_system_mute_control(self):
+        root = ElementTree.parse(WIDGET).getroot()
+        xaml_name = "{http://schemas.microsoft.com/winfx/2006/xaml}Name"
+        volume_card = next(
+            node
+            for node in root.iter()
+            if node.attrib.get(xaml_name) == "VolumeCard"
+        )
+        mute_toggle = next(
+            (
+                node
+                for node in volume_card.iter()
+                if node.attrib.get(xaml_name) == "MuteToggle"
+            ),
+            None,
+        )
+        names = {
+            node.attrib.get(xaml_name)
+            for node in volume_card.iter()
+        }
+
+        self.assertIsNotNone(mute_toggle)
+        self.assertIn("MuteStatus", names)
+        self.assertEqual("False", mute_toggle.attrib["IsEnabled"])
+        self.assertEqual("True", mute_toggle.attrib["IsTabStop"])
+        self.assertEqual(
+            "Silenciar audio del sistema",
+            mute_toggle.attrib["AutomationProperties.Name"],
+        )
+        self.assertTrue(mute_toggle.attrib["AutomationProperties.HelpText"])
+        self.assertEqual("MuteToggle_Toggled", mute_toggle.attrib["Toggled"])
+
+    def test_widget_verifies_mute_independently_and_ignores_stale_responses(self):
+        code = WIDGET_CODE.read_text(encoding="utf-8")
+
+        self.assertIn("MuteToggle_Toggled", code)
+        self.assertIn("volumeRefreshGeneration", code)
+        self.assertIn("muteRefreshGeneration", code)
+        self.assertIn("muteGeneration", code)
+        self.assertIn("muteWritePending", code)
+        self.assertIn("lastObservedMuted", code)
+        self.assertIn("volumeClient.SetMuteAsync", code)
+        self.assertIn("ApplyMuteResponse(volume)", code)
+        self.assertIn("response.ObservedMuted.HasValue", code)
+        self.assertIn("ApplyObservedMute(lastObservedMuted.Value)", code)
+        self.assertIn("CancelPendingMuteWrite", code)
+
     def test_project_compiles_shared_broker_launcher_and_volume_client(self):
         root = ElementTree.parse(PROJECT).getroot()
         namespace = {"msbuild": "http://schemas.microsoft.com/developer/msbuild/2003"}

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -380,6 +380,11 @@ class GameBarProjectTests(unittest.TestCase):
 
     def test_widget_verifies_mute_independently_and_ignores_stale_responses(self):
         code = WIDGET_CODE.read_text(encoding="utf-8")
+        refresh = code[
+            code.index("private async Task RefreshAsync()"):
+            code.index("private void ApplySnapshot")
+        ]
+        normalized_refresh = " ".join(refresh.split())
 
         self.assertIn("MuteToggle_Toggled", code)
         self.assertIn("volumeRefreshGeneration", code)
@@ -392,6 +397,16 @@ class GameBarProjectTests(unittest.TestCase):
         self.assertIn("response.ObservedMuted.HasValue", code)
         self.assertIn("ApplyObservedMute(lastObservedMuted.Value)", code)
         self.assertIn("CancelPendingMuteWrite", code)
+        self.assertIn(
+            "var muteWriteWasPendingAtRefreshStart = muteWritePending;",
+            normalized_refresh,
+        )
+        self.assertIn(
+            "if (!muteWriteWasPendingAtRefreshStart && "
+            "!muteWritePending && "
+            "muteRefreshGeneration == muteGeneration)",
+            normalized_refresh,
+        )
 
     def test_project_compiles_shared_broker_launcher_and_volume_client(self):
         root = ElementTree.parse(PROJECT).getroot()

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -339,12 +339,27 @@ class GameBarProjectTests(unittest.TestCase):
 
     def test_widget_debounces_volume_writes_and_ignores_stale_responses(self):
         code = WIDGET_CODE.read_text(encoding="utf-8")
+        refresh = code[
+            code.index("private async Task RefreshAsync()"):
+            code.index("private void ApplySnapshot")
+        ]
+        normalized_refresh = " ".join(refresh.split())
 
         self.assertIn("VolumeSlider_ValueChanged", code)
         self.assertIn("volumeGeneration", code)
         self.assertIn("TimeSpan.FromMilliseconds(150)", code)
         self.assertIn("ControlStatus.Unverifiable", code)
         self.assertIn("ApplyVolumeResponse(volume)", code)
+        self.assertIn(
+            "var volumeWriteWasPendingAtRefreshStart = volumeWritePending;",
+            normalized_refresh,
+        )
+        self.assertIn(
+            "if (!volumeWriteWasPendingAtRefreshStart && "
+            "!volumeWritePending && "
+            "volumeRefreshGeneration == volumeGeneration)",
+            normalized_refresh,
+        )
 
     def test_widget_has_accessible_focusable_system_mute_control(self):
         root = ElementTree.parse(WIDGET).getroot()
@@ -366,9 +381,18 @@ class GameBarProjectTests(unittest.TestCase):
             node.attrib.get(xaml_name)
             for node in volume_card.iter()
         }
+        mute_status = next(
+            node
+            for node in volume_card.iter()
+            if node.attrib.get(xaml_name) == "MuteStatus"
+        )
 
         self.assertIsNotNone(mute_toggle)
         self.assertIn("MuteStatus", names)
+        self.assertEqual(
+            "Polite",
+            mute_status.attrib.get("AutomationProperties.LiveSetting"),
+        )
         self.assertEqual("False", mute_toggle.attrib["IsEnabled"])
         self.assertEqual("True", mute_toggle.attrib["IsTabStop"])
         self.assertEqual(

--- a/windows/tests/test_gamebar_package.py
+++ b/windows/tests/test_gamebar_package.py
@@ -362,12 +362,21 @@ class GameBarProjectTests(unittest.TestCase):
     def test_volume_client_never_retries_an_indeterminate_write(self):
         code = VOLUME_CLIENT.read_text(encoding="utf-8")
 
+        self.assertIn(
+            "public Task<VolumeControlResponse> SetMuteAsync(bool requestedMuted)",
+            code,
+        )
+        self.assertIn(
+            "SendAsync(VolumeControlRequest.SetMute(requestedMuted))",
+            code,
+        )
         write_started = code.index("requestWriteStarted = true;")
         write_call = code.index("await writer.WriteLineAsync(")
         self.assertLess(write_started, write_call)
         self.assertIn("if (!attempt.RequestWriteStarted)", code)
         self.assertIn("control_response_unavailable", code)
         self.assertIn("VolumeControlResponse.Unverifiable", code)
+        self.assertIn("VolumeControlResponse.MuteUnverifiable", code)
         self.assertNotIn("Task.Run", code)
 
     def test_required_package_images_are_real_png_files(self):


### PR DESCRIPTION
## What does this change?

Adds a controller-friendly master mute control to the experimental Xbox Game Bar widget.

- Extends the existing volume contract with explicit mute request and readback fields.
- Reads volume and mute from the current default Core Audio `eRender/eConsole` endpoint.
- Applies `SetMute` once and reports success only when `GetMute` confirms the same state on the same endpoint session.
- Reuses the package-scoped control pipe, bounded timeouts, broker lifecycle, and no-retry boundary for indeterminate writes.
- Adds independent stale-response protection for volume and mute, accessible toggle status, and recovery from the last observed state.
- Keeps the capability independent of ASUS DMI and adds no persistence, automatic reapplication, per-application audio, or dependencies.

Windows remains Experimental. Physical validation on a ROG Xbox Ally X RC73XA is still pending.

## How was it tested?

- Core Release: 42/42
- Hardware Release: 53/53
- Game Bar package contract: 19/19
- Workflow isolation: 6/6
- Windows CI: `core-tests` and `gamebar-package` passed
- Locked restores and lockfile diff check passed
- UWP/Appx x64 build passed
- Artifact generated: `panel-de-control-gamebar-x64`

Windows CI run: https://github.com/Hooandee/panel-de-control/actions/runs/30614621505

Physical Game Bar/controller, endpoint switching, exclusive-mode, hide/show, and resume validation remains pending on RC73XA hardware.

## Checklist

- [x] The commit messages follow Conventional Commits.
- [ ] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` — not applicable; no Decky frontend changes.
- [ ] `ruff check py_modules main.py tests` and `python -m pytest` — not applicable; no Python product changes.
- [x] No secrets, tokens, personal data, or private development files are included.
- [x] No new third-party dependencies were added.
