### PR TITLE
fix(release): prevent silent Release Please skips

### DIFF
--- a/.github/workflows/changelog-bilingual.yml
+++ b/.github/workflows/changelog-bilingual.yml
@@ -6,6 +6,7 @@ name: changelog-bilingual
 # so the Spanish line is added by hand on the release PR and this check enforces it.
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
     paths: ["CHANGELOG.md"]
 
 permissions:
@@ -18,4 +19,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Keep the release PR parseable
+        env:
+          RELEASE_PR_TITLE: ${{ github.event.pull_request.title }}
+          RELEASE_PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/release_guard.py pr
       - run: python3 scripts/changelog_notes.py --check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,11 +41,17 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Build + attach the plugin zip only when a release was just tagged.
+      # The guard below must also run when release-please failed to recognise a
+      # merged release PR, so checkout cannot be conditional on release_created.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ steps.release.outputs.release_created }}
         with:
           persist-credentials: false
+
+      - name: Refuse an unrecognised release PR merge
+        env:
+          RELEASE_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
+        run: python3 scripts/release_guard.py result
 
       # Rewrite the release body into the clean, link-free, Spanish-first bilingual
       # note. Done in this job (not a separate on:release workflow) because a release

--- a/scripts/release_guard.py
+++ b/scripts/release_guard.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+
+_RELEASE_COMMIT = re.compile(
+    r"^chore\(main\): release panel-de-control "
+    r"(?P<version>\d+\.\d+\.\d+)(?: \(#\d+\))?$"
+)
+_RELEASE_HEADING = re.compile(r"^## \[(?P<version>\d+\.\d+\.\d+)\]\(")
+_RELEASE_FOOTER = (
+    "This PR was generated with [Release Please]"
+    "(https://github.com/googleapis/release-please). See "
+    "[documentation](https://github.com/googleapis/release-please#release-please)."
+)
+
+
+def _release_version(value: str) -> str | None:
+    first_line = value.splitlines()[0] if value else ""
+    match = _RELEASE_COMMIT.fullmatch(first_line.strip())
+    return match.group("version") if match else None
+
+
+def validate_pr(title: str, body: str) -> str | None:
+    version = _release_version(title)
+    if version is None:
+        return None
+
+    lines = body.replace("\r\n", "\n").splitlines()
+    delimiters = [index for index, line in enumerate(lines) if line == "---"]
+    if len(delimiters) < 2:
+        return (
+            "Release Please no puede reconocer esta PR: conserva los dos "
+            "delimitadores '---', el bloque de la versión y el footer generado."
+        )
+
+    content = lines[delimiters[0] + 1 : delimiters[-1]]
+    first_content_line = next((line.strip() for line in content if line.strip()), "")
+    heading = _RELEASE_HEADING.match(first_content_line)
+    if heading is None or heading.group("version") != version:
+        return (
+            "Release Please no puede reconocer esta PR: la primera línea útil del "
+            f"bloque generado debe contener la versión {version}."
+        )
+
+    footer = "\n".join(lines[delimiters[-1] + 1 :])
+    if _RELEASE_FOOTER not in footer:
+        return (
+            "Release Please no puede reconocer esta PR: restaura el footer generado "
+            "completo después del último delimitador."
+        )
+    return None
+
+
+def validate_result(commit_message: str, release_created: str) -> str | None:
+    version = _release_version(commit_message)
+    if version is not None and release_created.lower() != "true":
+        return (
+            f"El commit de release {version} no creó el tag ni el artefacto. "
+            "Release Please probablemente no pudo analizar el cuerpo de la PR."
+        )
+    return None
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode == "pr":
+        error = validate_pr(
+            os.environ.get("RELEASE_PR_TITLE", ""),
+            os.environ.get("RELEASE_PR_BODY", ""),
+        )
+    elif mode == "result":
+        error = validate_result(
+            os.environ.get("RELEASE_COMMIT_MESSAGE", ""),
+            os.environ.get("RELEASE_CREATED", ""),
+        )
+    else:
+        print("usage: release_guard.py pr | result", file=sys.stderr)
+        return 2
+
+    if error:
+        print(f"::error::{error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_guard.py
+++ b/tests/test_release_guard.py
@@ -1,0 +1,134 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release_guard.py"
+GENERATED_FOOTER = (
+    "This PR was generated with [Release Please]"
+    "(https://github.com/googleapis/release-please). See "
+    "[documentation](https://github.com/googleapis/release-please#release-please)."
+)
+
+
+def _run(mode: str, **values: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, **values}
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), mode],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_pr_rejects_release_body_that_release_please_cannot_parse():
+    result = _run(
+        "pr",
+        RELEASE_PR_TITLE="chore(main): release panel-de-control 0.36.0",
+        RELEASE_PR_BODY="## Español\n\nNotas humanas sin el bloque generado.",
+    )
+
+    assert result.returncode == 1
+    assert "Release Please no puede reconocer" in result.stdout
+
+
+def test_pr_accepts_human_header_around_parseable_release_body():
+    body = f"""Resumen humano en español.
+---
+
+## [0.37.0](https://example.test/compare) (2026-08-09)
+
+* Cambio visible
+
+---
+{GENERATED_FOOTER}
+"""
+    result = _run(
+        "pr",
+        RELEASE_PR_TITLE="chore(main): release panel-de-control 0.37.0",
+        RELEASE_PR_BODY=body,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_pr_rejects_human_text_inside_generated_release_section():
+    body = f"""Resumen humano fuera del bloque.
+---
+
+Esta línea impide que el parser encuentre la versión.
+## [0.37.0](https://example.test/compare) (2026-08-09)
+
+---
+{GENERATED_FOOTER}
+"""
+    result = _run(
+        "pr",
+        RELEASE_PR_TITLE="chore(main): release panel-de-control 0.37.0",
+        RELEASE_PR_BODY=body,
+    )
+
+    assert result.returncode == 1
+    assert "primera línea útil" in result.stdout
+
+
+def test_pr_rejects_truncated_release_please_footer():
+    body = """Resumen humano.
+---
+
+## [0.37.0](https://example.test/compare) (2026-08-09)
+
+---
+This PR was generated with [Release Please](https://example.test/wrong).
+"""
+    result = _run(
+        "pr",
+        RELEASE_PR_TITLE="chore(main): release panel-de-control 0.37.0",
+        RELEASE_PR_BODY=body,
+    )
+
+    assert result.returncode == 1
+    assert "footer generado completo" in result.stdout
+
+
+def test_pr_ignores_non_release_pull_requests():
+    result = _run(
+        "pr",
+        RELEASE_PR_TITLE="docs: improve installation guide",
+        RELEASE_PR_BODY="Any body is valid here.",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_result_rejects_release_commit_without_created_release():
+    result = _run(
+        "result",
+        RELEASE_COMMIT_MESSAGE=(
+            "chore(main): release panel-de-control 0.36.0 (#415)\n\nRelease notes"
+        ),
+        RELEASE_CREATED="false",
+    )
+
+    assert result.returncode == 1
+    assert "no creó el tag ni el artefacto" in result.stdout
+
+
+def test_result_accepts_created_release_and_regular_commit():
+    released = _run(
+        "result",
+        RELEASE_COMMIT_MESSAGE="chore(main): release panel-de-control 0.37.0 (#416)",
+        RELEASE_CREATED="true",
+    )
+    regular = _run(
+        "result",
+        RELEASE_COMMIT_MESSAGE="fix: keep plugin bundle loadable",
+        RELEASE_CREATED="false",
+    )
+
+    assert released.returncode == 0, released.stdout + released.stderr
+    assert regular.returncode == 0, regular.stdout + regular.stderr


### PR DESCRIPTION
## Summary

- Validate Release Please PR titles and generated body markers whenever a release PR is opened, edited, reopened, or synchronized.
- Fail the release workflow when a merged release commit does not produce `release_created=true`.
- Add regression coverage for valid metadata, version mismatches, missing delimiters, truncated footers, and silent post-merge skips.

## Root cause

The body of release PR #415 was replaced with hand-written release notes, removing the delimiters and footer that Release Please uses to recognize and update its PR. The action then reported that it could not parse the release PR body, skipped release creation and artifact upload, but the workflow still finished successfully.

This explains the missing 0.35/0.36 GitHub release artifacts. It does not by itself prove that every reported Decky dynamic-import failure has this cause; those reports still need the installed plugin version/source and Decky logs.

## Impact

Release metadata corruption now produces a visible failing check before merge, and a merged release commit that silently creates no GitHub release also fails the workflow. Runtime plugin behavior and device-specific code are unchanged.

## Verification

- `pnpm test:fe` — 641 tests passed
- `pnpm typecheck`
- `pnpm build`
- `.venv/bin/python -m pytest -q` — 1922 passed, 1 skipped, 55 subtests
- `ruff check .`
- Workflow YAML parsed successfully
- `git diff --check`
