### PR TITLE
fix: handle bogus Legion Go S TDP ceilings

### DIFF
--- a/main.py
+++ b/main.py
@@ -2250,13 +2250,12 @@ class Plugin:
         return levels, active, ac
 
     def _cap_level_limits(self, ll: dict, active_max: int) -> dict:
-        """Cap PL1 (sustained) to the active power ceiling. The boost rails PL2/PL3
-        keep their FIRMWARE max — they are short-term limits that legitimately exceed
-        PL1 (SPPT 45 / FPPT 55 on the Ally). Capping them to PL1's ceiling left the
-        additive boost offsets at 0 once PL1 reached the max (e.g. unlocked to 35 W)."""
         out = {}
+        cap_boost = bool(
+            getattr(self._tdp_backend, "cap_boost_to_active", False)
+        )
         for key, b in ll.items():
-            if key == "pl1":
+            if key == "pl1" or cap_boost:
                 hi = min(b["max"], active_max)
                 out[key] = {"min": min(b["min"], hi), "max": hi}
             else:

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -17,11 +17,24 @@ def is_gpd_win_mini_2025(device, root: str = "/") -> bool:
     )
 
 
-def legion_go_s_83n6_rail_floors(device, root: str = "/") -> dict[str, int]:
-    if (
+def is_legion_go_s_83n6(device, root: str = "/") -> bool:
+    return (
         getattr(device, "key", None) == "legion_go_s"
         and _read_dmi(root, "sys_vendor").casefold() == "lenovo"
         and _read_dmi(root, "product_name").casefold() == "83n6"
-    ):
+    )
+
+
+def legion_go_s_83n6_rail_floors(device, root: str = "/") -> dict[str, int]:
+    if is_legion_go_s_83n6(device, root):
         return {"pl2": 15, "pl3": 20}
     return {}
+
+
+def legion_go_s_83n6_firmware_attr_quirks(device, root: str = "/") -> dict:
+    if not is_legion_go_s_83n6(device, root):
+        return {}
+    return {
+        "ignored_live_maxes": {"pl1": 15, "pl2": 15, "pl3": 20},
+        "cap_boost_to_active": True,
+    }

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -1,5 +1,6 @@
 from device_quirks import (
     is_gpd_win_mini_2025,
+    legion_go_s_83n6_firmware_attr_quirks,
     legion_go_s_83n6_rail_floors,
 )
 from tdp.alib import AlibBackend
@@ -33,6 +34,7 @@ def _candidates(device, fallback, root, ryzenadj):
             profile_name="lenovo-wmi-gamezone",
             is_generic=generic,
             rail_floors=legion_go_s_83n6_rail_floors(device, root),
+            **legion_go_s_83n6_firmware_attr_quirks(device, root),
         )
 
     def msi():

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -41,6 +41,21 @@ def _normalise_rail_floors(values):
     return floors
 
 
