### PR TITLE
fix: preserve QAM scroll position

### DIFF
--- a/src/components/QamPanelGate.test.tsx
+++ b/src/components/QamPanelGate.test.tsx
@@ -8,6 +8,7 @@ let resizeCallback: ResizeObserverCallback;
 let observer: FakeResizeObserver;
 let intersectionCallback: IntersectionObserverCallback;
 let intersectionObserver: FakeIntersectionObserver;
+let intersectionOptions: IntersectionObserverInit | undefined;
 
 class FakeResizeObserver {
   observe = vi.fn();
@@ -23,9 +24,10 @@ class FakeIntersectionObserver {
   observe = vi.fn();
   disconnect = vi.fn();
 
-  constructor(callback: IntersectionObserverCallback) {
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
     intersectionCallback = callback;
     intersectionObserver = this;
+    intersectionOptions = options;
   }
 }
 
@@ -49,15 +51,43 @@ function visibleIntersection(target: Element): IntersectionObserverEntry {
   };
 }
 
+function outsideViewport(target: Element, rect: DOMRect): IntersectionObserverEntry {
+  return {
+    target,
+    time: 0,
+    rootBounds: {
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 800,
+      width: 268,
+      height: 800,
+    } as DOMRectReadOnly,
+    boundingClientRect: rect,
+    intersectionRect: {
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    } as DOMRectReadOnly,
+    isIntersecting: false,
+    intersectionRatio: 0,
+  };
+}
+
 describe("QamPanelGate", () => {
   beforeEach(() => {
     setDocumentVisibility("visible");
+    intersectionOptions = undefined;
     window.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
     window.IntersectionObserver = FakeIntersectionObserver as unknown as typeof IntersectionObserver;
   });
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -94,27 +124,246 @@ describe("QamPanelGate", () => {
     expect(screen.queryByTestId("heavy-panel")).toBeNull();
   });
 
-  it("unmounts children when the QAM document becomes hidden", () => {
+  it("keeps mounted content when vertical scrolling moves the gate edge above the viewport", () => {
     render(
       <QamPanelGate lifecycle={new AbortController().signal}>
         <div data-testid="heavy-panel" />
       </QamPanelGate>,
     );
     const host = screen.getByTestId("qam-panel-gate");
-    vi.spyOn(host, "getBoundingClientRect").mockReturnValue({ width: 268, height: 1 } as DOMRect);
+    const rect = vi.spyOn(host, "getBoundingClientRect");
+    const scrolledRect = {
+      left: 0,
+      right: 268,
+      top: -1,
+      bottom: 0,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(scrolledRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, scrolledRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.queryByTestId("heavy-panel")).toBeNull();
+
+    rect.mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
+    act(() => intersectionCallback([
+      visibleIntersection(host),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.getByTestId("heavy-panel")).toBeTruthy();
+
+    rect.mockReturnValue(scrolledRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, scrolledRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+
+    expect(screen.getByTestId("heavy-panel")).toBeTruthy();
+  });
+
+  it("unmounts content that moves horizontally after being retained during vertical scroll", () => {
+    vi.useFakeTimers();
+    render(
+      <QamPanelGate lifecycle={new AbortController().signal}>
+        <div data-testid="heavy-panel" style={{ height: 1000 }} />
+      </QamPanelGate>,
+    );
+    const host = screen.getByTestId("qam-panel-gate");
+    const rect = vi.spyOn(host, "getBoundingClientRect");
+    const enteringRect = {
+      left: 200,
+      right: 468,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(enteringRect);
+    act(() => intersectionCallback([{
+      ...visibleIntersection(host),
+      boundingClientRect: enteringRect,
+      intersectionRect: {
+        left: 200,
+        right: 268,
+        top: 0,
+        bottom: 1,
+        width: 68,
+        height: 1,
+      } as DOMRectReadOnly,
+      intersectionRatio: 68 / 268,
+    }], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.queryByTestId("heavy-panel")).toBeNull();
+    expect(intersectionOptions?.threshold).toEqual([0, 1]);
+
+    rect.mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
+    act(() => intersectionCallback([
+      visibleIntersection(host),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.getByTestId("heavy-panel")).toBeTruthy();
+
+    const scrolledRect = {
+      left: 0,
+      right: 268,
+      top: -1,
+      bottom: 0,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(scrolledRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, scrolledRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.getByTestId("heavy-panel")).toBeTruthy();
+
+    const hiddenRect = {
+      left: 268,
+      right: 536,
+      top: -1,
+      bottom: 0,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(hiddenRect);
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(screen.queryByTestId("heavy-panel")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+
+    rect.mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
+    act(() => intersectionCallback([
+      visibleIntersection(host),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(screen.getByTestId("heavy-panel")).toBeTruthy();
+  });
+
+  it("keeps settled bounds when content resizes during a partial tab exit", () => {
+    vi.useFakeTimers();
+    render(
+      <QamPanelGate lifecycle={new AbortController().signal}>
+        <div data-testid="heavy-panel" />
+      </QamPanelGate>,
+    );
+    const host = screen.getByTestId("qam-panel-gate");
+    const rect = vi.spyOn(host, "getBoundingClientRect");
+    rect.mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
+    act(() => intersectionCallback([
+      visibleIntersection(host),
+    ], intersectionObserver as unknown as IntersectionObserver));
+
+    const exitingRect = {
+      left: 200,
+      right: 468,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(exitingRect);
+    act(() => intersectionCallback([{
+      ...visibleIntersection(host),
+      boundingClientRect: exitingRect,
+      intersectionRect: {
+        left: 200,
+        right: 268,
+        top: 0,
+        bottom: 1,
+        width: 68,
+        height: 1,
+      } as DOMRectReadOnly,
+      intersectionRatio: 68 / 268,
+    }], intersectionObserver as unknown as IntersectionObserver));
+    act(() => resizeCallback([], observer as unknown as ResizeObserver));
+
+    const hiddenRect = {
+      left: 268,
+      right: 536,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    rect.mockReturnValue(hiddenRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, hiddenRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(screen.queryByTestId("heavy-panel")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("unmounts children when the QAM document becomes hidden", () => {
+    vi.useFakeTimers();
+    render(
+      <QamPanelGate lifecycle={new AbortController().signal}>
+        <div data-testid="heavy-panel" />
+      </QamPanelGate>,
+    );
+    const host = screen.getByTestId("qam-panel-gate");
+    vi.spyOn(host, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
     act(() => resizeCallback([], observer as unknown as ResizeObserver));
     act(() => intersectionCallback([
       visibleIntersection(host),
     ], intersectionObserver as unknown as IntersectionObserver));
     expect(screen.getByTestId("heavy-panel")).toBeTruthy();
 
+    const scrolledRect = {
+      left: 0,
+      right: 268,
+      top: -1,
+      bottom: 0,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    vi.spyOn(host, "getBoundingClientRect").mockReturnValue(scrolledRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, scrolledRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(vi.getTimerCount()).toBe(1);
+
     setDocumentVisibility("hidden");
     act(() => document.dispatchEvent(new Event("visibilitychange")));
 
     expect(screen.queryByTestId("heavy-panel")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("makes a materialized panel inert when its plugin lifecycle ends", () => {
+    vi.useFakeTimers();
     const lifecycle = new AbortController();
     render(
       <QamPanelGate lifecycle={lifecycle.signal}>
@@ -122,15 +371,37 @@ describe("QamPanelGate", () => {
       </QamPanelGate>,
     );
     const host = screen.getByTestId("qam-panel-gate");
-    vi.spyOn(host, "getBoundingClientRect").mockReturnValue({ width: 268, height: 1 } as DOMRect);
+    vi.spyOn(host, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      right: 268,
+      top: 0,
+      bottom: 1,
+      width: 268,
+      height: 1,
+    } as DOMRect);
     act(() => intersectionCallback([
       visibleIntersection(host),
     ], intersectionObserver as unknown as IntersectionObserver));
     expect(screen.getByTestId("heavy-panel")).toBeTruthy();
 
+    const scrolledRect = {
+      left: 0,
+      right: 268,
+      top: -1,
+      bottom: 0,
+      width: 268,
+      height: 1,
+    } as DOMRect;
+    vi.spyOn(host, "getBoundingClientRect").mockReturnValue(scrolledRect);
+    act(() => intersectionCallback([
+      outsideViewport(host, scrolledRect),
+    ], intersectionObserver as unknown as IntersectionObserver));
+    expect(vi.getTimerCount()).toBe(1);
+
     act(() => lifecycle.abort());
 
     expect(screen.queryByTestId("heavy-panel")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
     expect(observer.disconnect).toHaveBeenCalledOnce();
     expect(intersectionObserver.disconnect).toHaveBeenCalledOnce();
   });

--- a/src/components/QamPanelGate.tsx
+++ b/src/components/QamPanelGate.tsx
@@ -17,6 +17,18 @@ interface QamPanelGateProps extends PropsWithChildren {
   fallback?: ReactNode;
 }
 
+// Ancestor overflow can suppress IntersectionObserver updates after vertical clipping.
+const RETAINED_TAB_CHECK_MS = 100;
+
+interface HorizontalBounds {
+  left: number;
+  right: number;
+}
+
+function overlapsHorizontally(rect: DOMRect, bounds: HorizontalBounds): boolean {
+  return rect.left < bounds.right && rect.right > bounds.left;
+}
+
 export function canGateQamPanel(host: QamPanelCapabilities = window): boolean {
   return typeof host.ResizeObserver === "function"
     && typeof host.IntersectionObserver === "function";
@@ -36,12 +48,29 @@ export const QamPanelGate: FC<QamPanelGateProps> = ({ children, lifecycle, fallb
 
     let resize: ResizeObserver | null = null;
     let intersection: IntersectionObserver | null = null;
-    let intersecting = false;
+    let fullyIntersecting = false;
+    let retainedDuringScroll = false;
+    let visibleHorizontalBounds: HorizontalBounds | null = null;
+    let retentionPoll: number | null = null;
     let gated = false;
     let stopped = false;
+    const stopRetentionPoll = () => {
+      if (retentionPoll === null) return;
+      doc.defaultView?.clearInterval(retentionPoll);
+      retentionPoll = null;
+    };
+    const canRetainAtCurrentPosition = () => {
+      const rect = host.getBoundingClientRect();
+      return visibleHorizontalBounds !== null
+        && rect.width > 0
+        && rect.height > 0
+        && overlapsHorizontally(rect, visibleHorizontalBounds);
+    };
     const refresh = () => {
       if (stopped) return;
       if (lifecycle.aborted || doc.visibilityState !== "visible") {
+        retainedDuringScroll = false;
+        stopRetentionPoll();
         setMode("hidden");
         return;
       }
@@ -50,11 +79,28 @@ export const QamPanelGate: FC<QamPanelGateProps> = ({ children, lifecycle, fallb
         return;
       }
       const rect = host.getBoundingClientRect();
-      setMode(intersecting && rect.width > 0 && rect.height > 0 ? "content" : "hidden");
+      setMode(
+        (fullyIntersecting || retainedDuringScroll) && rect.width > 0 && rect.height > 0
+          ? "content"
+          : "hidden",
+      );
+    };
+    const pollRetainedPosition = () => {
+      const nextRetained = canRetainAtCurrentPosition();
+      if (nextRetained === retainedDuringScroll) return;
+      retainedDuringScroll = nextRetained;
+      if (!nextRetained) stopRetentionPoll();
+      refresh();
+    };
+    const startRetentionPoll = () => {
+      const view = doc.defaultView;
+      if (retentionPoll !== null || !view) return;
+      retentionPoll = view.setInterval(pollRetainedPosition, RETAINED_TAB_CHECK_MS);
     };
     const disconnect = () => {
       intersection?.disconnect();
       resize?.disconnect();
+      stopRetentionPoll();
       intersection = null;
       resize = null;
     };
@@ -83,12 +129,30 @@ export const QamPanelGate: FC<QamPanelGateProps> = ({ children, lifecycle, fallb
     }
 
     try {
-      resize = new Resize(refresh);
-      intersection = new Intersection((entries) => {
-        const entry = entries.find((candidate) => candidate.target === host);
-        intersecting = !!entry?.isIntersecting && entry.intersectionRatio > 0;
+      resize = new Resize(() => {
+        if (retainedDuringScroll) {
+          retainedDuringScroll = canRetainAtCurrentPosition();
+          if (!retainedDuringScroll) stopRetentionPoll();
+        }
         refresh();
       });
+      intersection = new Intersection((entries) => {
+        const entry = entries.find((candidate) => candidate.target === host);
+        fullyIntersecting = !!entry?.isIntersecting && entry.intersectionRatio === 1;
+        if (fullyIntersecting && entry) {
+          retainedDuringScroll = false;
+          visibleHorizontalBounds = {
+            left: entry.boundingClientRect.left,
+            right: entry.boundingClientRect.right,
+          };
+          stopRetentionPoll();
+        } else {
+          retainedDuringScroll = !!entry && canRetainAtCurrentPosition();
+          if (retainedDuringScroll) startRetentionPoll();
+          else stopRetentionPoll();
+        }
+        refresh();
+      }, { threshold: [0, 1] });
       gated = true;
       resize.observe(host);
       intersection.observe(host);


### PR DESCRIPTION
## What does this change?

Keeps the direct QAM panel mounted when vertical scrolling clips its visibility sentinel, preventing Steam from collapsing the panel and resetting the scroll position to the top.

The gate still waits for a fully visible tab before mounting the heavy content and still unmounts after a horizontal tab exit. A short, bounded geometry check covers the Chromium overflow case where `IntersectionObserver` stops emitting after vertical clipping.

Closes #422.
Closes #424.
Closes #425.

## How was it tested?

- `pnpm test:fe` — 644 tests passed.
- `pnpm typecheck`.
- `pnpm build`.
- `ruff check py_modules main.py tests`.
- `python -m pytest` — 1,928 passed and 1 skipped.
- ROG Xbox Ally X: opened the direct QAM tab, selected Display, scrolled from 0 to 739 px, and verified after 1.2 seconds that the position remained stable and the same panel tree stayed mounted.
- Legion Go 2: deployed the same bundle and verified the plugin loader, installed version, and bundle readback.

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.
