### PR TITLE
fix: keep game profiles in sync after game exit

### DIFF
--- a/src/tdp/gameReport.test.ts
+++ b/src/tdp/gameReport.test.ts
@@ -1,45 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isSameGameReport, shouldReportGame } from "./gameReport";
+import { isSameGameReport } from "./gameReport";
 
 const report = (appid: string | null, name: string | null = null) => ({ appid, name });
 
-describe("shouldReportGame", () => {
-  it("reports a game starting", () => {
-    expect(shouldReportGame(report("123", "Game"), report(null), undefined)).toBe(true);
-  });
-
-  it("does not re-report the committed game", () => {
-    expect(shouldReportGame(report("123", "Game"), report("123", "Game"), undefined)).toBe(false);
-  });
-
-  it("reports the game exit (null) even though nothing is in flight", () => {
-    // The regression: `null` is a real target ("no game"). When the idle sentinel was
-    // also `null`, this returned false and the exit was swallowed → backend stayed
-    // pinned to the last game and its per-game profile leaked into the Global view.
-    expect(shouldReportGame(report(null), report("123", "Game"), undefined)).toBe(true);
-  });
-
-  it("does not double-send while a null report is already in flight", () => {
-    expect(shouldReportGame(report(null), report("123", "Game"), report(null))).toBe(false);
-  });
-
-  it("does not re-send an appid already in flight", () => {
-    expect(shouldReportGame(report("123", "Game"), report(null), report("123", "Game"))).toBe(false);
-  });
-
-  it("nothing to do when already committed to no game", () => {
-    expect(shouldReportGame(report(null), report(null), undefined)).toBe(false);
-  });
-
-  it("reports a hydrated display name without changing the profile identity", () => {
-    expect(shouldReportGame(
-      report("123", "Actual name"),
-      report("123", "123"),
-      undefined,
-    )).toBe(true);
-  });
-
+describe("isSameGameReport", () => {
   it("recognises whether a late response still belongs to the current request", () => {
     expect(isSameGameReport(report("2", "B"), report("1", "A"))).toBe(false);
     expect(isSameGameReport(report("2", "B"), report("2", "B"))).toBe(true);

--- a/src/tdp/gameReport.ts
+++ b/src/tdp/gameReport.ts
@@ -6,12 +6,3 @@ export interface GameReport {
 export function isSameGameReport(a: GameReport, b: GameReport): boolean {
   return a.appid === b.appid && a.name === b.name;
 }
-
-export function shouldReportGame(
-  target: GameReport,
-  committed: GameReport,
-  inFlight: GameReport | undefined,
-): boolean {
-  return !isSameGameReport(target, committed)
-    && (!inFlight || !isSameGameReport(target, inFlight));
-}

--- a/src/tdp/gameWatcher.test.ts
+++ b/src/tdp/gameWatcher.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const setCurrentGame = vi.hoisted(() => vi.fn());
+const gameState = vi.hoisted(() => ({
+  current: null as { appid: string; liveAppid: number; name: string } | null,
+}));
+
+vi.mock("../api", () => ({ setCurrentGame }));
+vi.mock("./runningGame", () => ({
+  readRunningGame: () => gameState.current,
+}));
+
+import { startGameWatcher } from "./gameWatcher";
+
+const game = (appid: string, name: string) => ({
+  appid,
+  liveAppid: Number(appid),
+  name,
+});
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("startGameWatcher", () => {
+  let notifyLifetime: () => void;
+  let unregisterLifetime: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    gameState.current = null;
+    setCurrentGame.mockReset();
+    setCurrentGame.mockResolvedValue(undefined);
+    notifyLifetime = () => undefined;
+    unregisterLifetime = vi.fn();
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: (callback: () => void) => {
+          notifyLifetime = callback;
+          return { unregister: unregisterLifetime };
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("confirms startup idle after allowing Router to hydrate", async () => {
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    expect(setCurrentGame).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(setCurrentGame).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(setCurrentGame.mock.calls).toEqual([[null, null]]);
+    stop();
+  });
+
+  it("recovers when Steam announces exit before MainRunningApp clears", async () => {
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    notifyLifetime();
+    gameState.current = null;
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("applies the latest observation after an older request resolves", async () => {
+    const firstRequest = deferred();
+    setCurrentGame.mockImplementationOnce(() => firstRequest.promise);
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+
+    gameState.current = null;
+    notifyLifetime();
+    firstRequest.resolve();
+    await flushPromises();
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("retries a failed exit report without another Steam event", async () => {
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    gameState.current = null;
+    setCurrentGame.mockRejectedValueOnce(new Error("RPC unavailable"));
+    notifyLifetime();
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("retries a synchronous transport failure on the next poll", async () => {
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    gameState.current = null;
+    setCurrentGame.mockImplementationOnce(() => {
+      throw new Error("bridge unavailable");
+    });
+    notifyLifetime();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("moves to the latest context when an older request never settles", async () => {
+    const stalled = deferred();
+    setCurrentGame.mockImplementationOnce(() => stalled.promise);
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+
+    gameState.current = null;
+    notifyLifetime();
+    await vi.advanceTimersByTimeAsync(29999);
+    expect(setCurrentGame.mock.calls).toEqual([["101", "Game A"]]);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("repairs the context when an expired request resolves late", async () => {
+    const stalled = deferred();
+    setCurrentGame.mockImplementationOnce(() => stalled.promise);
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+
+    gameState.current = null;
+    notifyLifetime();
+    await vi.advanceTimersByTimeAsync(30000);
+    await flushPromises();
+    stalled.resolve();
+    await flushPromises();
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("bounds unresolved reports when the transport stays hung", async () => {
+    setCurrentGame.mockImplementation(() => new Promise(() => undefined));
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+
+    gameState.current = null;
+    notifyLifetime();
+    await vi.advanceTimersByTimeAsync(120000);
+
+    expect(setCurrentGame.mock.calls).toEqual([
+      ["101", "Game A"],
+      [null, null],
+    ]);
+    stop();
+  });
+
+  it("keeps polling when lifetime notifications are unavailable", async () => {
+    vi.stubGlobal("SteamClient", undefined);
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    gameState.current = game("101", "Game A");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([["101", "Game A"]]);
+    stop();
+  });
+
+  it("keeps polling when lifetime notification registration throws", async () => {
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: () => {
+          throw new Error("unsupported Steam API");
+        },
+      },
+    });
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    gameState.current = game("101", "Game A");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([["101", "Game A"]]);
+    stop();
+  });
+
+  it("deduplicates notification bursts and steady polls", async () => {
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+    await flushPromises();
+
+    notifyLifetime();
+    notifyLifetime();
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(setCurrentGame.mock.calls).toEqual([["101", "Game A"]]);
+    stop();
+  });
+
+  it("drops queued observations when the watcher stops", async () => {
+    const request = deferred();
+    setCurrentGame.mockImplementationOnce(() => request.promise);
+    gameState.current = game("101", "Game A");
+    const stop = startGameWatcher();
+
+    gameState.current = null;
+    notifyLifetime();
+    stop();
+    request.resolve();
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(setCurrentGame.mock.calls).toEqual([["101", "Game A"]]);
+    expect(unregisterLifetime).toHaveBeenCalledOnce();
+  });
+});

--- a/src/tdp/gameWatcher.ts
+++ b/src/tdp/gameWatcher.ts
@@ -1,5 +1,5 @@
 import { setCurrentGame } from "../api";
-import { GameReport, isSameGameReport, shouldReportGame } from "./gameReport";
+import { GameReport, isSameGameReport } from "./gameReport";
 import { readRunningGame } from "./runningGame";
 
 /**
@@ -17,85 +17,88 @@ import { readRunningGame } from "./runningGame";
  * useRunningGame is now a LOCAL UI read only — it does NOT report to the
  * backend, so there is no double-report / race with this watcher.
  *
- * Robustness (the crux of the restart bug — two failure modes):
- *  1. Router.MainRunningApp hydrates ASYNC. At plugin load the initial read can
- *     still be null even though a game is already running, and
- *     RegisterForAppLifetimeNotifications does NOT re-emit for an already-running
- *     game → the backend would stay at appid=None forever. So we run a bounded
- *     startup poll (every ~2 s) until we have SUCCESSFULLY reported a real appid,
- *     independent of whether the event API exists.
- *  2. The backend RPC may not be ready at load. We commit the report ONLY after
- *     setCurrentGame RESOLVES OK; on rejection we leave it so the next tick retries.
- *
  * Reports on game identity changes and when Steam hydrates a better display name.
  * Degrades: if the Steam/Decky API is unavailable or throws, it never throws.
  */
-// Startup poll cadence and how long to keep polling for the first successful
-// real-appid report before falling back to event-only steady state.
-const STARTUP_POLL_MS = 2000;
-const STARTUP_POLL_MAX = 30; // ~60 s of bounded startup retries
+const GAME_POLL_MS = 2000;
+const GAME_REPORT_TIMEOUT_MS = 30000;
+const MAX_PENDING_GAME_REPORTS = 2;
+
+interface PendingGameReport {
+  id: number;
+  target: GameReport;
+  timeout: ReturnType<typeof setTimeout> | null;
+}
 
 export function startGameWatcher(): () => void {
   let alive = true;
   let unregister: (() => void) | null = null;
-  let startupTimer: ReturnType<typeof setInterval> | null = null;
-  let eventFallbackTimer: ReturnType<typeof setInterval> | null = null;
-  let committed: GameReport = { appid: null, name: null };
-  let inFlight: GameReport | undefined;
-  let sawRealAppid = false; // have we ever SUCCESSFULLY reported a non-null appid?
-  let startupTicks = 0;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let committed: GameReport | undefined;
+  let desired: GameReport = { appid: null, name: null };
+  let inFlight: PendingGameReport | undefined;
+  let nextRequestId = 0;
+  const pendingRequestIds = new Set<number>();
 
-  const stopStartupPoll = (): void => {
-    if (startupTimer !== null) {
-      clearInterval(startupTimer);
-      startupTimer = null;
+  const clearActiveRequest = (request: PendingGameReport): boolean => {
+    if (inFlight?.id !== request.id) return false;
+    if (request.timeout !== null) clearTimeout(request.timeout);
+    inFlight = undefined;
+    return true;
+  };
+
+  const sendDesired = (): void => {
+    if (
+      !alive
+      || inFlight
+      || pendingRequestIds.size >= MAX_PENDING_GAME_REPORTS
+      || (committed && isSameGameReport(desired, committed))
+    ) return;
+    const request: PendingGameReport = {
+      id: ++nextRequestId,
+      target: desired,
+      timeout: null,
+    };
+    inFlight = request;
+    pendingRequestIds.add(request.id);
+    request.timeout = setTimeout(() => {
+      if (!alive || !clearActiveRequest(request)) return;
+      sendDesired();
+    }, GAME_REPORT_TIMEOUT_MS);
+    try {
+      Promise.resolve(setCurrentGame(request.target.appid, request.target.name))
+        .then(() => {
+          pendingRequestIds.delete(request.id);
+          if (!alive) return;
+          clearActiveRequest(request);
+          committed = request.target;
+          sendDesired();
+        })
+        .catch(() => {
+          pendingRequestIds.delete(request.id);
+          if (!alive) return;
+          clearActiveRequest(request);
+        });
+    } catch {
+      pendingRequestIds.delete(request.id);
+      clearActiveRequest(request);
     }
   };
 
-  const report = (): void => {
+  const report = (confirmIdle = false): void => {
     if (!alive) return;
     const next = readRunningGame();
-    const target: GameReport = {
+    desired = {
       appid: next ? next.appid : null,
       name: next ? next.name : null,
     };
-    if (!shouldReportGame(target, committed, inFlight)) return;
-    inFlight = target;
-    try {
-      // Pass the display name too so the HUD's Perfil metric can show it; the backend
-      // ignores it beyond that (the appid stays the profile key).
-      Promise.resolve(setCurrentGame(target.appid, target.name))
-        .then(() => {
-          if (!alive || !inFlight || !isSameGameReport(inFlight, target)) return;
-          committed = target;
-          inFlight = undefined;
-          if (target.appid !== null) {
-            sawRealAppid = true;
-            stopStartupPoll(); // got a real game → startup retries no longer needed
-          }
-        })
-        .catch(() => {
-          if (inFlight && isSameGameReport(inFlight, target)) inFlight = undefined;
-        });
-    } catch {
-      if (inFlight && isSameGameReport(inFlight, target)) inFlight = undefined;
-    }
+    if (desired.appid === null && committed === undefined && !inFlight && !confirmIdle) return;
+    sendDesired();
   };
 
-  // Startup poll: keep trying the initial read+report until we SUCCESSFULLY report
-  // a real appid (Router hydration + backend readiness), then stop. Bounded so a
-  // genuine "no game running" boot doesn't poll forever.
-  report(); // fire once immediately
-  startupTimer = setInterval(() => {
-    startupTicks += 1;
-    if (!alive || sawRealAppid || startupTicks >= STARTUP_POLL_MAX) {
-      stopStartupPoll();
-      return;
-    }
-    report();
-  }, STARTUP_POLL_MS);
+  report();
+  pollTimer = setInterval(() => report(true), GAME_POLL_MS);
 
-  // Subscribe to app lifetime notifications for immediate steady-state updates.
   try {
     const reg =
       SteamClient?.GameSessions?.RegisterForAppLifetimeNotifications?.(
@@ -109,19 +112,14 @@ export function startGameWatcher(): () => void {
           /* ignore */
         }
       };
-    } else {
-      // Notification API absent — poll steady-state too (in addition to startup).
-      eventFallbackTimer = setInterval(report, STARTUP_POLL_MS);
     }
-  } catch {
-    // Notification API threw — fall back to steady-state polling.
-    eventFallbackTimer = setInterval(report, STARTUP_POLL_MS);
-  }
+  } catch { /* polling remains active */ }
 
   return () => {
     alive = false;
     if (unregister) unregister();
-    stopStartupPoll();
-    if (eventFallbackTimer !== null) clearInterval(eventFallbackTimer);
+    if (pollTimer !== null) clearInterval(pollTimer);
+    if (inFlight?.timeout != null) clearTimeout(inFlight.timeout);
+    pendingRequestIds.clear();
   };
 }

--- a/src/tdp/useRunningGame.test.tsx
+++ b/src/tdp/useRunningGame.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const gameState = vi.hoisted(() => ({
+  current: null as { appid: string; liveAppid: number; name: string } | null,
+}));
+
+vi.mock("./runningGame", () => ({
+  readRunningGame: () => gameState.current,
+}));
+
+import { useRunningGame } from "./useRunningGame";
+
+describe("useRunningGame", () => {
+  let notifyLifetime: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    notifyLifetime = () => undefined;
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: (callback: () => void) => {
+          notifyLifetime = callback;
+          return { unregister: vi.fn() };
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("recovers when Steam announces exit before MainRunningApp clears", async () => {
+    gameState.current = { appid: "101", liveAppid: 101, name: "Game A" };
+    const { result, unmount } = renderHook(() => useRunningGame());
+    expect(result.current).toEqual(gameState.current);
+
+    act(() => notifyLifetime());
+    gameState.current = null;
+    await act(async () => vi.advanceTimersByTimeAsync(2000));
+
+    expect(result.current).toBeNull();
+    unmount();
+  });
+
+  it("keeps the same snapshot through duplicate events and polls", async () => {
+    gameState.current = { appid: "101", liveAppid: 101, name: "Game A" };
+    const { result, unmount } = renderHook(() => useRunningGame());
+    const initial = result.current;
+
+    act(() => notifyLifetime());
+    await act(async () => vi.advanceTimersByTimeAsync(4000));
+
+    expect(result.current).toBe(initial);
+    unmount();
+  });
+});

--- a/src/tdp/useRunningGame.ts
+++ b/src/tdp/useRunningGame.ts
@@ -14,7 +14,7 @@ export type { RunningGame };
  * backend report out of it means there is a single reporter and no race.
  *
  * Subscribes to SteamClient.GameSessions.RegisterForAppLifetimeNotifications
- * for live updates; falls back to a 2 s polling interval if that API is absent.
+ * for immediate updates and polls every 2 s for convergence.
  * Unsubscribes / clears the interval on unmount. Never throws.
  */
 export function useRunningGame(): RunningGame | null {
@@ -44,10 +44,9 @@ export function useRunningGame(): RunningGame | null {
       );
     };
 
-    // Initial read.
     sync();
+    timer = setInterval(sync, 2000);
 
-    // Subscribe to lifetime notifications for immediate updates.
     try {
       const reg =
         SteamClient?.GameSessions?.RegisterForAppLifetimeNotifications?.(
@@ -61,14 +60,8 @@ export function useRunningGame(): RunningGame | null {
             /* ignore */
           }
         };
-      } else {
-        // Notification API absent — fall back to polling.
-        timer = setInterval(sync, 2000);
       }
-    } catch {
-      // Notification API threw — fall back to polling.
-      timer = setInterval(sync, 2000);
-    }
+    } catch { /* polling remains active */ }
 
     return () => {
       alive = false;


### PR DESCRIPTION
## Español

### Qué cambia

- Mantiene eventos de Steam para reaccionar inmediatamente y añade una comprobación periódica para converger cuando el evento llega antes de que Router actualice el juego.
- Serializa el contexto deseado, enviado y confirmado para que siempre gane la observación más reciente.
- Recupera errores, RPC bloqueadas y respuestas tardías sin acumular más de dos llamadas pendientes.
- Mantiene el contexto visible del QAM sincronizado con el backend y espera la hidratación inicial antes de confirmar el perfil global.

### Resultado

Al cerrar un juego, los perfiles de TDP y el resto de ajustes por juego vuelven al contexto global aunque Steam pierda, adelante o duplique una notificación. La ruta es común a SteamOS y Bazzite y no depende del fabricante ni del backend de potencia.

## English

### What changed

- Keeps Steam events for immediate updates and adds periodic observation so state converges when an event arrives before Router updates the running game.
- Serializes desired, sent, and confirmed contexts so the latest observation always wins.
- Recovers from errors, stalled RPCs, and late responses while allowing at most two pending calls.
- Keeps the QAM-visible context aligned with the backend and allows initial Router hydration before confirming the global profile.

### Result

After a game exits, TDP profiles and every other per-game setting return to the global context even when Steam loses, advances, or duplicates a notification. The path is shared by SteamOS and Bazzite and is independent of the device vendor or power backend.

## Italiano

### Cosa cambia

- Mantiene gli eventi Steam per gli aggiornamenti immediati e aggiunge un controllo periodico per convergere quando l'evento arriva prima dell'aggiornamento del gioco in Router.
- Serializza i contesti desiderato, inviato e confermato affinché prevalga sempre l'ultima osservazione.
- Recupera errori, RPC bloccate e risposte tardive senza accumulare più di due chiamate in sospeso.
- Mantiene il contesto visibile nel QAM allineato al backend e attende l'idratazione iniziale di Router prima di confermare il profilo globale.

### Risultato

Alla chiusura di un gioco, i profili TDP e tutte le altre impostazioni per gioco tornano al contesto globale anche se Steam perde, anticipa o duplica una notifica. Il percorso è condiviso da SteamOS e Bazzite e non dipende dal produttore o dal backend di alimentazione.

## Validación / Validation / Verifica

- `pnpm typecheck`
- `pnpm test:fe` — 77 archivos, 651 tests
- `pnpm build`
- `ruff check py_modules main.py tests`
- `python -m pytest` — 1935 passed, 1 skipped, 55 subtests
- Smoke físico en Steam Deck OLED: carga correcta, contexto de juego sincronizado una sola vez, sin errores ni escrituras periódicas duplicadas.

Closes #420
Closes #457
Related to #438