+def _normalise_rail_values(values):
+    if not isinstance(values, dict):
+        return {}
+    known_rails = {rail for rail, _attr in _RAIL_ATTRS}
+    normalised = {}
+    for rail, value in values.items():
+        if rail not in known_rails:
+            continue
+        try:
+            normalised[rail] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return normalised
+
+
 class FirmwareAttrBackend(TDPBackend):
     """TDP via kernel firmware-attributes. Covers ASUS (asus-armoury), Lenovo
     (lenovo-wmi-other), MSI (msi-wmi-platform): ppt_pl1_spl/ppt_pl2_sppt/ppt_pl3_fppt
@@ -54,6 +69,8 @@ class FirmwareAttrBackend(TDPBackend):
         profile_name=None,
         is_generic=False,
         rail_floors=None,
+        ignored_live_maxes=None,
+        cap_boost_to_active=False,
     ):
         self.name = f"firmware-attr:{driver_prefix}"
         self._fallback = fallback
@@ -61,6 +78,8 @@ class FirmwareAttrBackend(TDPBackend):
         self._profile_name = profile_name  # Lenovo: set this platform-profile to "custom" first
         self._is_generic = is_generic
         self._rail_floors = _normalise_rail_floors(rail_floors)
+        self._ignored_live_maxes = _normalise_rail_values(ignored_live_maxes)
+        self.cap_boost_to_active = bool(cap_boost_to_active)
         self._dir = self._find_driver_dir(driver_prefix)
         self.supported = self._dir is not None and os.path.exists(self._attr("ppt_pl1_spl"))
         self._pp_dir = self._find_profile_dir()  # static, resolved once
@@ -205,13 +224,10 @@ class FirmwareAttrBackend(TDPBackend):
                     )
                     out[key] = {"min": lo, "max": hi}
             return out
-        # Recognised: rails from the profile (PL1 = charger max, boost scaled); writes
-        # clamp to the live ceiling anyway.
-        mn, mx = self._fallback.min_w, self._fallback.max_ac_w
+        mn = self._fallback.min_w
         bounds = {
-            "pl1": {"min": mn, "max": mx},
-            "pl2": {"min": mn, "max": round(mx * _PL2_BOOST_RATIO)},
-            "pl3": {"min": mn, "max": round(mx * _PL3_BOOST_RATIO)},
+            rail: {"min": mn, "max": self._profile_rail_max(attr)}
+            for rail, attr in _RAIL_ATTRS
         }
         for rail, floor in self._rail_floors.items():
             bound = bounds[rail]
@@ -223,21 +239,29 @@ class FirmwareAttrBackend(TDPBackend):
         charger max, boost rails profile-scaled. The profile is the authority — not the
         firmware's reported max, which some ASUS kernels report as a bogus 150 W."""
         mx = self._fallback.max_ac_w
+        if self.cap_boost_to_active:
+            return mx
         if attr == "ppt_pl2_sppt":
             return round(mx * _PL2_BOOST_RATIO)
         if attr == "ppt_pl3_fppt":
             return round(mx * _PL3_BOOST_RATIO)
         return mx
 
+    def _effective_live_max(self, rail, reported):
+        if reported == self._ignored_live_maxes.get(rail):
+            return None
+        return reported
+
     def _clamp_live(self, value, attr):
         mn, mx = self._live_bounds(attr)
         safe_hi = self._profile_rail_max(attr)
-        hi = min(mx if mx is not None else safe_hi, safe_hi)
-        live_lo = mn if mn is not None else self._fallback.min_w
         rail = next(
             (rail for rail, rail_attr in _RAIL_ATTRS if rail_attr == attr),
             None,
         )
+        live_hi = self._effective_live_max(rail, mx)
+        hi = min(live_hi if live_hi is not None else safe_hi, safe_hi)
+        live_lo = mn if mn is not None else self._fallback.min_w
         floor = self._rail_floors.get(rail, self._fallback.min_w)
         lo = min(hi, max(self._fallback.min_w, live_lo, floor))
         return max(lo, min(int(value), hi))
@@ -245,9 +269,6 @@ class FirmwareAttrBackend(TDPBackend):
     def set_levels(self, pl1, pl2, pl3, ac):
         if not self.supported:
             return TdpResult(pl1, None, False, "firmware-attributes path not present")
-        # Custom mode first (Lenovo prestep), then clamp each rail to the LIVE ceiling:
-        # writing above it is rejected, so the applied value follows what the firmware
-        # accepts now (25 W on battery, 30 W on charger) while the profile range stays put.
         self._set_custom_profile()
         values = {"pl1": pl1, "pl2": pl2, "pl3": pl3}
         attrs = dict(_RAIL_ATTRS)
@@ -299,7 +320,11 @@ class FirmwareAttrBackend(TDPBackend):
             if not os.path.exists(path):
                 continue
             lo, hi = self._live_bounds(attr)
-            primary[rail] = RailReading(self._read_int(path), lo, hi)
+            primary[rail] = RailReading(
+                self._read_int(path),
+                lo,
+                self._effective_live_max(rail, hi),
+            )
         surfaces = {self.name: primary} if primary else {}
         legacy = {
             rail: RailReading(self._read_int(path))
@@ -308,6 +333,19 @@ class FirmwareAttrBackend(TDPBackend):
         if legacy:
             surfaces["asus-nb-wmi"] = legacy
         return TdpObservation(readable=True, surfaces=surfaces)
+
+    def diagnostics(self):
+        reported = {}
+        for rail, attr in _RAIL_ATTRS:
+            if rail not in self._rails:
+                continue
+            lo, hi = self._live_bounds(attr)
+            reported[rail] = {"min": lo, "max": hi}
+        return {
+            "boost_capped_to_active": self.cap_boost_to_active,
+            "ignored_live_maxes": dict(self._ignored_live_maxes),
+            "reported_live_bounds": reported,
+        }
 
     @staticmethod
     def _observation_mismatches(observation, targets):

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -5,6 +5,7 @@ from device_profiles import DEVICE_TABLE, GENERIC
 from tdp import factory
 from tdp.backend import NullBackend
 from tdp.factory import select_backend
+from tdp.reconcile import build_targets
 
 
 def _p(key):
@@ -42,6 +43,17 @@ def _mk_dmi(root, vendor, product):
     for name, value in (("sys_vendor", vendor), ("product_name", product)):
         with open(os.path.join(base, name), "w") as f:
             f.write(value)
+
+
+def _set_fw_max(root, rail, value):
+    path = os.path.join(
+        root,
+        "sys/class/firmware-attributes/lenovo-wmi-other-0/attributes",
+        rail,
+        "max_value",
+    )
+    with open(path, "w") as handle:
+        handle.write(str(value))
 
 
 _NO_RYZENADJ = lambda: None  # noqa: E731
@@ -87,6 +99,141 @@ def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
 
     assert getattr(exact, "_rail_floors", None) == {"pl2": 15, "pl3": 20}
     assert getattr(nearby, "_rail_floors", None) == {}
+
+
+def test_exact_legion_go_s_83n6_applies_profile_safe_target_despite_low_firmware_max(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0", pl1_max=15)
+    _mk_dmi(root, "LENOVO", "83N6")
+    _set_fw_max(root, "ppt_pl2_sppt", 15)
+    _set_fw_max(root, "ppt_pl3_fppt", 20)
+
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    requested = {"pl1": 30, "pl2": 30, "pl3": 30}
+    targets = build_targets(requested, backend.level_limits(), backend.observe())
+    result = backend.apply_targets(targets.target, ac=True)
+
+    assert targets.target == requested
+    assert result.ok is True
+    assert result.applied_w == 30
+
+
+def test_exact_legion_go_s_83n6_does_not_unlock_unverified_boost_range(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0", pl1_max=15)
+    _mk_dmi(root, "LENOVO", "83N6")
+    _set_fw_max(root, "ppt_pl2_sppt", 15)
+    _set_fw_max(root, "ppt_pl3_fppt", 20)
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    targets = build_targets(
+        {"pl1": 999, "pl2": 999, "pl3": 999},
+        backend.level_limits(),
+        backend.observe(),
+    )
+
+    assert targets.target == {"pl1": 40, "pl2": 40, "pl3": 40}
+
+
+def test_exact_legion_go_s_83n6_uses_non_sentinel_live_max(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0", pl1_max=25)
+    _mk_dmi(root, "LENOVO", "83N6")
+    _set_fw_max(root, "ppt_pl2_sppt", 30)
+    _set_fw_max(root, "ppt_pl3_fppt", 35)
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    rails = backend.observe().surfaces[backend.name]
+
+    assert {rail: reading.max_w for rail, reading in rails.items()} == {
+        "pl1": 25,
+        "pl2": 30,
+        "pl3": 35,
+    }
+
+
+def test_exact_legion_go_s_83n6_diagnostics_keep_reported_sentinel_max(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0", pl1_max=15)
+    _mk_dmi(root, "LENOVO", "83N6")
+    _set_fw_max(root, "ppt_pl2_sppt", 15)
+    _set_fw_max(root, "ppt_pl3_fppt", 20)
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    assert backend.diagnostics() == {
+        "boost_capped_to_active": True,
+        "ignored_live_maxes": {"pl1": 15, "pl2": 15, "pl3": 20},
+        "reported_live_bounds": {
+            "pl1": {"min": 5, "max": 15},
+            "pl2": {"min": 5, "max": 15},
+            "pl3": {"min": 5, "max": 20},
+        },
+    }
+
+
+def test_nearby_legion_go_s_still_honours_low_firmware_max(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0", pl1_max=15)
+    _mk_dmi(root, "LENOVO", "83L3")
+    _set_fw_max(root, "ppt_pl2_sppt", 15)
+    _set_fw_max(root, "ppt_pl3_fppt", 20)
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    targets = build_targets(
+        {"pl1": 30, "pl2": 30, "pl3": 30},
+        backend.level_limits(),
+        backend.observe(),
+    )
+
+    assert targets.target == {"pl1": 15, "pl2": 15, "pl3": 20}
+
+
+def test_exact_legion_go_s_83n6_without_pl1_firmware_attr_uses_ryzenadj(tmp_path):
+    root = str(tmp_path)
+    base = os.path.join(
+        root,
+        "sys/class/firmware-attributes/lenovo-wmi-other-0/attributes",
+    )
+    for attr in ("ppt_cpu_cl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
+        path = os.path.join(base, attr)
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "current_value"), "w") as handle:
+            handle.write("15")
+    _mk_dmi(root, "LENOVO", "83N6")
+
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+    )
+
+    assert backend.name == "ryzenadj"
+    assert [item["candidate"] for item in backend.probe_trace] == [
+        "lenovo",
+        "asus",
+        "msi",
+        "ryzenadj",
+    ]
 
 
 def test_generic_device_does_not_get_83n6_rail_floors_from_dmi_alone(tmp_path):

--- a/tests/test_tdp_guard_rpc.py
+++ b/tests/test_tdp_guard_rpc.py
@@ -691,6 +691,29 @@ def test_backend_diagnostics_include_selected_rail_floors(plugin):
     assert descriptor.get("rail_floors") == {"pl2": 15, "pl3": 20}
 
 
+def test_backend_can_cap_boost_rails_to_active_battery_max(plugin):
+    plugin._tdp_backend.cap_boost_to_active = True
+    plugin._tdp_backend.get_limits = lambda: TdpLimits(
+        min_w=5,
+        default_w=15,
+        max_w=33,
+        max_ac_w=40,
+    )
+    plugin._tdp_backend.level_limits = lambda: {
+        "pl1": {"min": 5, "max": 40},
+        "pl2": {"min": 15, "max": 40},
+        "pl3": {"min": 20, "max": 40},
+    }
+
+    command = plugin._capture_tdp_command("battery", on_ac=False)
+
+    assert command.safe_bounds == {
+        "pl1": {"min": 5, "max": 33},
+        "pl2": {"min": 15, "max": 33},
+        "pl3": {"min": 20, "max": 33},
+    }
+
+
 def test_confirmed_secondary_rail_floor_is_constrained_without_retry(plugin):
     plugin._tdp_backend._rail_floors = {"pl2": 15, "pl3": 20}
     plugin._tdp_backend.level_limits = lambda: {


### PR DESCRIPTION
## What does this change?

Fixes #456
Fixes #460

- Scopes the workaround to the Lenovo Legion Go S with exact DMI product `83N6`.
- Ignores only the known bogus live maxima (`15/15/20 W`) while preserving any other firmware-reported limit.
- Keeps PL1/PL2/PL3 inside the active AC or battery ceiling.
- Preserves the raw firmware bounds in backend diagnostics.
- Keeps backend selection capability-based, including a safe `ryzenadj` fallback when a kernel exposes only the partial firmware-attribute layout.

## How was it tested?

- `ruff check py_modules main.py tests`
- `python -m pytest -q` — 1935 passed, 1 skipped, 55 subtests passed
- `pnpm typecheck`
- `pnpm test:fe` — 644 passed
- `pnpm build`
- Deployed to a physical Legion Go S 83N6: plugin load, backend probing, and safe fallback were confirmed on its current kernel. That kernel does not expose `ppt_pl1_spl`, so the corrected full firmware-attribute path is covered by synthetic sysfs tests.

## Checklist

- [x] The commit messages follow Conventional Commits.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] No third-party dependencies were added.