### PR TITLE
fix(audio): follow the selected output route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Español
+
+* Corrige el enrutado del ecualizador al cambiar entre altavoces, auriculares, Bluetooth, USB y HDMI. Conserva volumen y mute durante reinicios, suspensión, desconexiones y fallos, y restaura de forma segura las salidas anteriores cuando vuelven a estar disponibles. ([#469](https://github.com/Hooandee/panel-de-control/pull/469))
+
+### English
+
+* Fixes EQ routing when switching between speakers, headphones, Bluetooth, USB, and HDMI. Volume and mute survive restarts, suspend, disconnects, and failures, while previous outputs are safely restored when they become available again. ([#469](https://github.com/Hooandee/panel-de-control/pull/469))
+
+### Italiano
+
+* Corregge il routing dell'equalizzatore quando si passa tra altoparlanti, cuffie, Bluetooth, USB e HDMI. Volume e mute vengono preservati durante riavvii, sospensione, disconnessioni ed errori, mentre le uscite precedenti vengono ripristinate in sicurezza quando tornano disponibili. ([#469](https://github.com/Hooandee/panel-de-control/pull/469))
+
 ## [0.37.3](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.2...panel-de-control-v0.37.3) (2026-08-16)
 
 

--- a/main.py
+++ b/main.py
@@ -514,6 +514,8 @@ class Plugin:
         # Audio EQ output-route watcher: last applied route + its loop task.
         self._audio_task = None
         self._audio_route_last = None
+        self._audio_cleanup_pending = True
+        self._audio_runtime_expected = False
         self._audio_shutdown = False
         self._shutting_down = False
         self._offload_futures = set()
@@ -5939,6 +5941,7 @@ class Plugin:
                 self._record_audio_apply_failure(detail)
             else:
                 self._audio_apply_failures = 0
+                self._audio_runtime_expected = True
                 diagnostics = getattr(self._audio, "apply_diagnostics", None)
                 self._audio_last_apply = (
                     diagnostics()
@@ -5991,13 +5994,17 @@ class Plugin:
         while True:
             try:
                 await asyncio.sleep(_AUDIO_POLL_S)
-                if (
-                    not self._settings.get("audio_eq_enabled")
-                    or not self._audio.is_supported()
-                ):
+                enabled = bool(self._settings.get("audio_eq_enabled"))
+                supported = enabled and self._audio.is_supported()
+                if not enabled or not supported:
+                    if self._audio_runtime_expected:
+                        self._audio_cleanup_pending = True
+                    self._audio_runtime_expected = False
                     self._audio_route_last = None
-                    await self._offload_call(self._restore_audio_safe)
+                    if self._audio_cleanup_pending:
+                        await self._offload_call(self._restore_audio_safe)
                     continue
+                self._audio_runtime_expected = True
                 probe = await self._offload_call(self._audio_check)
                 if not probe["active"] or probe["route"] != self._audio_route_last:
                     self._audio_route_last = probe["route"]
@@ -6012,11 +6019,14 @@ class Plugin:
         disabled/uninstalled plugin leaves the audio untouched. Guarded."""
         try:
             if getattr(self, "_audio", None) is not None:
-                self._audio.teardown()
+                cleaned = self._audio.teardown()
+                self._audio_cleanup_pending = cleaned is not True
+                self._audio_runtime_expected = False
                 diagnostics = self._audio.apply_diagnostics()
                 if isinstance(diagnostics, dict):
                     self._audio_last_apply = dict(diagnostics)
         except Exception as error:  # noqa: BLE001
+            self._audio_cleanup_pending = True
             self._audio_last_apply = {
                 "ok": False,
                 "reason": "exception",
@@ -6067,6 +6077,8 @@ class Plugin:
         if enabled:
             self._reapply_audio()
         else:
+            self._audio_cleanup_pending = True
+            self._audio_runtime_expected = False
             self._offload(self._restore_audio_safe)
         return await self._offload_call(self._audio_state)
 

--- a/main.py
+++ b/main.py
@@ -5991,8 +5991,13 @@ class Plugin:
         while True:
             try:
                 await asyncio.sleep(_AUDIO_POLL_S)
-                if not self._settings.get("audio_eq_enabled") or not self._audio.is_supported():
+                if not self._settings.get("audio_eq_enabled"):
                     self._audio_route_last = None
+                    await self._offload_call(self._restore_audio_safe)
+                    continue
+                if not self._audio.is_supported():
+                    self._audio_route_last = None
+                    await self._offload_call(self._restore_audio_safe)
                     continue
                 probe = await self._offload_call(self._audio_check)
                 if not probe["active"] or probe["route"] != self._audio_route_last:
@@ -6009,8 +6014,15 @@ class Plugin:
         try:
             if getattr(self, "_audio", None) is not None:
                 self._audio.teardown()
-        except Exception:  # noqa: BLE001
-            pass
+                diagnostics = self._audio.apply_diagnostics()
+                if isinstance(diagnostics, dict):
+                    self._audio_last_apply = dict(diagnostics)
+        except Exception as error:  # noqa: BLE001
+            self._audio_last_apply = {
+                "ok": False,
+                "reason": "exception",
+                "error": type(error).__name__,
+            }
 
     def _audio_state(self) -> dict:
         route = self._current_route()
@@ -6066,60 +6078,86 @@ class Plugin:
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def apply_audio_preset(self, preset: str, scope: str = "global", appid=None) -> dict:
+    async def _audio_route_for_write(self, expected_route=None):
+        route = await self._offload_call(self._current_route)
+        if expected_route is not None and expected_route != route:
+            return None
+        return route
+
+    async def apply_audio_preset(
+        self, preset: str, scope: str = "global", appid=None, expected_route=None
+    ) -> dict:
         """Apply a preset to the active route for the given scope. device_tuned resolves
         to the per-machine speaker correction (flat on headphones)."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)  # pactl → off the loop
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         setting = audio_presets.resolve_preset(getattr(self._device, "key", None), preset, route)
         self._audio_eq.set_setting(resolved, route, setting, appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def set_audio_band(self, index: int, gain: float, scope: str, appid=None) -> dict:
+    async def set_audio_band(
+        self, index: int, gain: float, scope: str, appid=None, expected_route=None
+    ) -> dict:
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)  # pactl → off the loop
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_band(resolved, route, int(index), float(gain), appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def set_audio_bands(self, gains: list, scope: str, appid=None) -> dict:
+    async def set_audio_bands(
+        self, gains: list, scope: str, appid=None, expected_route=None
+    ) -> dict:
         """Replace all 10 band gains for the active route (drag-commit of the whole curve)."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)  # pactl → off the loop
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_bands(resolved, route, gains, appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def set_audio_loudness(self, on: bool, scope: str, appid=None) -> dict:
+    async def set_audio_loudness(
+        self, on: bool, scope: str, appid=None, expected_route=None
+    ) -> dict:
         """Toggle volume leveling (compression) for the active route — dialogue stays
         audible without loud peaks blasting; also protects small speakers."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_loudness(resolved, route, bool(on), appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def set_audio_balance(self, value: int, scope: str, appid=None) -> dict:
+    async def set_audio_balance(
+        self, value: int, scope: str, appid=None, expected_route=None
+    ) -> dict:
         """Set the L/R balance (-100..100) for the active route. Applies instantly — it
         only offsets the downstream pin, no filter-chain restart."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_balance(resolved, route, int(value), appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
@@ -6132,14 +6170,18 @@ class Plugin:
         self._audio_profiles.save(name, eff["gains"], eff["bass"])
         return await self._offload_call(self._audio_state)
 
-    async def apply_audio_profile(self, name: str, scope: str, appid=None) -> dict:
+    async def apply_audio_profile(
+        self, name: str, scope: str, appid=None, expected_route=None
+    ) -> dict:
         """Apply a saved profile's curve + bass to the active route for the given scope."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         prof = self._audio_profiles.get(name)
         if resolved is None or prof is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_bands(resolved, route, prof["gains"], appid=appid)
         self._audio_eq.set_bass(resolved, route, prof["bass"], appid=appid)
         self._reapply_audio()
@@ -6172,14 +6214,18 @@ class Plugin:
         except Exception:  # noqa: BLE001
             self._test_sample = None
 
-    async def set_audio_curve(self, gains: list, bass: int, scope: str, appid=None) -> dict:
+    async def set_audio_curve(
+        self, gains: list, bass: int, scope: str, appid=None, expected_route=None
+    ) -> dict:
         """Set the EQ gains and the bass-enhancement amount together in one apply (the tone
         sliders drive both — the Graves slider engages the bass enhancer)."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)  # pactl → off the loop
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.set_bands(resolved, route, gains, appid=appid)
         self._audio_eq.set_bass(resolved, route, int(bass), appid=appid)
         self._reapply_audio()
@@ -6196,13 +6242,17 @@ class Plugin:
         self._reapply_audio()
         return await self._offload_call(self._audio_state)
 
-    async def reset_audio(self, scope: str = "global", appid=None) -> dict:
+    async def reset_audio(
+        self, scope: str = "global", appid=None, expected_route=None
+    ) -> dict:
         """Flatten the active route's EQ for the given scope."""
         self._init()
         resolved = self._resolve_scope(scope, appid)
         if resolved is None:
             return await self._offload_call(self._audio_state)
-        route = await self._offload_call(self._current_route)  # pactl → off the loop
+        route = await self._audio_route_for_write(expected_route)
+        if route is None:
+            return await self._offload_call(self._audio_state)
         self._audio_eq.reset(resolved, route, appid=appid)
         self._reapply_audio()
         return await self._offload_call(self._audio_state)

--- a/main.py
+++ b/main.py
@@ -5991,11 +5991,10 @@ class Plugin:
         while True:
             try:
                 await asyncio.sleep(_AUDIO_POLL_S)
-                if not self._settings.get("audio_eq_enabled"):
-                    self._audio_route_last = None
-                    await self._offload_call(self._restore_audio_safe)
-                    continue
-                if not self._audio.is_supported():
+                if (
+                    not self._settings.get("audio_eq_enabled")
+                    or not self._audio.is_supported()
+                ):
                     self._audio_route_last = None
                     await self._offload_call(self._restore_audio_safe)
                     continue

--- a/main.py
+++ b/main.py
@@ -5983,7 +5983,11 @@ class Plugin:
 
     def _audio_check(self) -> dict:
         """Off-loop probe for the watcher: active route + confirmed EQ ownership."""
-        return {"route": self._current_route(), "active": self._audio.is_active()}
+        active = self._audio.is_active()
+        if active:
+            sync_state = getattr(self._audio, "sync_state", None)
+            active = not callable(sync_state) or sync_state() is True
+        return {"route": self._current_route(), "active": active}
 
     async def _audio_loop(self) -> None:
         """While the EQ is enabled, keep it live with the QAM closed: re-apply when the

--- a/py_modules/audio/filter_chain.py
+++ b/py_modules/audio/filter_chain.py
@@ -24,7 +24,19 @@ def _band_nodes(gains):
     ]
 
 
-def build_chain_config(gains, sink_name, description="Panel de Control", bass=0, loudness=False, caps=None):
+def _pipewire_string(value):
+    return str(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def build_chain_config(
+    gains,
+    sink_name,
+    description="Panel de Control",
+    bass=0,
+    loudness=False,
+    caps=None,
+    target=None,
+):
     nodes = _band_nodes(gains)
     links = [
         f'          {{ output = "eq_band_{i}:Out" input = "eq_band_{i + 1}:In" }}'
@@ -49,6 +61,7 @@ def build_chain_config(gains, sink_name, description="Panel de Control", bass=0,
         tail = "comp:out"
     nodes_s = "\n".join(nodes)
     links_s = "\n".join(links)
+    target_prop = f' target.object = "{_pipewire_string(target)}"' if target else ""
     return f"""context.modules = [
   {{ name = libpipewire-module-filter-chain
     args = {{
@@ -65,7 +78,7 @@ def build_chain_config(gains, sink_name, description="Panel de Control", bass=0,
       audio.channels = 2
       audio.position = [ FL FR ]
       capture.props  = {{ node.name = "{description}" node.description = "{description}" node.nick = "{description}" media.class = Audio/Sink priority.session = 2000 }}
-      playback.props = {{ node.name = "effect_output.{sink_name}" node.passive = true }}
+      playback.props = {{ node.name = "effect_output.{sink_name}" node.passive = true{target_prop} }}
     }}
   }}
 ]

--- a/py_modules/audio/pipewire.py
+++ b/py_modules/audio/pipewire.py
@@ -26,10 +26,12 @@ _RETRY_MIN_S = 15.0
 _RETRY_MAX_S = 60.0
 _RETRY_MAX_ATTEMPTS = 3
 _MAX_ENTRY_BYTES = 64 * 1024
+_MISSING_PARENT = object()
 _RETRY_OPERATIONS = {
     "config": "config_write",
     "default": "default_sink",
     "link": "target_link",
+    "marker": "pending_marker_cleanup",
     "service": "service_restart",
     "teardown": "teardown",
 }
@@ -289,7 +291,7 @@ class PipeWireEq:
         except KeyError:
             return self._session[0], self._session[0]
 
-    def _open_parent_dir(self, path, *, create=False):
+    def _open_parent_dir(self, path, *, create=False, missing_ok=False):
         if not path or not self._session or not os.path.isabs(path):
             return None
         uid, gid = self._session_ids()
@@ -306,7 +308,7 @@ class PipeWireEq:
                 except FileNotFoundError:
                     if not create:
                         os.close(current_fd)
-                        return None
+                        return _MISSING_PARENT if missing_ok else None
                     try:
                         os.mkdir(component, 0o755, dir_fd=current_fd)
                     except FileExistsError:
@@ -346,7 +348,9 @@ class PipeWireEq:
             os.close(parent_fd)
 
     def _remove_entry(self, path):
-        parent_fd = self._open_parent_dir(path)
+        parent_fd = self._open_parent_dir(path, missing_ok=True)
+        if parent_fd is _MISSING_PARENT:
+            return True
         if parent_fd is None:
             return False
         name = os.path.basename(path)
@@ -975,9 +979,20 @@ class PipeWireEq:
             or eq_present
         )
         if not runtime_pending:
-            self._clear_first_enable_pending()
+            retry_request = ("teardown_marker",)
+            if self._retry_blocked(retry_request, None):
+                return False
+            if not self._clear_first_enable_pending():
+                return self._defer_failure(
+                    retry_request,
+                    "marker",
+                    "teardown_marker_cleanup_failed",
+                    None,
+                )
+            self._cleanup_pending = False
             self._active = False
             self._owns_sink = False
+            self._clear_retry()
             self._record_apply(True, operation="teardown", unchanged=True)
             return True
         self._cleanup_pending = True
@@ -1037,7 +1052,6 @@ class PipeWireEq:
         self._requested_downstream = None
         self._configured_default_seen = None
         self._configured_request = None
-        self._clear_first_enable_pending()
         self._cleanup_pending = False
         self._last_applied = None
         self._user_vol = None
@@ -1045,5 +1059,12 @@ class PipeWireEq:
         self._clear_retry()
         self._active = False
         self._owns_sink = False
+        if not self._clear_first_enable_pending():
+            return self._defer_failure(
+                ("teardown_marker",),
+                "marker",
+                "teardown_marker_cleanup_failed",
+                downstream,
+            )
         self._record_apply(True, operation="teardown")
         return True

--- a/py_modules/audio/pipewire.py
+++ b/py_modules/audio/pipewire.py
@@ -22,6 +22,8 @@ _DIGITAL_HINTS = ("hdmi", "displayport", "iec958", "spdif")
 _SINK = "pdc_eq"
 _SERVICE = "filter-chain.service"
 _CONFIRM_DELAYS = (0, 0.05, 0.1, 0.2, 0.4)
+_DEFAULT_SET_DELAYS = (0, 0.1, 0.2)
+_DEFAULT_CONFIRM_TIMEOUT_S = 8.0
 _RETRY_MIN_S = 15.0
 _RETRY_MAX_S = 60.0
 _RETRY_MAX_ATTEMPTS = 3
@@ -190,9 +192,12 @@ class PipeWireEq:
         self._requested_downstream = None
         self._configured_default_seen = None
         self._configured_request = None
+        self._default_failure = None
         self._first_enable_pending = False
         self._first_enable_downstream = None
         self._first_enable_volume = None
+        self._first_enable_volumes = None
+        self._first_enable_mute = None
         self._cleanup_pending = False
         self._last_applied = None
         self._last_apply = None
@@ -200,6 +205,8 @@ class PipeWireEq:
         self._owns_sink = False
         self._user_vol = None
         self._downstream_volumes = {}
+        self._downstream_mutes = {}
+        self._pending_restores = []
         self._test_proc = None
         self._sleep = time.sleep
         self._monotonic = time.monotonic
@@ -463,35 +470,122 @@ class PipeWireEq:
             os.close(parent_fd)
 
     def _persist_first_enable_pending(self):
-        path = self._pending_path()
-        if not path or not self._session:
-            return False
-        return self._write_entry(
-            path,
-            json.dumps(
-                {
-                    "sink": self._first_enable_downstream,
-                    "volume": self._first_enable_volume,
-                }
-            ),
+        return self._persist_route_state(
+            self._first_enable_downstream,
+            self._first_enable_volume,
+            "prepared",
+            self._first_enable_mute,
+            self._first_enable_volumes,
+            self._first_enable_mute,
         )
+
+    def _persist_route_state(
+        self,
+        downstream,
+        volume,
+        phase,
+        muted,
+        physical_volumes,
+        physical_muted,
+    ):
+        path = self._pending_path()
+        if (
+            not path
+            or not self._session
+            or not downstream
+            or not re.fullmatch(r"\d+%", str(volume or ""))
+            or phase not in ("prepared", "active")
+            or not isinstance(muted, bool)
+            or not isinstance(physical_volumes, (list, tuple))
+            or not physical_volumes
+            or any(
+                not re.fullmatch(r"\d+%", str(value))
+                for value in physical_volumes
+            )
+            or not isinstance(physical_muted, bool)
+        ):
+            return False
+        state = {
+            "sink": downstream,
+            "volume": volume,
+            "phase": phase,
+            "muted": muted,
+            "physical_volumes": list(physical_volumes),
+            "physical_muted": physical_muted,
+            "pending_restores": list(self._pending_restores),
+        }
+        return self._write_entry(path, json.dumps(state))
+
+    def _route_state(self):
+        path = self._pending_path()
+        stored = self._read_entry(path) if path else None
+        if stored is None:
+            return None
+        try:
+            state = json.loads(stored)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(state, dict):
+            return None
+        if (
+            "phase" not in state
+            and isinstance(state.get("sink"), str)
+            and state["sink"]
+            and re.fullmatch(r"\d+%", str(state.get("volume", "")))
+        ):
+            current_default = self._runner(["pactl", "get-default-sink"])
+            muted = self._sink_muted(current_default) if current_default else None
+            physical_volumes = self._sink_volume_pcts(state["sink"])
+            physical_muted = self._sink_muted(state["sink"])
+            if muted is not None and physical_volumes and physical_muted is not None:
+                state.update({
+                    "phase": "prepared",
+                    "muted": muted,
+                    "physical_volumes": list(physical_volumes),
+                    "physical_muted": physical_muted,
+                })
+        if "pending_restores" not in state:
+            state["pending_restores"] = []
+        pending_restores = state["pending_restores"]
+        if (
+            not isinstance(state.get("sink"), str)
+            or not state["sink"]
+            or not re.fullmatch(r"\d+%", str(state.get("volume", "")))
+            or state.get("phase") not in ("prepared", "active")
+            or not isinstance(state.get("muted"), bool)
+            or not isinstance(state.get("physical_volumes"), list)
+            or not state["physical_volumes"]
+            or any(
+                not re.fullmatch(r"\d+%", str(value))
+                for value in state["physical_volumes"]
+            )
+            or not isinstance(state.get("physical_muted"), bool)
+            or not isinstance(pending_restores, list)
+            or any(
+                not isinstance(item, dict)
+                or not isinstance(item.get("sink"), str)
+                or not item["sink"]
+                or not isinstance(item.get("volumes"), list)
+                or not item["volumes"]
+                or any(
+                    not re.fullmatch(r"\d+%", str(value))
+                    for value in item["volumes"]
+                )
+                or not isinstance(item.get("muted"), bool)
+                for item in pending_restores
+            )
+        ):
+            return None
+        return state
 
     def _pending_first_enable(self, downstream):
         path = self._pending_path()
         stored = self._read_entry(path) if path else None
         persisted = bool(path and (stored is not None or self._entry_exists(path)))
         volume = None
-        if stored is not None:
-            try:
-                pending = json.loads(stored)
-            except (ValueError, TypeError):
-                pending = None
-            if (
-                isinstance(pending, dict)
-                and pending.get("sink") == downstream
-                and re.fullmatch(r"\d+%", str(pending.get("volume", "")))
-            ):
-                volume = pending["volume"]
+        pending = self._route_state()
+        if pending is not None and pending["sink"] == downstream:
+            volume = pending["volume"]
         if volume is None and self._first_enable_downstream == downstream:
             volume = self._first_enable_volume
         return self._first_enable_pending or persisted, volume
@@ -503,6 +597,8 @@ class PipeWireEq:
         self._first_enable_pending = False
         self._first_enable_downstream = None
         self._first_enable_volume = None
+        self._first_enable_volumes = None
+        self._first_enable_mute = None
         return True
 
     def _discard_first_enable_config(self, conf_path):
@@ -517,8 +613,8 @@ class PipeWireEq:
         return (
             bool(self._session)
             and filter_chain_module() is not None
+            and self._binary_available("pactl")
             and self._binary_available("pw-link")
-            and self._binary_available("pw-metadata")
         )
 
     @staticmethod
@@ -572,6 +668,28 @@ class PipeWireEq:
         values = self._sink_volume_pcts(sink)
         return values[0] if values else None
 
+    def _set_sink_volume_confirmed(self, sink, *values):
+        self._runner(["pactl", "set-sink-volume", sink, *values])
+        readback = self._sink_volume_pcts(sink)
+        if not readback:
+            return False
+        if len(values) == 1:
+            return all(value == values[0] for value in readback)
+        return readback == tuple(values)
+
+    def _sink_muted(self, sink):
+        value = self._runner(["pactl", "get-sink-mute", sink])
+        if value.endswith("yes"):
+            return True
+        if value.endswith("no"):
+            return False
+        return None
+
+    def _set_sink_mute_confirmed(self, sink, muted):
+        value = "1" if muted else "0"
+        self._runner(["pactl", "set-sink-mute", sink, value])
+        return self._sink_muted(sink) == bool(muted)
+
     def _downstream_sink(self):
         default_sink = self._runner(["pactl", "get-default-sink"])
         sinks = self._runner(["pactl", "list", "short", "sinks"])
@@ -599,6 +717,29 @@ class PipeWireEq:
                 f"effect_output.{_SINK}",
                 candidates,
             )
+            if linked is None:
+                conf = self._read_entry(self._conf_path())
+                match = re.search(r'\btarget\.object\s*=\s*"((?:\\.|[^"\\])*)"', conf or "")
+                if match:
+                    try:
+                        target = json.loads(f'"{match.group(1)}"')
+                    except (TypeError, ValueError):
+                        target = None
+                    if target in candidates:
+                        linked = target
+            if linked is None:
+                state = self._route_state()
+                if state is not None and state["sink"] in candidates:
+                    linked = state["sink"]
+            if (
+                linked is None
+                and self._requested_downstream is None
+                and self._active_downstream not in candidates
+                and configured not in candidates
+            ):
+                if len(candidates) != 1:
+                    return None
+                linked = candidates[0]
         elif default_sink in candidates:
             self._requested_downstream = default_sink
         return choose_downstream(
@@ -612,37 +753,78 @@ class PipeWireEq:
             requested=self._requested_downstream,
         )
 
-    def _set_default_confirmed(self, sink):
-        for delay in _CONFIRM_DELAYS:
+    def _set_default_confirmed(self, sink, expected_downstream=None):
+        observed = None
+        deadline = self._monotonic() + _DEFAULT_CONFIRM_TIMEOUT_S
+
+        def within_deadline():
+            return self._monotonic() < deadline
+
+        def stable(delays):
+            nonlocal observed
+            for delay in delays:
+                if not within_deadline():
+                    return False
+                if delay:
+                    self._sleep(delay)
+                if not within_deadline():
+                    return False
+                observed = self._runner(
+                    ["pactl", "get-default-sink"],
+                    timeout=1,
+                )
+                if observed != sink:
+                    return False
+            return True
+
+        self._default_failure = None
+        for delay in _DEFAULT_SET_DELAYS:
+            if not within_deadline():
+                break
             if delay:
                 self._sleep(delay)
-            if sink == self._label:
-                value = json.dumps({"name": sink}, separators=(",", ":"))
-                self._runner(
-                    [
-                        "pw-metadata",
-                        "-n",
-                        "default",
-                        "0",
-                        "default.audio.sink",
-                        value,
-                        "Spa:String:JSON",
-                    ]
-                )
-                if self._runner(["pactl", "get-default-sink"]) == sink:
-                    return True
-                continue
-            self._runner(["pactl", "set-default-sink", sink])
-            if self._runner(["pactl", "get-default-sink"]) == sink:
+            if not within_deadline():
+                break
+            self._runner(
+                ["pactl", "set-default-sink", sink],
+                timeout=1,
+            )
+            if stable(_CONFIRM_DELAYS):
+                self._default_failure = None
                 return True
+            if not observed:
+                self._default_failure = {
+                    "reason": "default_readback_missing",
+                    "current": None,
+                }
+                return False
+            if (
+                expected_downstream is not None
+                and observed not in (sink, expected_downstream)
+            ):
+                self._default_failure = {
+                    "reason": "downstream_changed_during_default",
+                    "current": observed,
+                }
+                return False
+        if not within_deadline():
+            self._default_failure = {
+                "reason": "default_confirmation_timeout",
+                "current": observed or None,
+            }
+            return False
+        self._default_failure = {
+            "reason": "default_sink_not_confirmed",
+            "current": observed or None,
+        }
         return False
 
-    def _target_link_confirmed(self, downstream, *, retry=False):
+    def _target_link_confirmed(self, downstream, *, retry=False, timeout=8):
         delays = _CONFIRM_DELAYS if retry else (0,)
         for delay in delays:
             if delay:
                 self._sleep(delay)
-            links = self._runner(["pw-link", "-l"])
+            links = self._runner(["pw-link", "-l"], timeout=timeout)
             if _link_reaches(links, f"effect_output.{_SINK}", downstream):
                 return True
         return False
@@ -669,29 +851,165 @@ class PipeWireEq:
         current = self._runner(["pactl", "get-default-sink"])
         if not current:
             return False
-        if current != self._label:
+        target = downstream if current == self._label else current
+        state = self._route_state()
+        if state is not None:
+            self._pending_restores = list(state["pending_restores"])
+        if state is not None and current != self._label and state["sink"] != target:
+            previous_pending_restores = list(self._pending_restores)
+            if not self._restore_previous_route_state(state, target):
+                return False
+            if (
+                self._pending_restores != previous_pending_restores
+                and not self._persist_route_state(
+                    state["sink"],
+                    state["volume"],
+                    state["phase"],
+                    state["muted"],
+                    state["physical_volumes"],
+                    state["physical_muted"],
+                )
+            ):
+                return False
             return True
-        if not downstream or not self._set_default_confirmed(downstream):
+        owned = (
+            target in self._downstream_volumes
+            or target in self._downstream_mutes
+            or (state is not None and state["sink"] == target)
+        )
+        if current != self._label and not owned:
+            return True
+        if not target:
             return False
-        volume = self._sink_volume_pct(self._label) or self._user_vol
-        self._restore_downstream_volume(downstream)
-        if volume:
-            self._runner(["pactl", "set-sink-volume", downstream, volume])
+        prepared = state is not None and state.get("phase") == "prepared"
+        volume = (
+            state["volume"]
+            if prepared and state["sink"] == target
+            else self._sink_volume_pct(self._label)
+        ) or (state["volume"] if state is not None and state["sink"] == target else None)
+        muted = (
+            state["muted"]
+            if prepared and state["sink"] == target
+            else self._sink_muted(self._label)
+        )
+        if muted is None and state is not None and state["sink"] == target:
+            muted = state["muted"]
+        if (
+            not volume
+            or muted is None
+            or not self._set_sink_volume_confirmed(target, volume)
+            or not self._set_sink_mute_confirmed(target, muted)
+        ):
+            return False
+        if current != target and not self._set_default_confirmed(target):
+            return False
+        if state is not None and self._pending_restores:
+            live_sinks = {
+                name
+                for name, _status in _sink_candidates(
+                    self._runner(["pactl", "list", "short", "sinks"]),
+                    self._label,
+                )
+            }
+            previous_pending_restores = list(self._pending_restores)
+            if not self._restore_pending_routes(live_sinks - {target}):
+                return False
+            if (
+                self._pending_restores != previous_pending_restores
+                and not self._persist_route_state(
+                    state["sink"],
+                    state["volume"],
+                    state["phase"],
+                    state["muted"],
+                    state["physical_volumes"],
+                    state["physical_muted"],
+                )
+            ):
+                return False
+        self._downstream_volumes.pop(target, None)
+        self._downstream_mutes.pop(target, None)
         self._owns_sink = False
         return True
 
     def _pin_downstream(self, downstream, balance):
         if downstream not in self._downstream_volumes:
-            self._downstream_volumes[downstream] = self._sink_volume_pcts(downstream)
+            volumes = self._sink_volume_pcts(downstream)
+            if not volumes:
+                return False
+            self._downstream_volumes[downstream] = volumes
+        if downstream not in self._downstream_mutes:
+            muted = self._sink_muted(downstream)
+            if muted is None:
+                return False
+            self._downstream_mutes[downstream] = muted
         left, right = balance_channels(balance)
-        self._runner(["pactl", "set-sink-volume", downstream, "100%"])
+        if not self._set_sink_volume_confirmed(downstream, "100%"):
+            return False
         if left != right:
-            self._runner(["pactl", "set-sink-volume", downstream, f"{left}%", f"{right}%"])
+            if not self._set_sink_volume_confirmed(
+                downstream,
+                f"{left}%",
+                f"{right}%",
+            ):
+                return False
+        if not self._set_sink_mute_confirmed(downstream, False):
+            return False
+        return True
 
-    def _restore_downstream_volume(self, downstream):
-        values = self._downstream_volumes.pop(downstream, None)
-        if values:
-            self._runner(["pactl", "set-sink-volume", downstream, *values])
+    def _restore_downstream(self, downstream):
+        values = self._downstream_volumes.get(downstream)
+        muted = self._downstream_mutes.get(downstream)
+        if values and not self._set_sink_volume_confirmed(downstream, *values):
+            return False
+        if isinstance(muted, bool) and not self._set_sink_mute_confirmed(
+            downstream,
+            muted,
+        ):
+            return False
+        self._downstream_volumes.pop(downstream, None)
+        self._downstream_mutes.pop(downstream, None)
+        return bool(values) or isinstance(muted, bool)
+
+    def _restore_previous_route_state(self, state, downstream):
+        if state is None or state["sink"] == downstream:
+            return True
+        sinks = self._runner(["pactl", "list", "short", "sinks"])
+        names = {name for name, _status in _sink_candidates(sinks, self._label)}
+        previous = state["sink"]
+        if previous not in names:
+            if not any(item["sink"] == previous for item in self._pending_restores):
+                self._pending_restores.append({
+                    "sink": previous,
+                    "volumes": list(state["physical_volumes"]),
+                    "muted": state["physical_muted"],
+                })
+            return True
+        if not self._set_sink_volume_confirmed(
+            previous,
+            *state["physical_volumes"],
+        ):
+            return False
+        if not self._set_sink_mute_confirmed(previous, state["physical_muted"]):
+            return False
+        self._downstream_volumes.pop(previous, None)
+        self._downstream_mutes.pop(previous, None)
+        return True
+
+    def _restore_pending_routes(self, names):
+        remaining = []
+        for item in self._pending_restores:
+            if item["sink"] not in names:
+                remaining.append(item)
+                continue
+            if not self._set_sink_volume_confirmed(
+                item["sink"],
+                *item["volumes"],
+            ) or not self._set_sink_mute_confirmed(item["sink"], item["muted"]):
+                return False
+            self._downstream_volumes.pop(item["sink"], None)
+            self._downstream_mutes.pop(item["sink"], None)
+        self._pending_restores = remaining
+        return True
 
     def _retry_blocked(self, request, downstream):
         if self._retry_request != request:
@@ -771,6 +1089,17 @@ class PipeWireEq:
             **details,
         }
 
+    def _fail_activation(self, reason, downstream, **details):
+        rollback_confirmed = self.teardown() is True
+        self._record_apply(
+            False,
+            reason,
+            downstream=downstream,
+            rollback_confirmed=rollback_confirmed,
+            **details,
+        )
+        return False
+
     def apply_diagnostics(self):
         return dict(self._last_apply) if self._last_apply is not None else None
 
@@ -784,6 +1113,52 @@ class PipeWireEq:
             and self._target_link_confirmed(downstream)
         )
 
+    def sync_state(self):
+        state = self._route_state()
+        if state is None or state["phase"] != "active":
+            return False
+        downstream = self._downstream_sink()
+        if (
+            downstream != state["sink"]
+            or self._runner(["pactl", "get-default-sink"]) != self._label
+            or not self._target_link_confirmed(downstream)
+        ):
+            return False
+        volume = self._sink_volume_pct(self._label)
+        muted = self._sink_muted(self._label)
+        if not volume or muted is None:
+            return False
+        self._pending_restores = list(state["pending_restores"])
+        previous_pending_restores = list(self._pending_restores)
+        live_sinks = {
+            name
+            for name, _status in _sink_candidates(
+                self._runner(["pactl", "list", "short", "sinks"]),
+                self._label,
+            )
+        }
+        linked_sink = _linked_downstream(
+            self._runner(["pw-link", "-l"]),
+            f"effect_output.{_SINK}",
+            live_sinks,
+        )
+        if not self._restore_pending_routes(live_sinks - {linked_sink}):
+            return False
+        if (
+            volume == state["volume"]
+            and muted == state["muted"]
+            and self._pending_restores == previous_pending_restores
+        ):
+            return True
+        return self._persist_route_state(
+            downstream,
+            volume,
+            "active",
+            muted,
+            state["physical_volumes"],
+            state["physical_muted"],
+        )
+
     def ensure_sink(self, gains, bass=0, loudness=False, balance=0):
         if not self.is_supported():
             self._record_apply(False, "unsupported")
@@ -792,6 +1167,43 @@ class PipeWireEq:
         if not downstream:
             self._record_apply(False, "downstream_missing")
             return False
+        current_default = self._runner(["pactl", "get-default-sink"])
+        state = self._route_state()
+        if state is not None:
+            self._pending_restores = list(state["pending_restores"])
+            previous_pending_restores = list(self._pending_restores)
+            live_sinks = {
+                name
+                for name, _status in _sink_candidates(
+                    self._runner(["pactl", "list", "short", "sinks"]),
+                    self._label,
+                )
+            }
+            linked_sink = _linked_downstream(
+                self._runner(["pw-link", "-l"]),
+                f"effect_output.{_SINK}",
+                live_sinks,
+            )
+            if not self._restore_pending_routes(live_sinks - {linked_sink}):
+                return self._fail_activation(
+                    "pending_route_restore_not_confirmed",
+                    downstream,
+                )
+            if self._pending_restores != previous_pending_restores:
+                if not self._persist_route_state(
+                    state["sink"],
+                    state["volume"],
+                    state["phase"],
+                    state["muted"],
+                    state["physical_volumes"],
+                    state["physical_muted"],
+                ):
+                    return self._fail_activation(
+                        "route_state_write_failed",
+                        downstream,
+                    )
+                self._clear_retry()
+                state = self._route_state()
         applied = (list(gains), bass, loudness)
         request = (tuple(gains), bass, bool(loudness), downstream)
         if self._retry_blocked(request, downstream):
@@ -808,7 +1220,27 @@ class PipeWireEq:
         if first and first_ever:
             self._first_enable_pending = True
             self._first_enable_downstream = downstream
-            self._first_enable_volume = self._sink_volume_pct(downstream)
+            self._first_enable_volumes = self._sink_volume_pcts(downstream)
+            self._first_enable_volume = (
+                self._first_enable_volumes[0]
+                if self._first_enable_volumes
+                else None
+            )
+            self._first_enable_mute = self._sink_muted(downstream)
+            if not self._first_enable_volume:
+                self._record_apply(
+                    False,
+                    "downstream_volume_missing",
+                    downstream=downstream,
+                )
+                return False
+            if self._first_enable_mute is None:
+                self._record_apply(
+                    False,
+                    "downstream_mute_missing",
+                    downstream=downstream,
+                )
+                return False
             if not self._persist_first_enable_pending():
                 return self._defer_failure(
                     request,
@@ -817,6 +1249,7 @@ class PipeWireEq:
                     downstream,
                 )
         configured_same = self._configured_request == request and not first_ever
+        service_restarted = False
         if not unchanged and not configured_same:
             try:
                 wrote_conf = self._write_conf(gains, bass, loudness, downstream)
@@ -849,6 +1282,102 @@ class PipeWireEq:
                         current=current_default or None,
                     )
                     return False
+                restart_state = self._route_state()
+                if restart_state is not None:
+                    self._pending_restores = list(
+                        restart_state["pending_restores"]
+                    )
+                    if (
+                        restart_state["sink"] != downstream
+                        and not any(
+                            item["sink"] == restart_state["sink"]
+                            for item in self._pending_restores
+                        )
+                    ):
+                        self._pending_restores.append({
+                            "sink": restart_state["sink"],
+                            "volumes": list(
+                                restart_state["physical_volumes"]
+                            ),
+                            "muted": restart_state["physical_muted"],
+                        })
+                    preserve_state = (
+                        restart_state["phase"] == "active"
+                        or restart_state["sink"] == downstream
+                    )
+                    live_eq_volume = (
+                        self._sink_volume_pct(self._label)
+                        if restart_state["phase"] == "active"
+                        else None
+                    )
+                    live_eq_mute = (
+                        self._sink_muted(self._label)
+                        if restart_state["phase"] == "active"
+                        else None
+                    )
+                    if live_eq_volume and live_eq_mute is not None:
+                        restart_volume = live_eq_volume
+                        restart_mute = live_eq_mute
+                    elif preserve_state:
+                        restart_volume = restart_state["volume"]
+                        restart_mute = restart_state["muted"]
+                    else:
+                        restart_volume = self._sink_volume_pct(current_default)
+                        restart_mute = self._sink_muted(current_default)
+                    if restart_state["sink"] == downstream:
+                        physical_volumes = restart_state["physical_volumes"]
+                        physical_muted = restart_state["physical_muted"]
+                    else:
+                        physical_volumes = self._sink_volume_pcts(downstream)
+                        physical_muted = self._sink_muted(downstream)
+                    if (
+                        not restart_volume
+                        or restart_mute is None
+                        or not physical_volumes
+                        or physical_muted is None
+                        or not self._persist_route_state(
+                            downstream,
+                            restart_volume,
+                            "prepared",
+                            restart_mute,
+                            physical_volumes,
+                            physical_muted,
+                        )
+                    ):
+                        return self._fail_activation(
+                            "route_state_write_failed",
+                            downstream,
+                        )
+                    state = self._route_state()
+                else:
+                    restart_volume = (
+                        self._sink_volume_pct(self._label)
+                        or self._sink_volume_pct(current_default)
+                    )
+                    restart_mute = self._sink_muted(self._label)
+                    if restart_mute is None:
+                        restart_mute = self._sink_muted(current_default)
+                    physical_volumes = self._sink_volume_pcts(downstream)
+                    physical_muted = self._sink_muted(downstream)
+                    if (
+                        not restart_volume
+                        or restart_mute is None
+                        or not physical_volumes
+                        or physical_muted is None
+                        or not self._persist_route_state(
+                            downstream,
+                            restart_volume,
+                            "prepared",
+                            restart_mute,
+                            physical_volumes,
+                            physical_muted,
+                        )
+                    ):
+                        return self._fail_activation(
+                            "route_state_write_failed",
+                            downstream,
+                        )
+                    state = self._route_state()
                 if not self._restart():
                     return self._defer_failure(
                         request,
@@ -857,6 +1386,7 @@ class PipeWireEq:
                         downstream,
                         bypass=True,
                     )
+                service_restarted = True
                 self._configured_request = request
             if not self._target_link_confirmed(downstream, retry=True):
                 return self._defer_failure(
@@ -866,48 +1396,224 @@ class PipeWireEq:
                     downstream,
                     bypass=True,
                 )
-        if not self._set_default_confirmed(self._label):
-            rollback_confirmed = None
-            if first and first_ever:
-                self._remove_entry(conf_path)
-                self._restart()
-                rollback_confirmed = self._sink_absent_confirmed(self._label)
-                self._cleanup_pending = not rollback_confirmed
-                self._set_default_confirmed(downstream)
-                self._configured_request = None
+        state = self._route_state()
+        if state is not None and state["pending_restores"]:
+            self._pending_restores = list(state["pending_restores"])
+            previous_pending_restores = list(self._pending_restores)
+            live_sinks = {
+                name
+                for name, _status in _sink_candidates(
+                    self._runner(["pactl", "list", "short", "sinks"]),
+                    self._label,
+                )
+            }
+            linked_sink = _linked_downstream(
+                self._runner(["pw-link", "-l"]),
+                f"effect_output.{_SINK}",
+                live_sinks,
+            )
+            if not self._restore_pending_routes(live_sinks - {linked_sink}):
+                return self._fail_activation(
+                    "pending_route_restore_not_confirmed",
+                    downstream,
+                )
+            if self._pending_restores != previous_pending_restores:
+                if not self._persist_route_state(
+                    state["sink"],
+                    state["volume"],
+                    state["phase"],
+                    state["muted"],
+                    state["physical_volumes"],
+                    state["physical_muted"],
+                ):
+                    return self._fail_activation(
+                        "route_state_write_failed",
+                        downstream,
+                    )
+                state = self._route_state()
+        activation_volume = None
+        activation_mute = None
+        commit_eq_volume = False
+        default_handoff = current_default != self._label
+        route_handoff = (
+            (state is not None and state["sink"] != downstream)
+            or (
+                self._active_downstream is not None
+                and self._active_downstream != downstream
+            )
+        )
+        if first or default_handoff or route_handoff or service_restarted:
+            _pending, pending_volume = self._pending_first_enable(downstream)
+            state = self._route_state()
+            already_default = current_default == self._label
+            if first:
+                live_sink = self._label if already_default else downstream
+                live_volume = self._sink_volume_pct(live_sink)
+                live_mute = self._sink_muted(live_sink)
+                active_recovery = (
+                    already_default
+                    and state is not None
+                    and state["sink"] == downstream
+                    and state["phase"] == "active"
+                )
+                activation_volume = (
+                    live_volume if active_recovery else pending_volume or live_volume
+                )
+                activation_mute = (
+                    live_mute if active_recovery else state["muted"] if state else live_mute
+                )
+            else:
+                same_route_recovery = (
+                    service_restarted
+                    and state is not None
+                    and state["sink"] == downstream
+                )
+                activation_volume = (
+                    state["volume"]
+                    if same_route_recovery
+                    else self._sink_volume_pct(self._label) or self._user_vol
+                )
+                activation_mute = (
+                    state["muted"]
+                    if same_route_recovery
+                    else self._sink_muted(self._label)
+                )
+            if not activation_volume:
+                return self._fail_activation(
+                    "downstream_volume_missing",
+                    downstream,
+                )
+            if activation_mute is None:
+                return self._fail_activation(
+                    "downstream_mute_missing",
+                    downstream,
+                )
+            if not self._restore_previous_route_state(state, downstream):
+                return self._fail_activation(
+                    "previous_route_state_restore_not_confirmed",
+                    downstream,
+                )
+            if state is not None and state["sink"] == downstream:
+                physical_volumes = tuple(state["physical_volumes"])
+                physical_muted = state["physical_muted"]
+            else:
+                physical_volumes = self._sink_volume_pcts(downstream)
+                physical_muted = self._sink_muted(downstream)
+            if not physical_volumes or physical_muted is None:
+                return self._fail_activation(
+                    "downstream_snapshot_missing",
+                    downstream,
+                )
+            self._downstream_volumes[downstream] = tuple(physical_volumes)
+            self._downstream_mutes[downstream] = physical_muted
+            if not self._persist_route_state(
+                downstream,
+                activation_volume,
+                "prepared",
+                activation_mute,
+                physical_volumes,
+                physical_muted,
+            ):
+                return self._fail_activation(
+                    "route_state_write_failed",
+                    downstream,
+                )
+            commit_eq_volume = first or default_handoff or service_restarted
+            if default_handoff:
+                if not self._set_sink_volume_confirmed(self._label, "100%"):
+                    return self._fail_activation(
+                        "eq_volume_stage_not_confirmed",
+                        downstream,
+                    )
+            if not self._set_sink_mute_confirmed(self._label, activation_mute):
+                return self._fail_activation(
+                    "eq_mute_not_confirmed",
+                    downstream,
+                )
+        if not self._set_default_confirmed(self._label, downstream):
+            default_failure = dict(self._default_failure or {})
             return self._defer_failure(
                 request,
                 "default",
-                "default_sink_not_confirmed",
+                default_failure.get("reason", "default_sink_not_confirmed"),
                 downstream,
                 bypass=True,
-                **(
-                    {"rollback_confirmed": rollback_confirmed}
-                    if rollback_confirmed is not None
-                    else {}
-                ),
+                current=default_failure.get("current"),
             )
-        if first:
-            pending, pending_volume = self._pending_first_enable(downstream)
-            if pending:
-                vol = pending_volume or self._sink_volume_pct(downstream)
-                if vol:
-                    self._user_vol = vol
-                    self._runner(["pactl", "set-sink-volume", self._label, vol])
-            if not self._clear_first_enable_pending():
-                return self._defer_failure(
-                    request,
-                    "config",
-                    "pending_marker_cleanup_failed",
+        current_downstream = self._downstream_sink()
+        if (
+            current_downstream != downstream
+            or not self._target_link_confirmed(downstream)
+        ):
+            bypass_confirmed = bool(
+                current_downstream
+                and self._set_default_confirmed(current_downstream)
+            )
+            return self._fail_activation(
+                "downstream_changed_during_default",
+                downstream,
+                current=current_downstream,
+                bypass_confirmed=bypass_confirmed,
+            )
+        if commit_eq_volume:
+            self._user_vol = activation_volume
+            if activation_volume != "100%" and not self._set_sink_volume_confirmed(
+                self._label,
+                activation_volume,
+            ):
+                return self._fail_activation(
+                    "eq_volume_commit_not_confirmed",
                     downstream,
-                    bypass=True,
                 )
+        if first:
             self._orig_default = downstream
         self._owns_sink = True
         previous_downstream = self._active_downstream
-        if previous_downstream and previous_downstream != downstream:
-            self._restore_downstream_volume(previous_downstream)
-        self._pin_downstream(downstream, balance)
+        if (
+            previous_downstream
+            and previous_downstream != downstream
+            and (
+                previous_downstream in self._downstream_volumes
+                or previous_downstream in self._downstream_mutes
+            )
+        ):
+            if not self._restore_downstream(previous_downstream):
+                return self._fail_activation(
+                    "previous_downstream_restore_not_confirmed",
+                    downstream,
+                )
+        if not self._pin_downstream(downstream, balance):
+            return self._fail_activation(
+                "downstream_volume_pin_not_confirmed",
+                downstream,
+            )
+        final_downstream = self._downstream_sink()
+        if (
+            self._runner(["pactl", "get-default-sink"]) != self._label
+            or final_downstream != downstream
+            or not self._target_link_confirmed(downstream)
+        ):
+            return self._fail_activation(
+                "post_pin_route_not_confirmed",
+                downstream,
+                current=final_downstream,
+            )
+        final_volume = self._sink_volume_pct(self._label)
+        final_mute = self._sink_muted(self._label)
+        physical_volumes = self._downstream_volumes.get(downstream)
+        physical_muted = self._downstream_mutes.get(downstream)
+        if not final_volume or final_mute is None or not self._persist_route_state(
+            downstream,
+            final_volume,
+            "active",
+            final_mute,
+            physical_volumes,
+            physical_muted,
+        ):
+            return self._fail_activation(
+                "route_state_write_failed",
+                downstream,
+            )
         self._last_applied = applied
         self._active_downstream = downstream
         if self._requested_downstream == downstream:
@@ -971,6 +1677,113 @@ class PipeWireEq:
         all_names = {name for name, _state in _sink_candidates(sinks, "")}
         eq_present = self._label in all_names
         names = all_names - {self._label}
+        state = self._route_state()
+        if state is not None:
+            self._pending_restores = list(state["pending_restores"])
+            if (
+                state["sink"] not in names
+                and not any(
+                    item["sink"] == state["sink"]
+                    for item in self._pending_restores
+                )
+            ):
+                self._pending_restores.append({
+                    "sink": state["sink"],
+                    "volumes": list(state["physical_volumes"]),
+                    "muted": state["physical_muted"],
+                })
+        previous_pending_restores = (
+            list(state["pending_restores"])
+            if state is not None
+            else list(self._pending_restores)
+        )
+        if not self._restore_pending_routes(names):
+            return self._defer_failure(
+                ("teardown_pending_routes",),
+                "teardown",
+                "teardown_previous_sink_restore_not_confirmed",
+                None,
+            )
+        if state is not None and self._pending_restores != previous_pending_restores:
+            if not self._persist_route_state(
+                state["sink"],
+                state["volume"],
+                state["phase"],
+                state["muted"],
+                state["physical_volumes"],
+                state["physical_muted"],
+            ):
+                return self._defer_failure(
+                    ("teardown_pending_routes",),
+                    "marker",
+                    "teardown_marker_write_failed",
+                    state["sink"],
+                )
+            self._clear_retry()
+            state = self._route_state()
+        if (
+            state is not None
+            and current_default == state["sink"]
+            and current_default != self._label
+        ):
+            transfer_volume = (
+                self._sink_volume_pct(self._label)
+                if state["phase"] == "active" and eq_present
+                else None
+            ) or state["volume"]
+            transfer_mute = (
+                self._sink_muted(self._label)
+                if state["phase"] == "active" and eq_present
+                else None
+            )
+            if transfer_mute is None:
+                transfer_mute = state["muted"]
+            if (
+                not self._set_sink_volume_confirmed(
+                    state["sink"],
+                    transfer_volume,
+                )
+                or not self._set_sink_mute_confirmed(
+                    state["sink"],
+                    transfer_mute,
+                )
+            ):
+                return self._defer_failure(
+                    ("teardown_owned_default", state["sink"]),
+                    "teardown",
+                    "teardown_owned_default_restore_not_confirmed",
+                    state["sink"],
+                )
+            self._downstream_volumes.pop(state["sink"], None)
+            self._downstream_mutes.pop(state["sink"], None)
+        if (
+            state is not None
+            and current_default not in (self._label, state["sink"])
+        ):
+            previous_pending_restores = list(self._pending_restores)
+            if not self._restore_previous_route_state(state, current_default):
+                return self._defer_failure(
+                    ("teardown_previous_route", state["sink"]),
+                    "teardown",
+                    "teardown_previous_sink_restore_not_confirmed",
+                    state["sink"],
+                )
+            if self._pending_restores != previous_pending_restores:
+                if not self._persist_route_state(
+                    state["sink"],
+                    state["volume"],
+                    state["phase"],
+                    state["muted"],
+                    state["physical_volumes"],
+                    state["physical_muted"],
+                ):
+                    return self._defer_failure(
+                        ("teardown_previous_route", state["sink"]),
+                        "marker",
+                        "teardown_marker_write_failed",
+                        state["sink"],
+                    )
+                state = self._route_state()
         runtime_pending = (
             had_conf
             or self._orig_default is not None
@@ -978,6 +1791,59 @@ class PipeWireEq:
             or current_default == self._label
             or eq_present
         )
+        if state is not None and not runtime_pending:
+            retry_request = ("teardown_journal", state["sink"])
+            downstream = state["sink"]
+            if self._retry_blocked(retry_request, downstream):
+                return False
+            if downstream not in names:
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_downstream_missing",
+                    downstream,
+                )
+            active_target = current_default == downstream
+            volumes = (
+                (state["volume"],)
+                if active_target
+                else tuple(state["physical_volumes"])
+            )
+            muted = state["muted"] if active_target else state["physical_muted"]
+            if not self._set_sink_volume_confirmed(downstream, *volumes):
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_volume_not_confirmed",
+                    downstream,
+                )
+            if not self._set_sink_mute_confirmed(downstream, muted):
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_mute_not_confirmed",
+                    downstream,
+                )
+            if self._pending_restores:
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_pending_sink_missing",
+                    downstream,
+                )
+            if not self._clear_first_enable_pending():
+                return self._defer_failure(
+                    retry_request,
+                    "marker",
+                    "teardown_marker_cleanup_failed",
+                    downstream,
+                )
+            self._cleanup_pending = False
+            self._active = False
+            self._owns_sink = False
+            self._clear_retry()
+            self._record_apply(True, operation="teardown")
+            return True
         if not runtime_pending:
             retry_request = ("teardown_marker",)
             if self._retry_blocked(retry_request, None):
@@ -1008,18 +1874,74 @@ class PipeWireEq:
                 downstream = self._orig_default
             else:
                 downstream = self._downstream_sink()
-        our_vol = (
-            self._sink_volume_pct(self._label) or self._user_vol
+        _pending, pending_volume = (
+            self._pending_first_enable(downstream)
+            if transfer_volume and downstream
+            else (False, None)
+        )
+        eq_volume = self._sink_volume_pct(self._label) if transfer_volume else None
+        our_vol = None
+        if transfer_volume:
+            if state is not None and state.get("phase") != "active":
+                our_vol = pending_volume or eq_volume or self._user_vol
+            else:
+                our_vol = eq_volume or pending_volume or self._user_vol
+        our_mute = (
+            self._sink_muted(self._label)
             if transfer_volume
             else None
         )
+        if (
+            our_mute is None
+            and state is not None
+            and state["sink"] == downstream
+            and isinstance(state.get("muted"), bool)
+        ):
+            our_mute = state["muted"]
+        if transfer_volume:
+            if not downstream:
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_downstream_missing",
+                    downstream,
+                )
+            if not self._set_sink_volume_confirmed(
+                downstream,
+                our_vol or "100%",
+            ):
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_volume_not_confirmed",
+                    downstream,
+                )
+            if our_mute is None or not self._set_sink_mute_confirmed(
+                downstream,
+                our_mute,
+            ):
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_mute_not_confirmed",
+                    downstream,
+                )
+            if not self._set_default_confirmed(downstream):
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
+                    "teardown_default_not_confirmed",
+                    downstream,
+                )
+            self._downstream_volumes.pop(downstream, None)
+            self._downstream_mutes.pop(downstream, None)
         if had_conf:
             self._remove_entry(path)
         restarted = self._restart()
         sink_absent = restarted and self._sink_absent_confirmed(self._label)
         if not restarted or not sink_absent:
             for sink in list(self._downstream_volumes):
-                self._restore_downstream_volume(sink)
+                self._restore_downstream(sink)
             return self._defer_failure(
                 retry_request,
                 "teardown",
@@ -1028,25 +1950,13 @@ class PipeWireEq:
                 bypass=True,
             )
         for sink in list(self._downstream_volumes):
-            self._restore_downstream_volume(sink)
-        if transfer_volume and downstream:
-            self._runner(
-                ["pactl", "set-sink-volume", downstream, our_vol or "100%"]
-            )
-            if not self._set_default_confirmed(downstream):
+            if not self._restore_downstream(sink):
                 return self._defer_failure(
                     retry_request,
                     "teardown",
-                    "teardown_default_not_confirmed",
+                    "teardown_previous_sink_restore_not_confirmed",
                     downstream,
                 )
-        elif transfer_volume:
-            return self._defer_failure(
-                retry_request,
-                "teardown",
-                "teardown_downstream_missing",
-                downstream,
-            )
         self._orig_default = None
         self._active_downstream = None
         self._requested_downstream = None
@@ -1056,9 +1966,17 @@ class PipeWireEq:
         self._last_applied = None
         self._user_vol = None
         self._downstream_volumes = {}
+        self._downstream_mutes = {}
         self._clear_retry()
         self._active = False
         self._owns_sink = False
+        if self._pending_restores:
+            return self._defer_failure(
+                retry_request,
+                "teardown",
+                "teardown_pending_sink_missing",
+                downstream,
+            )
         if not self._clear_first_enable_pending():
             return self._defer_failure(
                 ("teardown_marker",),

--- a/py_modules/audio/pipewire.py
+++ b/py_modules/audio/pipewire.py
@@ -1,9 +1,4 @@
-"""Device layer for the EQ sink: writes the filter-chain conf into the user's
-filter-chain.conf.d/, restarts the filter-chain service to apply, and sets the sink as
-default. Runs session commands (pactl / systemctl --user) against the logged-in user from
-the root backend, mirroring the gamescope/fan spawn hygiene (clean_env + XDG_RUNTIME_DIR).
-Apply on release: every gain change rewrites the conf and restarts (~1s); live per-band
-control isn't available via the CLI on current PipeWire."""
+"""PipeWire filter-chain lifecycle for the system EQ."""
 import glob
 import json
 import os
@@ -31,6 +26,13 @@ _RETRY_MIN_S = 15.0
 _RETRY_MAX_S = 60.0
 _RETRY_MAX_ATTEMPTS = 3
 _MAX_ENTRY_BYTES = 64 * 1024
+_RETRY_OPERATIONS = {
+    "config": "config_write",
+    "default": "default_sink",
+    "link": "target_link",
+    "service": "service_restart",
+    "teardown": "teardown",
+}
 
 
 def _find_lib(*relative):
@@ -152,15 +154,13 @@ def _configured_default_sink(pw_metadata_text):
 
 
 def _relevant_links(pw_link_text, *, cap=2500):
-    """Filter `pw-link -l` to the lines that reveal the EQ routing — our node, hardware
-    outputs and loopbacks — keeping each matched node line with its indented `|->`/`|<-`
-    continuation. Capped so the report bundle stays small."""
+    """Return the bounded subset of links involved in EQ routing."""
     if not pw_link_text:
         return ""
     keep = ("pdc_eq", "alsa_output", "bluez_output", "loopback")
     out, keeping = [], False
     for line in pw_link_text.splitlines():
-        if line[:1] not in (" ", "\t"):  # a node line (not an indented peer)
+        if line[:1] not in (" ", "\t"):
             keeping = any(k in line.lower() for k in keep)
         if keeping:
             out.append(line)
@@ -168,8 +168,7 @@ def _relevant_links(pw_link_text, *, cap=2500):
 
 
 def _find_session():
-    """The logged-in user's PipeWire session: (uid, runtime_dir, user) from the pipewire
-    socket under /run/user/*, or None when no session is present."""
+    """Return the session owning the active PipeWire socket."""
     for sock in glob.glob("/run/user/*/pipewire-0"):
         runtime = os.path.dirname(sock)
         try:
@@ -208,15 +207,10 @@ class PipeWireEq:
         self._retry_attempts = 0
         self._retry_service_token = None
         self._retry_recovery = None
-        # Human-facing sink name shown in the system/Steam volume OSD (reads node.name),
-        # e.g. "Legion Go EQ". Used both as the label and as the sink's node.name.
         self._name = name or "Panel de Control"
         self._label = f"{self._name} EQ"
 
-    # --- session command plumbing -------------------------------------------------
     def _session_cmd(self, argv):
-        """Build (cmd, env) to run `argv` as the logged-in user with a clean env + XDG
-        runtime, from the (root) backend. Returns (None, None) with no session."""
         if not self._session:
             return None, None
         _uid, runtime, user = self._session
@@ -233,7 +227,6 @@ class PipeWireEq:
         return cmd, env
 
     def _run(self, argv, timeout=8):
-        """Run a session command and return its stdout (or ''). Never raises."""
         cmd, env = self._session_cmd(argv)
         if cmd is None:
             return ""
@@ -289,14 +282,17 @@ class PipeWireEq:
         path = self._conf_path()
         return f"{path}.first-enable-pending" if path else None
 
+    def _session_ids(self):
+        try:
+            account = pwd.getpwuid(self._session[0])
+            return account.pw_uid, account.pw_gid
+        except KeyError:
+            return self._session[0], self._session[0]
+
     def _open_parent_dir(self, path, *, create=False):
         if not path or not self._session or not os.path.isabs(path):
             return None
-        try:
-            account = pwd.getpwuid(self._session[0])
-            uid, gid = account.pw_uid, account.pw_gid
-        except KeyError:
-            uid = gid = self._session[0]
+        uid, gid = self._session_ids()
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
         current_fd = None
         try:
@@ -409,11 +405,7 @@ class PipeWireEq:
         name = os.path.basename(path)
         temp_name = f".{name}.{os.getpid()}.{secrets.token_hex(8)}"
         temp_fd = None
-        try:
-            account = pwd.getpwuid(self._session[0])
-            uid, gid = account.pw_uid, account.pw_gid
-        except KeyError:
-            uid = gid = self._session[0]
+        uid, gid = self._session_ids()
         try:
             try:
                 existing = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
@@ -480,15 +472,14 @@ class PipeWireEq:
             ),
         )
 
-    def _first_enable_is_pending(self):
+    def _pending_first_enable(self, downstream):
         path = self._pending_path()
-        return self._first_enable_pending or bool(path and self._entry_exists(path))
-
-    def _pending_first_enable_volume(self, downstream):
-        path = self._pending_path()
-        if path and self._entry_exists(path):
+        stored = self._read_entry(path) if path else None
+        persisted = bool(path and (stored is not None or self._entry_exists(path)))
+        volume = None
+        if stored is not None:
             try:
-                pending = json.loads(self._read_entry(path))
+                pending = json.loads(stored)
             except (ValueError, TypeError):
                 pending = None
             if (
@@ -496,10 +487,10 @@ class PipeWireEq:
                 and pending.get("sink") == downstream
                 and re.fullmatch(r"\d+%", str(pending.get("volume", "")))
             ):
-                return pending["volume"]
-        if self._first_enable_downstream == downstream:
-            return self._first_enable_volume
-        return None
+                volume = pending["volume"]
+        if volume is None and self._first_enable_downstream == downstream:
+            volume = self._first_enable_volume
+        return self._first_enable_pending or persisted, volume
 
     def _clear_first_enable_pending(self):
         path = self._pending_path()
@@ -516,9 +507,8 @@ class PipeWireEq:
             self._clear_first_enable_pending()
         return removed
 
-    # --- capability ---------------------------------------------------------------
     def is_supported(self):
-        if not self._session:  # re-probe: the session may come up after _init (self-heal)
+        if not self._session:
             self._session = _find_session()
         return (
             bool(self._session)
@@ -531,7 +521,6 @@ class PipeWireEq:
     def _binary_available(name):
         return resolve_bin(name) != name or shutil.which(name) is not None
 
-    # --- lifecycle ----------------------------------------------------------------
     def _write_conf(self, gains, bass, loudness, downstream=None):
         path = self._conf_path()
         if not path:
@@ -688,9 +677,6 @@ class PipeWireEq:
         return True
 
     def _pin_downstream(self, downstream, balance):
-        """Hold the physical sink at unity, offset per-channel for L/R balance (far side
-        attenuated, near side at unity). Pin unity first so a non-stereo sink stays
-        transparent when the two-value write fails, rather than a hidden attenuation."""
         if downstream not in self._downstream_volumes:
             self._downstream_volumes[downstream] = self._sink_volume_pcts(downstream)
         left, right = balance_channels(balance)
@@ -722,13 +708,7 @@ class PipeWireEq:
             if service_changed or link_recovered:
                 self._clear_retry()
                 return False
-            operation = {
-                "config": "config_write",
-                "default": "default_sink",
-                "link": "target_link",
-                "service": "service_restart",
-                "teardown": "teardown",
-            }.get(self._retry_recovery, "apply")
+            operation = _RETRY_OPERATIONS.get(self._retry_recovery, "apply")
             self._record_apply(
                 False,
                 f"{operation}_retry_exhausted",
@@ -753,6 +733,22 @@ class PipeWireEq:
         self._retry_recovery = recovery
         self._retry_at = self._monotonic() + self._retry_delay
         self._retry_delay = min(_RETRY_MAX_S, self._retry_delay * 2)
+
+    def _defer_failure(
+        self,
+        request,
+        recovery,
+        reason,
+        downstream,
+        *,
+        bypass=False,
+        **details,
+    ):
+        self._defer_retry(request, recovery)
+        if bypass:
+            details["bypass_confirmed"] = self._bypass_eq_default(downstream)
+        self._record_apply(False, reason, downstream=downstream, **details)
+        return False
 
     def _clear_retry(self):
         self._retry_request = None
@@ -785,16 +781,6 @@ class PipeWireEq:
         )
 
     def ensure_sink(self, gains, bass=0, loudness=False, balance=0):
-        """Create/refresh the EQ sink (bands + optional bass enhancer), make it default,
-        and keep the physical sink it feeds pinned at unity (100%), offset for balance.
-        Steam's volume controls the default sink — i.e. ours — so the downstream must stay
-        transparent, or its level becomes a hidden second attenuation the user can't reach.
-        Re-pinning every apply is self-healing across resume/reload; captured physical levels
-        are restored on route handoff and teardown.
-
-        Diff-gated: an unchanged (gains, bass, loudness) skips the conf rewrite + ~1s restart
-        (just re-asserts default + the pin). Balance is outside the gate — it only moves the
-        pin, so it re-applies without a restart."""
         if not self.is_supported():
             self._record_apply(False, "unsupported")
             return False
@@ -812,8 +798,6 @@ class PipeWireEq:
             and downstream == self._active_downstream
             and self._target_link_confirmed(downstream)
         )
-        # First-ever enable (no conf yet) vs a boot re-assert (conf exists) — check before
-        # _write_conf creates it.
         first = self._orig_default is None
         conf_path = self._conf_path()
         first_ever = not (conf_path and self._entry_exists(conf_path))
@@ -822,13 +806,12 @@ class PipeWireEq:
             self._first_enable_downstream = downstream
             self._first_enable_volume = self._sink_volume_pct(downstream)
             if not self._persist_first_enable_pending():
-                self._defer_retry(request, "config")
-                self._record_apply(
-                    False,
+                return self._defer_failure(
+                    request,
+                    "config",
                     "pending_marker_write_failed",
-                    downstream=downstream,
+                    downstream,
                 )
-                return False
         configured_same = self._configured_request == request and not first_ever
         if not unchanged and not configured_same:
             try:
@@ -841,16 +824,14 @@ class PipeWireEq:
             if not wrote_conf:
                 if first and first_ever:
                     self._discard_first_enable_config(conf_path)
-                bypass_confirmed = self._bypass_eq_default(downstream)
-                self._defer_retry(request, "config")
-                self._record_apply(
-                    False,
+                return self._defer_failure(
+                    request,
+                    "config",
                     "config_write_failed",
-                    downstream=downstream,
-                    bypass_confirmed=bypass_confirmed,
+                    downstream,
+                    bypass=True,
                     **({"error": write_error} if write_error else {}),
                 )
-                return False
         if not unchanged:
             if not configured_same:
                 current_default = self._runner(["pactl", "get-default-sink"])
@@ -865,26 +846,22 @@ class PipeWireEq:
                     )
                     return False
                 if not self._restart():
-                    self._defer_retry(request, "service")
-                    bypass_confirmed = self._bypass_eq_default(downstream)
-                    self._record_apply(
-                        False,
+                    return self._defer_failure(
+                        request,
+                        "service",
                         "service_restart_failed",
-                        downstream=downstream,
-                        bypass_confirmed=bypass_confirmed,
+                        downstream,
+                        bypass=True,
                     )
-                    return False
                 self._configured_request = request
             if not self._target_link_confirmed(downstream, retry=True):
-                self._defer_retry(request, "link")
-                bypass_confirmed = self._bypass_eq_default(downstream)
-                self._record_apply(
-                    False,
+                return self._defer_failure(
+                    request,
+                    "link",
                     "target_link_not_confirmed",
-                    downstream=downstream,
-                    bypass_confirmed=bypass_confirmed,
+                    downstream,
+                    bypass=True,
                 )
-                return False
         if not self._set_default_confirmed(self._label):
             rollback_confirmed = None
             if first and first_ever:
@@ -894,41 +871,33 @@ class PipeWireEq:
                 self._cleanup_pending = not rollback_confirmed
                 self._set_default_confirmed(downstream)
                 self._configured_request = None
-            bypass_confirmed = self._bypass_eq_default(downstream)
-            self._defer_retry(request, "default")
-            self._record_apply(
-                False,
+            return self._defer_failure(
+                request,
+                "default",
                 "default_sink_not_confirmed",
-                downstream=downstream,
-                bypass_confirmed=bypass_confirmed,
+                downstream,
+                bypass=True,
                 **(
                     {"rollback_confirmed": rollback_confirmed}
                     if rollback_confirmed is not None
                     else {}
                 ),
             )
-            return False
         if first:
-            if self._first_enable_is_pending():
-                # Carry the downstream's level onto our sink so enabling doesn't jump
-                # loudness. Skip on a boot re-assert: the sink already holds the user's
-                # level (WirePlumber restores it), and the downstream is always unity.
-                vol = self._pending_first_enable_volume(
-                    downstream
-                ) or self._sink_volume_pct(downstream)
+            pending, pending_volume = self._pending_first_enable(downstream)
+            if pending:
+                vol = pending_volume or self._sink_volume_pct(downstream)
                 if vol:
                     self._user_vol = vol
                     self._runner(["pactl", "set-sink-volume", self._label, vol])
             if not self._clear_first_enable_pending():
-                bypass_confirmed = self._bypass_eq_default(downstream)
-                self._defer_retry(request, "config")
-                self._record_apply(
-                    False,
+                return self._defer_failure(
+                    request,
+                    "config",
                     "pending_marker_cleanup_failed",
-                    downstream=downstream,
-                    bypass_confirmed=bypass_confirmed,
+                    downstream,
+                    bypass=True,
                 )
-                return False
             self._orig_default = downstream
         self._owns_sink = True
         previous_downstream = self._active_downstream
@@ -946,7 +915,6 @@ class PipeWireEq:
         return True
 
     def set_gains(self, gains, bass=0, loudness=False, balance=0):
-        """Apply on release: rewrite the conf + restart (balance just moves the pin)."""
         return self.ensure_sink(gains, bass, loudness, balance)
 
     def current_route(self):
@@ -956,9 +924,6 @@ class PipeWireEq:
             return "speaker"
 
     def is_default(self):
-        """True when our EQ sink is the current default output. WirePlumber can re-pick
-        the physical device as default on resume/hotplug (dropping the EQ); the watcher
-        uses this to re-assert."""
         return self._runner(["pactl", "get-default-sink"]) == self._label
 
     def diagnostics(self):
@@ -982,11 +947,6 @@ class PipeWireEq:
                 "route": self.current_route(),
                 "eq_volume": self._sink_volume_pct(self._label),
                 "downstream_volume": self._sink_volume_pct(downstream) if downstream else None,
-                # Where the EQ node's output actually routes (does it reach a hardware
-                # output, or a virtual/loopback sink that swallows it?). This is the
-                # signal that tells a "no sound with the EQ on" report apart: node graph
-                # + whether the filter-chain loaded. Filtered to the relevant nodes and
-                # capped so the bundle stays small.
                 "links": _relevant_links(self._runner(["pw-link", "-l"])),
                 "modules": self._runner(["pactl", "list", "short", "modules"]) or "",
             })
@@ -999,10 +959,6 @@ class PipeWireEq:
         return info
 
     def teardown(self):
-        """Remove the sink and hand the user's current level back to the physical sink
-        (fail-safe on disable/unload). No-op when we never created a sink — otherwise we'd
-        needlessly restart the shared filter-chain service (interrupting the user's own
-        filters) on every unload."""
         self.stop_test()
         path = self._conf_path()
         had_conf = bool(path and self._entry_exists(path))
@@ -1047,17 +1003,15 @@ class PipeWireEq:
         restarted = self._restart()
         sink_absent = restarted and self._sink_absent_confirmed(self._label)
         if not restarted or not sink_absent:
-            bypass_confirmed = self._bypass_eq_default(downstream)
             for sink in list(self._downstream_volumes):
                 self._restore_downstream_volume(sink)
-            self._defer_retry(retry_request, "teardown")
-            self._record_apply(
-                False,
+            return self._defer_failure(
+                retry_request,
+                "teardown",
                 "teardown_restart_failed" if not restarted else "teardown_sink_still_present",
-                downstream=downstream,
-                bypass_confirmed=bypass_confirmed,
+                downstream,
+                bypass=True,
             )
-            return False
         for sink in list(self._downstream_volumes):
             self._restore_downstream_volume(sink)
         if transfer_volume and downstream:
@@ -1065,17 +1019,19 @@ class PipeWireEq:
                 ["pactl", "set-sink-volume", downstream, our_vol or "100%"]
             )
             if not self._set_default_confirmed(downstream):
-                self._defer_retry(retry_request, "teardown")
-                self._record_apply(
-                    False,
+                return self._defer_failure(
+                    retry_request,
+                    "teardown",
                     "teardown_default_not_confirmed",
-                    downstream=downstream,
+                    downstream,
                 )
-                return False
         elif transfer_volume:
-            self._defer_retry(retry_request, "teardown")
-            self._record_apply(False, "teardown_downstream_missing")
-            return False
+            return self._defer_failure(
+                retry_request,
+                "teardown",
+                "teardown_downstream_missing",
+                downstream,
+            )
         self._orig_default = None
         self._active_downstream = None
         self._requested_downstream = None

--- a/py_modules/audio/pipewire.py
+++ b/py_modules/audio/pipewire.py
@@ -5,21 +5,32 @@ the root backend, mirroring the gamescope/fan spawn hygiene (clean_env + XDG_RUN
 Apply on release: every gain change rewrites the conf and restarts (~1s); live per-band
 control isn't available via the CLI on current PipeWire."""
 import glob
+import json
 import os
 import pwd
 import re
+import secrets
+import shutil
 import signal
+import stat
 import subprocess
+import time
 
 from audio.const import balance_channels
 from audio.filter_chain import build_chain_config
 from audio.route import route_of_sink
+from controllers.detect import clean_env, resolve_bin
 from osinfo import _parse_os_release
 
 _DIGITAL_HINTS = ("hdmi", "displayport", "iec958", "spdif")
 
 _SINK = "pdc_eq"
 _SERVICE = "filter-chain.service"
+_CONFIRM_DELAYS = (0, 0.05, 0.1, 0.2, 0.4)
+_RETRY_MIN_S = 15.0
+_RETRY_MAX_S = 60.0
+_RETRY_MAX_ATTEMPTS = 3
+_MAX_ENTRY_BYTES = 64 * 1024
 
 
 def _find_lib(*relative):
@@ -49,7 +60,7 @@ def _is_digital(name):
     return any(h in (name or "").lower() for h in _DIGITAL_HINTS)
 
 
-def pick_downstream(short_sinks_text, our_name):
+def _sink_candidates(short_sinks_text, our_name):
     candidates = []
     for line in (short_sinks_text or "").splitlines():
         parts = line.split("\t")
@@ -57,17 +68,87 @@ def pick_downstream(short_sinks_text, our_name):
         state = parts[4] if len(parts) > 4 else ""
         if name and name != our_name:
             candidates.append((name, state))
-    pool = [c for c in candidates if not _is_digital(c[0])] or candidates
-    if not pool:
+    return candidates
+
+
+def pick_downstream(short_sinks_text, our_name):
+    candidates = _sink_candidates(short_sinks_text, our_name)
+    if not candidates:
         return None
-    running = [n for n, s in pool if s == "RUNNING"]  # the active output on multi-sink devices
+    running = [n for n, s in candidates if s == "RUNNING"]
+    if running:
+        return running[0]
+    pool = [c for c in candidates if not _is_digital(c[0])] or candidates
     return running[0] if running else pool[0][0]
 
 
-def choose_downstream(default_sink, short_sinks_text, our_name):
-    if default_sink and default_sink != our_name and not _is_digital(default_sink):
-        return default_sink
+def choose_downstream(
+    default_sink,
+    short_sinks_text,
+    our_name,
+    preferred=None,
+    linked=None,
+    configured=None,
+    configured_changed=False,
+    requested=None,
+):
+    candidates = _sink_candidates(short_sinks_text, our_name)
+    names = {name for name, _state in candidates}
+    if default_sink and default_sink != our_name:
+        if not candidates or default_sink in names:
+            return default_sink
+    if requested and requested in names:
+        return requested
+    if (
+        configured
+        and configured in names
+        and (configured_changed or preferred is None)
+    ):
+        return configured
+    if linked and linked in names:
+        return linked
+    if preferred and preferred in names:
+        return preferred
+    if configured and configured in names:
+        return configured
     return pick_downstream(short_sinks_text, our_name)
+
+
+def _link_reaches(pw_link_text, source, target):
+    in_source = False
+    for line in (pw_link_text or "").splitlines():
+        if line[:1] not in (" ", "\t"):
+            in_source = line.strip().rsplit(":", 1)[0] == source
+        elif in_source:
+            peer = line.strip()
+            if peer.startswith("|->") or peer.startswith("|<-"):
+                peer = peer[3:].strip().rsplit(":", 1)[0]
+                if peer == target:
+                    return True
+    return False
+
+
+def _linked_downstream(pw_link_text, source, candidates):
+    for candidate in candidates:
+        if _link_reaches(pw_link_text, source, candidate):
+            return candidate
+    return None
+
+
+def _configured_default_sink(pw_metadata_text):
+    for line in (pw_metadata_text or "").splitlines():
+        if "key:'default.configured.audio.sink'" not in line:
+            continue
+        match = re.search(r"value:'(.*?)'\s+type:", line)
+        if not match:
+            return None
+        try:
+            value = json.loads(match.group(1))
+        except (TypeError, ValueError):
+            return None
+        name = value.get("name") if isinstance(value, dict) else None
+        return name if isinstance(name, str) and name else None
+    return None
 
 
 def _relevant_links(pw_link_text, *, cap=2500):
@@ -104,13 +185,29 @@ class PipeWireEq:
         self._runner = runner or self._run
         self._session = _find_session()
         self._orig_default = None
+        self._active_downstream = None
+        self._requested_downstream = None
+        self._configured_default_seen = None
+        self._configured_request = None
+        self._first_enable_pending = False
+        self._first_enable_downstream = None
+        self._first_enable_volume = None
+        self._cleanup_pending = False
         self._last_applied = None
         self._last_apply = None
         self._active = False
         self._owns_sink = False
         self._user_vol = None
-        self._pinned = set()
+        self._downstream_volumes = {}
         self._test_proc = None
+        self._sleep = time.sleep
+        self._monotonic = time.monotonic
+        self._retry_request = None
+        self._retry_at = 0.0
+        self._retry_delay = _RETRY_MIN_S
+        self._retry_attempts = 0
+        self._retry_service_token = None
+        self._retry_recovery = None
         # Human-facing sink name shown in the system/Steam volume OSD (reads node.name),
         # e.g. "Legion Go EQ". Used both as the label and as the sink's node.name.
         self._name = name or "Panel de Control"
@@ -122,14 +219,17 @@ class PipeWireEq:
         runtime, from the (root) backend. Returns (None, None) with no session."""
         if not self._session:
             return None, None
-        from controllers.detect import clean_env
-
         _uid, runtime, user = self._session
         env = clean_env()
         env["XDG_RUNTIME_DIR"] = runtime
         env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={runtime}/bus"
         env["LC_ALL"] = "C"  # pactl field labels ("Name:", "Active Port:") must stay English to parse
-        cmd = ["runuser", "-u", user, "--", *argv] if os.geteuid() == 0 else list(argv)
+        argv = [resolve_bin(argv[0]), *argv[1:]]
+        cmd = (
+            [resolve_bin("runuser"), "-u", user, "--", *argv]
+            if os.geteuid() == 0
+            else list(argv)
+        )
         return cmd, env
 
     def _run(self, argv, timeout=8):
@@ -182,64 +282,485 @@ class PipeWireEq:
     def _conf_path(self):
         if not self._session:
             return None
-        home = pwd.getpwuid(self._session[0]).pw_dir
+        home = os.path.realpath(pwd.getpwuid(self._session[0]).pw_dir)
         return os.path.join(home, ".config/pipewire/filter-chain.conf.d/pdc-eq.conf")
+
+    def _pending_path(self):
+        path = self._conf_path()
+        return f"{path}.first-enable-pending" if path else None
+
+    def _open_parent_dir(self, path, *, create=False):
+        if not path or not self._session or not os.path.isabs(path):
+            return None
+        try:
+            account = pwd.getpwuid(self._session[0])
+            uid, gid = account.pw_uid, account.pw_gid
+        except KeyError:
+            uid = gid = self._session[0]
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+        current_fd = None
+        try:
+            current_fd = os.open(os.sep, flags)
+            parent = os.path.dirname(os.path.normpath(path))
+            for component in parent.split(os.sep):
+                if not component:
+                    continue
+                try:
+                    next_fd = os.open(component, flags, dir_fd=current_fd)
+                except FileNotFoundError:
+                    if not create:
+                        os.close(current_fd)
+                        return None
+                    try:
+                        os.mkdir(component, 0o755, dir_fd=current_fd)
+                    except FileExistsError:
+                        pass
+                    try:
+                        os.chown(
+                            component,
+                            uid,
+                            gid,
+                            dir_fd=current_fd,
+                            follow_symlinks=False,
+                        )
+                    except OSError:
+                        pass
+                    next_fd = os.open(component, flags, dir_fd=current_fd)
+                os.close(current_fd)
+                current_fd = next_fd
+            return current_fd
+        except (OSError, ValueError):
+            if current_fd is not None:
+                try:
+                    os.close(current_fd)
+                except OSError:
+                    pass
+            return None
+
+    def _entry_exists(self, path):
+        parent_fd = self._open_parent_dir(path)
+        if parent_fd is None:
+            return False
+        try:
+            os.stat(os.path.basename(path), dir_fd=parent_fd, follow_symlinks=False)
+            return True
+        except OSError:
+            return False
+        finally:
+            os.close(parent_fd)
+
+    def _remove_entry(self, path):
+        parent_fd = self._open_parent_dir(path)
+        if parent_fd is None:
+            return False
+        name = os.path.basename(path)
+        try:
+            os.unlink(name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            return False
+        finally:
+            os.close(parent_fd)
+        return not self._entry_exists(path)
+
+    def _read_entry(self, path):
+        parent_fd = self._open_parent_dir(path)
+        if parent_fd is None:
+            return None
+        file_fd = None
+        try:
+            file_fd = os.open(
+                os.path.basename(path),
+                os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+                dir_fd=parent_fd,
+            )
+            entry = os.fstat(file_fd)
+            if (
+                not stat.S_ISREG(entry.st_mode)
+                or entry.st_uid != self._session[0]
+            ):
+                return None
+            chunks = []
+            size = 0
+            while True:
+                chunk = os.read(file_fd, 4096)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > _MAX_ENTRY_BYTES:
+                    return None
+                chunks.append(chunk)
+            return b"".join(chunks).decode("utf-8")
+        except (OSError, UnicodeError):
+            return None
+        finally:
+            if file_fd is not None:
+                os.close(file_fd)
+            os.close(parent_fd)
+
+    def _write_entry(self, path, content):
+        data = content.encode("utf-8")
+        if len(data) > _MAX_ENTRY_BYTES:
+            return False
+        parent_fd = self._open_parent_dir(path, create=True)
+        if parent_fd is None:
+            return False
+        name = os.path.basename(path)
+        temp_name = f".{name}.{os.getpid()}.{secrets.token_hex(8)}"
+        temp_fd = None
+        try:
+            account = pwd.getpwuid(self._session[0])
+            uid, gid = account.pw_uid, account.pw_gid
+        except KeyError:
+            uid = gid = self._session[0]
+        try:
+            try:
+                existing = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and (
+                not stat.S_ISREG(existing.st_mode) or existing.st_uid != uid
+            ):
+                return False
+            temp_fd = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            os.fchmod(temp_fd, 0o600)
+            while data:
+                written = os.write(temp_fd, data)
+                if written <= 0:
+                    raise OSError("short write")
+                data = data[written:]
+            try:
+                os.fchown(temp_fd, uid, gid)
+            except OSError:
+                pass
+            if os.fstat(temp_fd).st_uid != uid:
+                return False
+            os.fsync(temp_fd)
+            os.close(temp_fd)
+            temp_fd = None
+            os.replace(
+                temp_name,
+                name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.fsync(parent_fd)
+            return True
+        except (OSError, ValueError):
+            return False
+        finally:
+            if temp_fd is not None:
+                try:
+                    os.close(temp_fd)
+                except OSError:
+                    pass
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+            os.close(parent_fd)
+
+    def _persist_first_enable_pending(self):
+        path = self._pending_path()
+        if not path or not self._session:
+            return False
+        return self._write_entry(
+            path,
+            json.dumps(
+                {
+                    "sink": self._first_enable_downstream,
+                    "volume": self._first_enable_volume,
+                }
+            ),
+        )
+
+    def _first_enable_is_pending(self):
+        path = self._pending_path()
+        return self._first_enable_pending or bool(path and self._entry_exists(path))
+
+    def _pending_first_enable_volume(self, downstream):
+        path = self._pending_path()
+        if path and self._entry_exists(path):
+            try:
+                pending = json.loads(self._read_entry(path))
+            except (ValueError, TypeError):
+                pending = None
+            if (
+                isinstance(pending, dict)
+                and pending.get("sink") == downstream
+                and re.fullmatch(r"\d+%", str(pending.get("volume", "")))
+            ):
+                return pending["volume"]
+        if self._first_enable_downstream == downstream:
+            return self._first_enable_volume
+        return None
+
+    def _clear_first_enable_pending(self):
+        path = self._pending_path()
+        if path and not self._remove_entry(path):
+            return False
+        self._first_enable_pending = False
+        self._first_enable_downstream = None
+        self._first_enable_volume = None
+        return True
+
+    def _discard_first_enable_config(self, conf_path):
+        removed = not conf_path or self._remove_entry(conf_path)
+        if removed:
+            self._clear_first_enable_pending()
+        return removed
 
     # --- capability ---------------------------------------------------------------
     def is_supported(self):
         if not self._session:  # re-probe: the session may come up after _init (self-heal)
             self._session = _find_session()
-        return bool(self._session) and filter_chain_module() is not None
+        return (
+            bool(self._session)
+            and filter_chain_module() is not None
+            and self._binary_available("pw-link")
+            and self._binary_available("pw-metadata")
+        )
+
+    @staticmethod
+    def _binary_available(name):
+        return resolve_bin(name) != name or shutil.which(name) is not None
 
     # --- lifecycle ----------------------------------------------------------------
-    def _write_conf(self, gains, bass, loudness):
+    def _write_conf(self, gains, bass, loudness, downstream=None):
         path = self._conf_path()
         if not path:
             return False
-        uid = self._session[0]
-        # Create the config dirs owned by the session user, not root.
-        d = os.path.dirname(path)
-        made = []
-        while d and not os.path.exists(d):
-            made.append(d)
-            d = os.path.dirname(d)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        for created in made:
-            try:
-                os.chown(created, uid, uid)
-            except OSError:
-                pass
-        with open(path, "w") as f:
-            f.write(build_chain_config(gains, _SINK, self._label, bass, loudness, caps_plugin()))
-        try:
-            os.chown(path, uid, uid)
-        except OSError:
-            pass
-        return True
+        return self._write_entry(
+            path,
+            build_chain_config(
+                gains,
+                _SINK,
+                self._label,
+                bass,
+                loudness,
+                caps_plugin(),
+                target=downstream,
+            ),
+        )
+
+    def _service_token(self):
+        return self._runner(
+            [
+                "systemctl",
+                "--user",
+                "show",
+                _SERVICE,
+                "--property=InvocationID",
+                "--property=MainPID",
+                "--value",
+            ]
+        )
 
     def _restart(self):
+        before = self._service_token()
         self._runner(["systemctl", "--user", "restart", _SERVICE])
+        active = self._runner(["systemctl", "--user", "is-active", _SERVICE]) == "active"
+        after = self._service_token()
+        return active and bool(before) and bool(after) and after != before
+
+    def _sink_volume_pcts(self, sink):
+        values = re.findall(
+            r"(\d+)%", self._runner(["pactl", "get-sink-volume", sink]) or ""
+        )
+        return tuple(f"{value}%" for value in values) or None
 
     def _sink_volume_pct(self, sink):
-        """The sink's front volume as a 'NN%' string, or None."""
-        m = re.search(r"(\d+)%", self._runner(["pactl", "get-sink-volume", sink]) or "")
-        return f"{m.group(1)}%" if m else None
+        values = self._sink_volume_pcts(sink)
+        return values[0] if values else None
 
     def _downstream_sink(self):
+        default_sink = self._runner(["pactl", "get-default-sink"])
+        sinks = self._runner(["pactl", "list", "short", "sinks"])
+        candidates = [name for name, _state in _sink_candidates(sinks, self._label)]
+        if self._requested_downstream not in candidates:
+            self._requested_downstream = None
+        linked = None
+        configured = None
+        configured_changed = False
+        if default_sink == self._label:
+            configured = _configured_default_sink(
+                self._runner(["pw-metadata", "-n", "default"])
+            )
+            configured_changed = (
+                self._configured_default_seen is not None
+                and configured != self._configured_default_seen
+            )
+            self._configured_default_seen = configured
+            if configured in candidates and (
+                configured_changed or self._active_downstream is None
+            ):
+                self._requested_downstream = configured
+            linked = _linked_downstream(
+                self._runner(["pw-link", "-l"]),
+                f"effect_output.{_SINK}",
+                candidates,
+            )
+        elif default_sink in candidates:
+            self._requested_downstream = default_sink
         return choose_downstream(
-            self._runner(["pactl", "get-default-sink"]),
-            self._runner(["pactl", "list", "short", "sinks"]),
+            default_sink,
+            sinks,
             self._label,
+            preferred=self._active_downstream,
+            linked=linked,
+            configured=configured,
+            configured_changed=configured_changed,
+            requested=self._requested_downstream,
         )
+
+    def _set_default_confirmed(self, sink):
+        for delay in _CONFIRM_DELAYS:
+            if delay:
+                self._sleep(delay)
+            if sink == self._label:
+                value = json.dumps({"name": sink}, separators=(",", ":"))
+                self._runner(
+                    [
+                        "pw-metadata",
+                        "-n",
+                        "default",
+                        "0",
+                        "default.audio.sink",
+                        value,
+                        "Spa:String:JSON",
+                    ]
+                )
+                if self._runner(["pactl", "get-default-sink"]) == sink:
+                    return True
+                continue
+            self._runner(["pactl", "set-default-sink", sink])
+            if self._runner(["pactl", "get-default-sink"]) == sink:
+                return True
+        return False
+
+    def _target_link_confirmed(self, downstream, *, retry=False):
+        delays = _CONFIRM_DELAYS if retry else (0,)
+        for delay in delays:
+            if delay:
+                self._sleep(delay)
+            links = self._runner(["pw-link", "-l"])
+            if _link_reaches(links, f"effect_output.{_SINK}", downstream):
+                return True
+        return False
+
+    def _sink_absent_confirmed(self, sink):
+        for delay in _CONFIRM_DELAYS:
+            if delay:
+                self._sleep(delay)
+            raw = self._runner(["pactl", "list", "short", "sinks"])
+            if not raw:
+                continue
+            names = {
+                name
+                for name, _state in _sink_candidates(
+                    raw,
+                    "",
+                )
+            }
+            if names and sink not in names:
+                return True
+        return False
+
+    def _bypass_eq_default(self, downstream):
+        current = self._runner(["pactl", "get-default-sink"])
+        if not current:
+            return False
+        if current != self._label:
+            return True
+        if not downstream or not self._set_default_confirmed(downstream):
+            return False
+        volume = self._sink_volume_pct(self._label) or self._user_vol
+        self._restore_downstream_volume(downstream)
+        if volume:
+            self._runner(["pactl", "set-sink-volume", downstream, volume])
+        self._owns_sink = False
+        return True
 
     def _pin_downstream(self, downstream, balance):
         """Hold the physical sink at unity, offset per-channel for L/R balance (far side
         attenuated, near side at unity). Pin unity first so a non-stereo sink stays
         transparent when the two-value write fails, rather than a hidden attenuation."""
+        if downstream not in self._downstream_volumes:
+            self._downstream_volumes[downstream] = self._sink_volume_pcts(downstream)
         left, right = balance_channels(balance)
         self._runner(["pactl", "set-sink-volume", downstream, "100%"])
         if left != right:
             self._runner(["pactl", "set-sink-volume", downstream, f"{left}%", f"{right}%"])
+
+    def _restore_downstream_volume(self, downstream):
+        values = self._downstream_volumes.pop(downstream, None)
+        if values:
+            self._runner(["pactl", "set-sink-volume", downstream, *values])
+
+    def _retry_blocked(self, request, downstream):
+        if self._retry_request != request:
+            self._clear_retry()
+            return False
+        if self._retry_attempts >= _RETRY_MAX_ATTEMPTS:
+            current_service_token = self._service_token()
+            service_changed = (
+                bool(self._retry_service_token)
+                and bool(current_service_token)
+                and current_service_token != self._retry_service_token
+            )
+            link_recovered = (
+                self._retry_recovery == "link"
+                and self._configured_request == request
+                and self._target_link_confirmed(downstream)
+            )
+            if service_changed or link_recovered:
+                self._clear_retry()
+                return False
+            operation = {
+                "config": "config_write",
+                "default": "default_sink",
+                "link": "target_link",
+                "service": "service_restart",
+                "teardown": "teardown",
+            }.get(self._retry_recovery, "apply")
+            self._record_apply(
+                False,
+                f"{operation}_retry_exhausted",
+                downstream=downstream,
+            )
+            return True
+        remaining = self._retry_at - self._monotonic()
+        if remaining <= 0:
+            return False
+        self._record_apply(
+            False,
+            "service_restart_backoff",
+            downstream=downstream,
+            retry_in=round(remaining, 1),
+        )
+        return True
+
+    def _defer_retry(self, request, recovery):
+        self._retry_request = request
+        self._retry_attempts += 1
+        self._retry_service_token = self._service_token()
+        self._retry_recovery = recovery
+        self._retry_at = self._monotonic() + self._retry_delay
+        self._retry_delay = min(_RETRY_MAX_S, self._retry_delay * 2)
+
+    def _clear_retry(self):
+        self._retry_request = None
+        self._retry_at = 0.0
+        self._retry_delay = _RETRY_MIN_S
+        self._retry_attempts = 0
+        self._retry_service_token = None
+        self._retry_recovery = None
 
     def _record_apply(self, ok, reason=None, **details):
         if not ok:
@@ -254,10 +775,13 @@ class PipeWireEq:
         return dict(self._last_apply) if self._last_apply is not None else None
 
     def is_active(self):
+        downstream = self._downstream_sink()
         return (
             self._active
             and self.is_default()
-            and self._downstream_sink() is not None
+            and downstream is not None
+            and downstream == self._active_downstream
+            and self._target_link_confirmed(downstream)
         )
 
     def ensure_sink(self, gains, bass=0, loudness=False, balance=0):
@@ -265,8 +789,8 @@ class PipeWireEq:
         and keep the physical sink it feeds pinned at unity (100%), offset for balance.
         Steam's volume controls the default sink — i.e. ours — so the downstream must stay
         transparent, or its level becomes a hidden second attenuation the user can't reach.
-        Re-pinning every apply is self-healing across resume/reload (no volume snapshot to
-        drift or corrupt).
+        Re-pinning every apply is self-healing across resume/reload; captured physical levels
+        are restored on route handoff and teardown.
 
         Diff-gated: an unchanged (gains, bass, loudness) skips the conf rewrite + ~1s restart
         (just re-asserts default + the pin). Balance is outside the gate — it only moves the
@@ -279,48 +803,145 @@ class PipeWireEq:
             self._record_apply(False, "downstream_missing")
             return False
         applied = (list(gains), bass, loudness)
-        unchanged = self._orig_default is not None and applied == self._last_applied
+        request = (tuple(gains), bass, bool(loudness), downstream)
+        if self._retry_blocked(request, downstream):
+            return False
+        unchanged = (
+            self._orig_default is not None
+            and applied == self._last_applied
+            and downstream == self._active_downstream
+            and self._target_link_confirmed(downstream)
+        )
         # First-ever enable (no conf yet) vs a boot re-assert (conf exists) — check before
         # _write_conf creates it.
-        conf_path = self._conf_path()
-        first_ever = not (conf_path and os.path.exists(conf_path))
-        if not unchanged and not self._write_conf(gains, bass, loudness):
-            self._record_apply(False, "config_write_failed", downstream=downstream)
-            return False
         first = self._orig_default is None
+        conf_path = self._conf_path()
+        first_ever = not (conf_path and self._entry_exists(conf_path))
+        if first and first_ever:
+            self._first_enable_pending = True
+            self._first_enable_downstream = downstream
+            self._first_enable_volume = self._sink_volume_pct(downstream)
+            if not self._persist_first_enable_pending():
+                self._defer_retry(request, "config")
+                self._record_apply(
+                    False,
+                    "pending_marker_write_failed",
+                    downstream=downstream,
+                )
+                return False
+        configured_same = self._configured_request == request and not first_ever
+        if not unchanged and not configured_same:
+            try:
+                wrote_conf = self._write_conf(gains, bass, loudness, downstream)
+            except (OSError, ValueError) as error:
+                wrote_conf = False
+                write_error = type(error).__name__
+            else:
+                write_error = None
+            if not wrote_conf:
+                if first and first_ever:
+                    self._discard_first_enable_config(conf_path)
+                bypass_confirmed = self._bypass_eq_default(downstream)
+                self._defer_retry(request, "config")
+                self._record_apply(
+                    False,
+                    "config_write_failed",
+                    downstream=downstream,
+                    bypass_confirmed=bypass_confirmed,
+                    **({"error": write_error} if write_error else {}),
+                )
+                return False
         if not unchanged:
-            self._restart()
-        self._runner(["pactl", "set-default-sink", self._label])
-        if not self.is_default():
+            if not configured_same:
+                current_default = self._runner(["pactl", "get-default-sink"])
+                if current_default not in (self._label, downstream):
+                    if first and first_ever:
+                        self._discard_first_enable_config(conf_path)
+                    self._record_apply(
+                        False,
+                        "downstream_changed",
+                        downstream=downstream,
+                        current=current_default or None,
+                    )
+                    return False
+                if not self._restart():
+                    self._defer_retry(request, "service")
+                    bypass_confirmed = self._bypass_eq_default(downstream)
+                    self._record_apply(
+                        False,
+                        "service_restart_failed",
+                        downstream=downstream,
+                        bypass_confirmed=bypass_confirmed,
+                    )
+                    return False
+                self._configured_request = request
+            if not self._target_link_confirmed(downstream, retry=True):
+                self._defer_retry(request, "link")
+                bypass_confirmed = self._bypass_eq_default(downstream)
+                self._record_apply(
+                    False,
+                    "target_link_not_confirmed",
+                    downstream=downstream,
+                    bypass_confirmed=bypass_confirmed,
+                )
+                return False
+        if not self._set_default_confirmed(self._label):
+            rollback_confirmed = None
             if first and first_ever:
-                try:
-                    os.remove(conf_path)
-                except OSError:
-                    pass
+                self._remove_entry(conf_path)
                 self._restart()
-                self._runner(["pactl", "set-default-sink", downstream])
+                rollback_confirmed = self._sink_absent_confirmed(self._label)
+                self._cleanup_pending = not rollback_confirmed
+                self._set_default_confirmed(downstream)
+                self._configured_request = None
+            bypass_confirmed = self._bypass_eq_default(downstream)
+            self._defer_retry(request, "default")
             self._record_apply(
                 False,
                 "default_sink_not_confirmed",
                 downstream=downstream,
+                bypass_confirmed=bypass_confirmed,
+                **(
+                    {"rollback_confirmed": rollback_confirmed}
+                    if rollback_confirmed is not None
+                    else {}
+                ),
             )
             return False
         if first:
-            self._orig_default = downstream
-            if first_ever:
+            if self._first_enable_is_pending():
                 # Carry the downstream's level onto our sink so enabling doesn't jump
                 # loudness. Skip on a boot re-assert: the sink already holds the user's
                 # level (WirePlumber restores it), and the downstream is always unity.
-                vol = self._sink_volume_pct(downstream)
+                vol = self._pending_first_enable_volume(
+                    downstream
+                ) or self._sink_volume_pct(downstream)
                 if vol:
                     self._user_vol = vol
                     self._runner(["pactl", "set-sink-volume", self._label, vol])
+            if not self._clear_first_enable_pending():
+                bypass_confirmed = self._bypass_eq_default(downstream)
+                self._defer_retry(request, "config")
+                self._record_apply(
+                    False,
+                    "pending_marker_cleanup_failed",
+                    downstream=downstream,
+                    bypass_confirmed=bypass_confirmed,
+                )
+                return False
+            self._orig_default = downstream
         self._owns_sink = True
+        previous_downstream = self._active_downstream
+        if previous_downstream and previous_downstream != downstream:
+            self._restore_downstream_volume(previous_downstream)
         self._pin_downstream(downstream, balance)
-        if balance:
-            self._pinned.add(downstream)
         self._last_applied = applied
+        self._active_downstream = downstream
+        if self._requested_downstream == downstream:
+            self._requested_downstream = None
         self._active = True
+        self._cleanup_pending = False
+        self._clear_retry()
         self._record_apply(True, downstream=downstream, unchanged=unchanged)
         return True
 
@@ -350,7 +971,7 @@ class PipeWireEq:
             "session": None,
         }
         if self._session:
-            info["session"] = {"uid": self._session[0], "user": self._session[2]}
+            info["session"] = {"uid": self._session[0]}
         try:
             downstream = self._downstream_sink()
             info.update({
@@ -374,10 +995,7 @@ class PipeWireEq:
         path = self._conf_path()
         info["conf_path"] = path
         info["last_apply"] = self.apply_diagnostics()
-        try:
-            info["conf"] = open(path).read() if path and os.path.exists(path) else None
-        except OSError:
-            info["conf"] = None
+        info["conf"] = self._read_entry(path) if path else None
         return info
 
     def teardown(self):
@@ -387,36 +1005,89 @@ class PipeWireEq:
         filters) on every unload."""
         self.stop_test()
         path = self._conf_path()
-        had_conf = bool(path and os.path.exists(path))
-        if not had_conf and self._orig_default is None:
+        had_conf = bool(path and self._entry_exists(path))
+        current_default = self._runner(["pactl", "get-default-sink"])
+        sinks = self._runner(["pactl", "list", "short", "sinks"])
+        all_names = {name for name, _state in _sink_candidates(sinks, "")}
+        eq_present = self._label in all_names
+        names = all_names - {self._label}
+        runtime_pending = (
+            had_conf
+            or self._orig_default is not None
+            or self._cleanup_pending
+            or current_default == self._label
+            or eq_present
+        )
+        if not runtime_pending:
+            self._clear_first_enable_pending()
             self._active = False
             self._owns_sink = False
-            return
-        transfer_volume = self._owns_sink and self.is_default()
-        downstream = self._orig_default or self._downstream_sink()
+            self._record_apply(True, operation="teardown", unchanged=True)
+            return True
+        self._cleanup_pending = True
+        retry_request = ("teardown",)
+        if self._retry_blocked(retry_request, self._active_downstream):
+            return False
+        transfer_volume = current_default == self._label
+        downstream = None
+        if transfer_volume:
+            if self._active_downstream in names:
+                downstream = self._active_downstream
+            elif self._orig_default in names:
+                downstream = self._orig_default
+            else:
+                downstream = self._downstream_sink()
         our_vol = (
             self._sink_volume_pct(self._label) or self._user_vol
             if transfer_volume
             else None
         )
-        pinned = self._pinned
         if had_conf:
-            try:
-                os.remove(path)
-            except OSError:
-                pass
-        self._restart()
-        for sink in pinned:  # re-centre any sink a route change left panned
-            self._runner(["pactl", "set-sink-volume", sink, "100%"])
-        if downstream:
-            if transfer_volume:
-                self._runner(
-                    ["pactl", "set-sink-volume", downstream, our_vol or "100%"]
+            self._remove_entry(path)
+        restarted = self._restart()
+        sink_absent = restarted and self._sink_absent_confirmed(self._label)
+        if not restarted or not sink_absent:
+            bypass_confirmed = self._bypass_eq_default(downstream)
+            for sink in list(self._downstream_volumes):
+                self._restore_downstream_volume(sink)
+            self._defer_retry(retry_request, "teardown")
+            self._record_apply(
+                False,
+                "teardown_restart_failed" if not restarted else "teardown_sink_still_present",
+                downstream=downstream,
+                bypass_confirmed=bypass_confirmed,
+            )
+            return False
+        for sink in list(self._downstream_volumes):
+            self._restore_downstream_volume(sink)
+        if transfer_volume and downstream:
+            self._runner(
+                ["pactl", "set-sink-volume", downstream, our_vol or "100%"]
+            )
+            if not self._set_default_confirmed(downstream):
+                self._defer_retry(retry_request, "teardown")
+                self._record_apply(
+                    False,
+                    "teardown_default_not_confirmed",
+                    downstream=downstream,
                 )
-            self._runner(["pactl", "set-default-sink", downstream])
+                return False
+        elif transfer_volume:
+            self._defer_retry(retry_request, "teardown")
+            self._record_apply(False, "teardown_downstream_missing")
+            return False
         self._orig_default = None
+        self._active_downstream = None
+        self._requested_downstream = None
+        self._configured_default_seen = None
+        self._configured_request = None
+        self._clear_first_enable_pending()
+        self._cleanup_pending = False
         self._last_applied = None
         self._user_vol = None
-        self._pinned = set()
+        self._downstream_volumes = {}
+        self._clear_retry()
         self._active = False
         self._owns_sink = False
+        self._record_apply(True, operation="teardown")
+        return True

--- a/py_modules/audio/route.py
+++ b/py_modules/audio/route.py
@@ -2,7 +2,16 @@
 independent curve per route; internal speakers get the correction, headphones/external
 default to no speaker correction. Pure classifier + an injectable reader for testing."""
 
-_HEADPHONE_HINTS = ("headphone", "headset", "bluetooth", "a2dp", "usb", "hdmi", "displayport")
+_HEADPHONE_HINTS = (
+    "headphone",
+    "headset",
+    "bluetooth",
+    "bluez_output",
+    "a2dp",
+    "usb",
+    "hdmi",
+    "displayport",
+)
 
 
 def classify_route(name):
@@ -13,12 +22,21 @@ def classify_route(name):
 
 
 def route_of_sink(pactl_list_output, sink_name):
-    if sink_name:
-        in_block = False
-        for line in (pactl_list_output or "").splitlines():
-            s = line.strip()
-            if s.startswith("Name:"):
-                in_block = s.split("Name:", 1)[1].strip() == sink_name
-            elif in_block and s.startswith("Active Port:"):
-                return classify_route(s)
+    if not sink_name:
+        return "speaker"
+    in_block = False
+    description = ""
+    active_port = ""
+    for line in (pactl_list_output or "").splitlines():
+        s = line.strip()
+        if s.startswith("Name:"):
+            if in_block:
+                break
+            in_block = s.split("Name:", 1)[1].strip() == sink_name
+        elif in_block and s.startswith("Description:"):
+            description = s.split("Description:", 1)[1].strip()
+        elif in_block and s.startswith("Active Port:"):
+            active_port = s.split("Active Port:", 1)[1].strip()
+    if in_block:
+        return classify_route(f"{sink_name} {description} {active_port}")
     return "speaker"

--- a/py_modules/report/collector.py
+++ b/py_modules/report/collector.py
@@ -27,10 +27,13 @@ SCHEMA = 2
 _MAX_TEXT = 4000  # user free-text cap (defensive; the UI also limits it)
 
 # Scrub the VALUE of any dict key that looks like a hardware identifier.
-_SCRUB_KEY = re.compile(r"serial|uuid|\bmac\b|mac_?addr|hostname|host_name", re.I)
+_SCRUB_KEY = re.compile(
+    r"serial|uuid|\bmac\b|mac_?addr|hostname|host_name|^(?:user|username)$",
+    re.I,
+)
 _HOME_PATH = re.compile(r"/home/[^/\s:\"']+")
 # Identifiers that can appear inside free text (log lines, dmesg/journal output).
-_MAC = re.compile(r"\b(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}\b")
+_MAC = re.compile(r"\b(?:[0-9a-fA-F]{2}[:_-]){5}[0-9a-fA-F]{2}\b")
 _UUID = re.compile(
     r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
 )

--- a/src/api.ts
+++ b/src/api.ts
@@ -814,24 +814,24 @@ export const getAudioState = callable<[], AudioState>("get_audio_state");
 export const setSpeakerGuard = callable<[enabled: boolean], AudioState>("set_speaker_guard");
 export const setAudioEnabled = callable<[enabled: boolean], AudioState>("set_audio_enabled");
 export const applyAudioPreset =
-  callable<[preset: string, scope: Scope, appid: string | null], AudioState>("apply_audio_preset");
+  callable<[preset: string, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("apply_audio_preset");
 export const setAudioBand =
-  callable<[index: number, gain: number, scope: Scope, appid: string | null], AudioState>("set_audio_band");
+  callable<[index: number, gain: number, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("set_audio_band");
 export const setAudioBands =
-  callable<[gains: number[], scope: Scope, appid: string | null], AudioState>("set_audio_bands");
+  callable<[gains: number[], scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("set_audio_bands");
 export const setAudioFollowGlobal =
   callable<[follow: boolean, appid: string | null], AudioState>("set_audio_follow_global");
 export const resetAudio =
-  callable<[scope: Scope, appid: string | null], AudioState>("reset_audio");
+  callable<[scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("reset_audio");
 export const setAudioCurve =
-  callable<[gains: number[], bass: number, scope: Scope, appid: string | null], AudioState>("set_audio_curve");
+  callable<[gains: number[], bass: number, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("set_audio_curve");
 export const setAudioLoudness =
-  callable<[on: boolean, scope: Scope, appid: string | null], AudioState>("set_audio_loudness");
+  callable<[on: boolean, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("set_audio_loudness");
 export const setAudioBalance =
-  callable<[value: number, scope: Scope, appid: string | null], AudioState>("set_audio_balance");
+  callable<[value: number, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("set_audio_balance");
 export const setAudioTest =
   callable<[playing: boolean, sample: string], AudioState>("set_audio_test");
 export const saveAudioProfile = callable<[name: string], AudioState>("save_audio_profile");
 export const applyAudioProfile =
-  callable<[name: string, scope: Scope, appid: string | null], AudioState>("apply_audio_profile");
+  callable<[name: string, scope: Scope, appid: string | null, expectedRoute: AudioState["route"] | null], AudioState>("apply_audio_profile");
 export const deleteAudioProfile = callable<[name: string], AudioState>("delete_audio_profile");

--- a/src/audio/useEq.test.tsx
+++ b/src/audio/useEq.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AudioState } from "../api";
+
+const mocks = vi.hoisted(() => ({
+  getAudioState: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  getAudioState: mocks.getAudioState,
+  applyAudioPreset: vi.fn(),
+  applyAudioProfile: vi.fn(),
+  deleteAudioProfile: vi.fn(),
+  resetAudio: vi.fn(),
+  saveAudioProfile: vi.fn(),
+  setAudioBalance: vi.fn(),
+  setAudioBands: vi.fn(),
+  setAudioCurve: vi.fn(),
+  setAudioEnabled: vi.fn(),
+  setAudioFollowGlobal: vi.fn(),
+  setAudioLoudness: vi.fn(),
+  setAudioTest: vi.fn(),
+  setSpeakerGuard: vi.fn(),
+}));
+
+vi.mock("../tdp/useRunningGame", () => ({ useRunningGame: () => null }));
+vi.mock("../useScopeSync", () => ({
+  useScopeSync: () => ({ scope: "global", onScope: vi.fn() }),
+}));
+
+import { useEq } from "./useEq";
+
+const audioState = (route: AudioState["route"]): AudioState => ({
+  supported: true,
+  enabled: true,
+  active: true,
+  last_apply: { ok: true },
+  route,
+  appid: null,
+  follows_global: true,
+  has_game_profile: false,
+  preset: "flat",
+  gains: Array(10).fill(0),
+  bass: 0,
+  loudness: false,
+  balance: 0,
+  test_playing: false,
+  test_sample: null,
+  test_samples: [],
+  presets: [],
+  profiles: [],
+  device_name: "Test",
+  guard: true,
+  safe_limits: { bands: Array(10).fill(12), bass: 100 },
+});
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useEq route refresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.getAudioState
+      .mockResolvedValueOnce(audioState("speaker"))
+      .mockResolvedValue(audioState("headphone"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("refreshes an enabled EQ while the panel remains open", async () => {
+    const { result } = renderHook(() => useEq());
+    await settle();
+    expect(result.current.state?.route).toBe("speaker");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+
+    expect(result.current.state?.route).toBe("headphone");
+    expect(mocks.getAudioState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/audio/useEq.ts
+++ b/src/audio/useEq.ts
@@ -21,6 +21,8 @@ import { useRunningGame } from "../tdp/useRunningGame";
 import { useScopeSync } from "../useScopeSync";
 import { applyTone, bassToEnhancer, ToneRegion } from "./logic";
 
+const ROUTE_REFRESH_MS = 4_000;
+
 export interface EqControl {
   state: AudioState | null;
   scope: Scope;
@@ -86,6 +88,7 @@ export function useEq(): EqControl {
   }, []);
 
   const refresh = useCallback(() => {
+    if (Object.keys(pendings.current).length > 0) return;
     getAudioState().then(setState).catch(() => {});
   }, []);
 
@@ -94,6 +97,12 @@ export function useEq(): EqControl {
     flush();
     refresh();
   }, [appid, refresh, flush]);
+
+  useEffect(() => {
+    if (!state?.enabled) return;
+    const timer = setInterval(refresh, ROUTE_REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [state?.enabled, refresh]);
 
   useEffect(() => () => {
     flush();
@@ -120,12 +129,13 @@ export function useEq(): EqControl {
   }, []);
 
   const onPreset = useCallback((id: string) => {
-    applyAudioPreset(id, wScope, wTarget).then(setState).catch(() => {});
+    applyAudioPreset(id, wScope, wTarget, stateRef.current?.route ?? null).then(setState).catch(() => {});
   }, [wScope, wTarget]);
 
   const onBands = useCallback((gains: number[]) => {
+    const route = stateRef.current?.route ?? null;
     setState((cur) => (cur ? { ...cur, gains, preset: "custom" } : cur)); // optimistic
-    schedule("curve", () => { setAudioBands(gains, wScope, wTarget).then(setState).catch(() => {}); });
+    schedule("curve", () => { setAudioBands(gains, wScope, wTarget, route).then(setState).catch(() => {}); });
   }, [wScope, wTarget, schedule]);
 
   // A tone slider sets one region's level. Graves also engages the bass enhancer. Reads the
@@ -136,17 +146,18 @@ export function useEq(): EqControl {
     const gains = applyTone(cur.gains, region, level);
     const bass = region === "graves" ? bassToEnhancer(level) : cur.bass;
     setState({ ...cur, gains, bass, preset: "custom" });
-    schedule("curve", () => { setAudioCurve(gains, bass, wScope, wTarget).then(setState).catch(() => {}); });
+    schedule("curve", () => { setAudioCurve(gains, bass, wScope, wTarget, cur.route).then(setState).catch(() => {}); });
   }, [wScope, wTarget, schedule]);
 
   const onLoudness = useCallback((on: boolean) => {
     setState((cur) => (cur ? { ...cur, loudness: on } : cur)); // optimistic
-    setAudioLoudness(on, wScope, wTarget).then(setState).catch(() => {});
+    setAudioLoudness(on, wScope, wTarget, stateRef.current?.route ?? null).then(setState).catch(() => {});
   }, [wScope, wTarget]);
 
   const onBalance = useCallback((value: number) => {
+    const route = stateRef.current?.route ?? null;
     setState((cur) => (cur ? { ...cur, balance: value } : cur)); // optimistic
-    schedule("balance", () => { setAudioBalance(value, wScope, wTarget).then(setState).catch(() => {}); });
+    schedule("balance", () => { setAudioBalance(value, wScope, wTarget, route).then(setState).catch(() => {}); });
   }, [wScope, wTarget, schedule]);
 
   const onGuard = useCallback((on: boolean) => {
@@ -156,7 +167,7 @@ export function useEq(): EqControl {
 
   const onReset = useCallback(() => {
     cancel();
-    resetAudio(wScope, wTarget).then(setState).catch(() => {});
+    resetAudio(wScope, wTarget, stateRef.current?.route ?? null).then(setState).catch(() => {});
   }, [wScope, wTarget, cancel]);
 
   const onTest = useCallback((sample: string) => {
@@ -171,7 +182,7 @@ export function useEq(): EqControl {
     saveAudioProfile(name).then(setState).catch(() => {});
   }, []);
   const onApplyProfile = useCallback((name: string) => {
-    applyAudioProfile(name, wScope, wTarget).then(setState).catch(() => {});
+    applyAudioProfile(name, wScope, wTarget, stateRef.current?.route ?? null).then(setState).catch(() => {});
   }, [wScope, wTarget]);
   const onDeleteProfile = useCallback((name: string) => {
     deleteAudioProfile(name).then(setState).catch(() => {});

--- a/src/sections/SonidoSection.tsx
+++ b/src/sections/SonidoSection.tsx
@@ -52,11 +52,23 @@ export const SonidoSection: FC = () => {
 
   if (!state.supported) {
     return (
-      <PanelSectionRow>
-        <div style={{ fontSize: theme.font.caption, color: theme.color.textMuted }}>
-          {t("audio.unsupported")}
-        </div>
-      </PanelSectionRow>
+      <div style={{ display: "flex", flexDirection: "column", gap: theme.space.section }}>
+        {state.enabled && (
+          <PanelSectionRow>
+            <ToggleField
+              label={t("audio.enable")}
+              description={t("audio.enable.desc")}
+              checked
+              onChange={onEnable}
+            />
+          </PanelSectionRow>
+        )}
+        <PanelSectionRow>
+          <div style={{ fontSize: theme.font.caption, color: theme.color.textMuted }}>
+            {t("audio.unsupported")}
+          </div>
+        </PanelSectionRow>
+      </div>
     );
   }
 

--- a/tests/test_audio_filter_chain.py
+++ b/tests/test_audio_filter_chain.py
@@ -20,6 +20,26 @@ def test_sink_name_and_class():
     assert "node.passive = true" in cfg
 
 
+def test_playback_stream_targets_the_selected_physical_sink():
+    cfg = build_chain_config(
+        gains=[0.0] * 10,
+        sink_name="pdc_eq",
+        target="bluez_output.headset",
+    )
+
+    assert 'target.object = "bluez_output.headset"' in cfg
+
+
+def test_playback_target_is_escaped_as_a_pipewire_string():
+    cfg = build_chain_config(
+        gains=[0.0] * 10,
+        sink_name="pdc_eq",
+        target='sink."quoted"\\path',
+    )
+
+    assert 'target.object = "sink.\\"quoted\\"\\\\path"' in cfg
+
+
 def test_gains_are_embedded():
     gains = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     cfg = build_chain_config(gains=gains, sink_name="pdc_eq")

--- a/tests/test_audio_pipewire.py
+++ b/tests/test_audio_pipewire.py
@@ -248,6 +248,8 @@ class _FakeRunner:
         else:
             self._volumes = {}
             self._vol = downstream_vol
+        self._volume_channels = {}
+        self._mutes = {}
         self._default = "alsa_speaker"
         self._link_target = "alsa_speaker"
         self._configured_target = None
@@ -264,6 +266,16 @@ class _FakeRunner:
             return self._default
         if argv[:2] == ["pactl", "set-default-sink"]:
             self._default = argv[2]
+            self._configured_default = argv[2]
+            return ""
+        if argv[:2] == ["pactl", "set-sink-volume"]:
+            values = [value for value in argv[3:] if value.endswith("%")]
+            if values:
+                self._volumes[argv[2]] = values[0]
+                self._volume_channels[argv[2]] = tuple(values)
+            return ""
+        if argv[:2] == ["pactl", "set-sink-mute"]:
+            self._mutes[argv[2]] = argv[3] in ("1", "yes", "true")
             return ""
         if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
             self._service_generation += 1
@@ -319,8 +331,17 @@ class _FakeRunner:
         if "list" in s and "sinks" in s:
             return self._sinks
         if "get-sink-volume" in s:
-            volume = self._volumes.get(argv[-1], self._vol)
+            sink = argv[-1]
+            values = self._volume_channels.get(sink)
+            if values:
+                return "Volume: " + " ".join(
+                    f"channel-{index}: 26214 / {value} / ..."
+                    for index, value in enumerate(values)
+                )
+            volume = self._volumes.get(sink, self._vol)
             return f"Volume: front-left: 26214 / {volume} / ..."
+        if "get-sink-mute" in s:
+            return "Mute: yes" if self._mutes.get(argv[-1], False) else "Mute: no"
         return ""
 
     def volume_sets(self, sink):
@@ -337,6 +358,7 @@ def _make_eq(tmp_path, fake, conf_exists):
     eq._conf_path = lambda: str(conf)
     fake._conf_path = str(conf)
     eq.is_supported = lambda: True
+    eq._sleep = lambda _delay: None
     def write_conf(*args, **kwargs):
         fake._configured_target = kwargs.get("downstream") or args[-1]
         conf.write_text("x")
@@ -350,8 +372,375 @@ def test_ensure_sink_first_enable_carries_downstream_volume(tmp_path):
     fake = _FakeRunner(downstream_vol="40%")
     eq = _make_eq(tmp_path, fake, conf_exists=False)
     assert eq.ensure_sink([0] * 10) is True
-    assert fake.volume_sets("X EQ") == [["pactl", "set-sink-volume", "X EQ", "40%"]]
+    assert fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
+        ["pactl", "set-sink-volume", "X EQ", "40%"],
+    ]
     assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] in fake.calls
+
+
+def test_first_enable_stages_unity_before_switching_the_default(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+
+    assert eq.ensure_sink([0] * 10) is True
+
+    stage = fake.calls.index(["pactl", "set-sink-volume", "X EQ", "100%"])
+    switch = fake.calls.index(["pactl", "set-default-sink", "X EQ"])
+    commit = fake.calls.index(["pactl", "set-sink-volume", "X EQ", "40%"])
+    pin = fake.calls.index(["pactl", "set-sink-volume", "alsa_speaker", "100%"])
+    assert stage < switch < commit < pin
+
+
+def test_first_enable_without_volume_readback_stays_on_the_physical_sink(tmp_path):
+    fake = _FakeRunner(downstream_vol="")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert fake.volume_sets("alsa_speaker") == []
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "downstream_volume_missing",
+        "downstream": "alsa_speaker",
+    }
+
+
+def test_first_enable_requires_unity_stage_readback(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+
+    def ignore_unity_stage(argv, timeout=8):
+        if argv == ["pactl", "set-sink-volume", "X EQ", "100%"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_unity_stage
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert fake.volume_sets("alsa_speaker") == [
+        ["pactl", "set-sink-volume", "alsa_speaker", "40%"],
+    ]
+    assert eq.apply_diagnostics()["reason"] == "eq_volume_stage_not_confirmed"
+
+
+def test_first_enable_requires_eq_volume_commit_readback(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+
+    def ignore_eq_commit(argv, timeout=8):
+        if argv == ["pactl", "set-sink-volume", "X EQ", "40%"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_eq_commit
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert eq.apply_diagnostics()["reason"] == "eq_volume_commit_not_confirmed"
+
+
+def test_first_enable_requires_physical_pin_readback(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+
+    def ignore_physical_pin(argv, timeout=8):
+        if argv == ["pactl", "set-sink-volume", "alsa_speaker", "100%"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_physical_pin
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert eq.apply_diagnostics()["reason"] == "downstream_volume_pin_not_confirmed"
+
+
+def test_default_reversion_after_physical_pin_rolls_back_without_publishing(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    run = eq._runner
+
+    def revert_after_pin(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["pactl", "set-sink-volume", "alsa_speaker", "100%"]:
+            fake._default = "alsa_speaker"
+            fake._configured_default = "alsa_speaker"
+        return result
+
+    eq._runner = revert_after_pin
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert eq.is_active() is False
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "post_pin_route_not_confirmed",
+        "downstream": "alsa_speaker",
+        "current": "alsa_speaker",
+        "rollback_confirmed": True,
+    }
+
+
+def test_mute_ownership_moves_to_eq_and_back_to_the_physical_sink(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    fake._mutes["alsa_speaker"] = True
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake._mutes["X EQ"] is True
+    assert fake._mutes["alsa_speaker"] is False
+
+    fake._mutes["X EQ"] = False
+    assert eq.teardown() is True
+    assert fake._mutes["alsa_speaker"] is False
+
+
+def test_mute_selected_while_eq_is_active_survives_teardown(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._mutes["X EQ"] = True
+
+    assert eq.teardown() is True
+    assert fake._mutes["alsa_speaker"] is True
+
+
+def test_volume_selected_while_eq_is_active_survives_teardown(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake(["pactl", "set-sink-volume", "X EQ", "55%"])
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "55%"
+
+
+def test_hotplug_during_default_confirmation_aborts_before_volume_commit(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    set_default = eq._set_default_confirmed
+
+    def confirm_then_hotplug(sink, expected_downstream=None):
+        confirmed = set_default(sink, expected_downstream)
+        if sink == "X EQ":
+            fake._default = "X EQ"
+            fake._link_target = "bluez_output.headset"
+            fake._sinks = (
+                "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+                "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+            )
+        return confirmed
+
+    eq._set_default_confirmed = confirm_then_hotplug
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "bluez_output.headset"
+    assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] not in fake.calls
+    assert ["pactl", "set-sink-volume", "bluez_output.headset", "100%"] not in fake.calls
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "downstream_changed_during_default",
+            "downstream": "alsa_speaker",
+            "current": "bluez_output.headset",
+            "bypass_confirmed": True,
+            "rollback_confirmed": False,
+        }
+    assert eq._route_state()["pending_restores"][0]["sink"] == "alsa_speaker"
+
+
+def test_pactl_handoff_restores_physical_configured_default_on_teardown(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    fake._configured_default = "alsa_speaker"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+    transient = {"pending": False}
+
+    def model_configured_default(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv[:5] == [
+            "pw-metadata",
+            "-n",
+            "default",
+            "0",
+            "default.audio.sink",
+        ]:
+            transient["pending"] = True
+        elif argv == ["pactl", "get-default-sink"] and transient["pending"]:
+            transient["pending"] = False
+            fake._default = "alsa_speaker"
+        elif argv[:2] == ["pactl", "set-default-sink"]:
+            fake._configured_default = argv[2]
+        return result
+
+    eq._runner = model_configured_default
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake._configured_default == "X EQ"
+    assert eq.teardown() is True
+    assert fake._default == "alsa_speaker"
+    assert fake._configured_default == "alsa_speaker"
+
+
+def test_pactl_fallback_handoff_restores_the_latest_physical_intent(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    fake._configured_default = "alsa_speaker"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+    transient = {"pending": False}
+
+    def model_configured_default(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv[:5] == [
+            "pw-metadata",
+            "-n",
+            "default",
+            "0",
+            "default.audio.sink",
+        ]:
+            transient["pending"] = True
+        elif argv == ["pactl", "get-default-sink"] and transient["pending"]:
+            transient["pending"] = False
+            fake._default = "alsa_speaker"
+        elif argv[:2] == ["pactl", "set-default-sink"]:
+            fake._configured_default = argv[2]
+        return result
+
+    eq._runner = model_configured_default
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq._active_downstream == "bluez_output.headset"
+    assert fake._configured_default == "X EQ"
+
+    assert eq.teardown() is True
+    assert fake._default == "bluez_output.headset"
+    assert fake._configured_default == "bluez_output.headset"
+
+
+def test_empty_default_readback_aborts_before_physical_volume_pin(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+    probing = {"active": False}
+
+    def lose_default_readback(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["pactl", "set-default-sink", "X EQ"]:
+            probing["active"] = True
+        if argv == ["pactl", "get-default-sink"] and probing["active"]:
+            return ""
+        return result
+
+    eq._runner = lose_default_readback
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake.calls.count(["pactl", "set-default-sink", "X EQ"]) == 1
+    assert fake.volume_sets("alsa_speaker") == []
+
+
+def test_route_change_during_default_confirmation_is_not_overridden(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    fake._configured_default = "alsa_speaker"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+    probing = {"reads": 0}
+
+    def select_headset_during_probe(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["pactl", "get-default-sink"] and fake._default == "X EQ":
+            probing["reads"] += 1
+            if probing["reads"] == 2:
+                fake._default = "bluez_output.headset"
+                fake._configured_default = "bluez_output.headset"
+                fake._link_target = "bluez_output.headset"
+                fake._sinks = (
+                    "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+                    "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+                )
+        return result
+
+    eq._runner = select_headset_during_probe
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "bluez_output.headset"
+    assert fake.calls.count(["pactl", "set-default-sink", "X EQ"]) == 1
+    assert fake.volume_sets("alsa_speaker") == []
+    assert fake.volume_sets("bluez_output.headset") == []
+
+
+def test_first_enable_rolls_back_when_all_eq_default_writes_are_transient(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+    transient = {"pending": False}
+
+    def revert_eq_default(argv, timeout=8):
+        result = run(argv, timeout)
+        if (
+            argv[:5]
+            == ["pw-metadata", "-n", "default", "0", "default.audio.sink"]
+            or argv == ["pactl", "set-default-sink", "X EQ"]
+        ):
+            transient["pending"] = True
+        elif argv == ["pactl", "get-default-sink"] and transient["pending"]:
+            transient["pending"] = False
+            fake._default = "alsa_speaker"
+        return result
+
+    eq._runner = revert_eq_default
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] not in fake.calls
+    assert Path(eq._conf_path()).exists()
+    assert eq._route_state()["phase"] == "prepared"
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "default_sink_not_confirmed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+        "current": "alsa_speaker",
+    }
 
 
 def test_first_enable_creates_a_missing_pipewire_config_directory(tmp_path):
@@ -364,7 +753,15 @@ def test_first_enable_creates_a_missing_pipewire_config_directory(tmp_path):
 
     assert eq.ensure_sink([0] * 10) is True
     assert conf.exists()
-    assert not Path(f"{conf}.first-enable-pending").exists()
+    assert json.loads(Path(f"{conf}.first-enable-pending").read_text()) == {
+        "sink": "alsa_speaker",
+        "volume": "40%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": False,
+        "pending_restores": [],
+    }
 
 
 def test_volume_marker_refuses_to_follow_a_symlink(tmp_path):
@@ -376,6 +773,8 @@ def test_volume_marker_refuses_to_follow_a_symlink(tmp_path):
     marker.symlink_to(victim)
     eq._first_enable_downstream = "alsa_speaker"
     eq._first_enable_volume = "40%"
+    eq._first_enable_volumes = ("40%",)
+    eq._first_enable_mute = False
 
     assert eq._persist_first_enable_pending() is False
     assert victim.read_text() == "unchanged"
@@ -472,6 +871,8 @@ def test_config_and_volume_marker_are_private_to_the_session_user(tmp_path):
     eq = _make_eq(tmp_path, fake, conf_exists=False)
     eq._first_enable_downstream = "alsa_speaker"
     eq._first_enable_volume = "40%"
+    eq._first_enable_volumes = ("40%",)
+    eq._first_enable_mute = False
 
     assert eq._persist_first_enable_pending() is True
     assert stat.S_IMODE(os.stat(eq._pending_path()).st_mode) == 0o600
@@ -524,12 +925,30 @@ def test_trusted_home_alias_is_resolved_before_secure_directory_walk(
     assert Path(eq._conf_path()).exists()
 
 
-def test_ensure_sink_boot_reassert_preserves_user_volume(tmp_path):
+def test_boot_activation_from_physical_default_preserves_user_volume(tmp_path):
     fake = _FakeRunner(downstream_vol="100%")
     eq = _make_eq(tmp_path, fake, conf_exists=True)
     assert eq.ensure_sink([0] * 10) is True
-    assert fake.volume_sets("X EQ") == []
+    assert fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
+    ]
     assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] in fake.calls
+
+
+def test_reassert_with_eq_already_default_never_stages_audible_volume(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "X EQ": "40%",
+    })
+    fake._default = "X EQ"
+    fake._configured_default = "alsa_speaker"
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._sleep = lambda _delay: None
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert ["pactl", "set-sink-volume", "X EQ", "100%"] not in fake.calls
+    assert fake._volumes["X EQ"] == "40%"
 
 
 def test_same_curve_restarts_filter_chain_when_output_changes(tmp_path):
@@ -664,9 +1083,20 @@ def test_teardown_falls_back_to_a_live_sink_after_hot_unplug(tmp_path):
         "3\tX EQ\tPipeWire\t...\tRUNNING\n"
     )
 
-    eq.teardown()
+    assert eq.teardown() is False
 
     assert fake._default == "alsa_speaker"
+    assert eq._route_state()["pending_restores"][0]["sink"] == (
+        "bluez_output.headset"
+    )
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+    )
+    eq._monotonic = lambda: 100.0
+
+    assert eq.teardown() is True
     assert eq.apply_diagnostics()["ok"] is True
 
 
@@ -690,15 +1120,67 @@ def test_route_handoff_retargets_while_eq_remains_default(tmp_path):
 
     handoff = fake.calls[checkpoint:]
     restart = handoff.index(["systemctl", "--user", "restart", "filter-chain.service"])
-    eq_default = next(
-        index
-        for index, call in enumerate(handoff)
-        if call[:5]
-        == ["pw-metadata", "-n", "default", "0", "default.audio.sink"]
-    )
+    eq_default = handoff.index(["pactl", "set-default-sink", "X EQ"])
     assert ["pactl", "set-default-sink", "alsa_speaker"] not in handoff
     assert restart < eq_default
     assert fake._link_target == "alsa_speaker"
+
+
+def test_route_handoff_stages_eq_before_republishing_it(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    checkpoint = len(fake.calls)
+
+    assert eq.ensure_sink([0] * 10) is True
+
+    handoff = fake.calls[checkpoint:]
+    stage = handoff.index(["pactl", "set-sink-volume", "X EQ", "100%"])
+    switch = handoff.index(["pactl", "set-default-sink", "X EQ"])
+    commit = handoff.index(["pactl", "set-sink-volume", "X EQ", "40%"])
+    pin = handoff.index([
+        "pactl", "set-sink-volume", "bluez_output.headset", "100%"
+    ])
+    assert stage < switch < commit < pin
+    assert eq._route_state()["sink"] == "bluez_output.headset"
+
+
+def test_eq_default_route_handoff_restores_old_sink_after_restart(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    checkpoint = len(fake.calls)
+
+    assert eq.ensure_sink([0] * 10) is True
+
+    handoff = fake.calls[checkpoint:]
+    restart = handoff.index([
+        "systemctl", "--user", "restart", "filter-chain.service"
+    ])
+    restore = handoff.index([
+        "pactl", "set-sink-volume", "alsa_speaker", "40%"
+    ])
+    assert restart < restore
 
 
 def test_route_handoff_fails_honestly_when_target_link_is_not_confirmed(tmp_path):
@@ -769,80 +1251,79 @@ def test_output_change_during_apply_aborts_before_restarting_old_target(tmp_path
     }
 
 
-def test_ensure_sink_retries_until_default_readback_confirms(tmp_path):
+def test_ensure_sink_uses_only_the_canonical_pactl_default_write(tmp_path):
     fake = _FakeRunner()
     eq = _make_eq(tmp_path, fake, conf_exists=False)
     eq._sleep = lambda _delay: None
-    attempts = 0
-    run = eq._runner
 
-    def confirm_on_third_attempt(argv, timeout=8):
-        nonlocal attempts
-        if argv[:5] == [
+    assert eq.ensure_sink([0] * 10) is True
+    assert ["pactl", "set-default-sink", "X EQ"] in fake.calls
+    assert not any(
+        call[:5] == [
             "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
-            attempts += 1
-            if attempts < 3:
-                fake.calls.append(argv)
-                return ""
-        return run(argv, timeout)
-
-    eq._runner = confirm_on_third_attempt
-
-    assert eq.ensure_sink([0] * 10) is True
-    assert attempts == 3
+        ]
+        for call in fake.calls
+    )
 
 
-def test_ensure_sink_sets_effective_default_without_overwriting_configured_output(tmp_path):
+def test_default_probe_uses_short_subprocess_timeouts(tmp_path):
     fake = _FakeRunner()
     eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    timeouts = []
+
+    def bounded_runner(argv, timeout=8):
+        if argv[0] in ("pactl", "pw-metadata"):
+            timeouts.append(timeout)
+        return fake(argv, timeout)
+
+    eq._runner = bounded_runner
+
+    assert eq._set_default_confirmed("X EQ", "alsa_speaker") is True
+    assert timeouts
+    assert max(timeouts) <= 1
+
+
+def test_default_probe_has_a_finite_end_to_end_budget(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    now = {"value": 0.0}
+
+    eq._monotonic = lambda: now["value"]
     run = eq._runner
 
-    def metadata_default(argv, timeout=8):
-        if argv[:5] == [
-            "pw-metadata",
-            "-n",
-            "default",
-            "0",
-            "default.audio.sink",
-        ]:
+    def reject_default(argv, timeout=8):
+        now["value"] += 3.0
+        if argv == ["pactl", "set-default-sink", "X EQ"]:
             fake.calls.append(argv)
-            fake._default = "X EQ"
             return ""
         return run(argv, timeout)
 
-    eq._runner = metadata_default
+    eq._runner = reject_default
+
+    assert eq._set_default_confirmed("X EQ", "alsa_speaker") is False
+    assert eq._default_failure == {
+        "reason": "default_confirmation_timeout",
+        "current": "alsa_speaker",
+    }
+    assert fake.calls.count(["pactl", "set-default-sink", "X EQ"]) < 5
+
+
+def test_ensure_sink_journals_physical_output_before_configured_default_is_eq(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
 
     assert eq.ensure_sink([0] * 10) is True
-    assert not any(
-        call[:3] == ["pactl", "set-default-sink", "X EQ"] for call in fake.calls
-    )
-
-
-def test_eq_default_confirmation_never_falls_back_to_pactl(tmp_path):
-    fake = _FakeRunner()
-    eq = _make_eq(tmp_path, fake, conf_exists=True)
-    eq._sleep = lambda _delay: None
-    run = eq._runner
-
-    def ignore_metadata_change(argv, timeout=8):
-        if argv[:5] == [
-            "pw-metadata",
-            "-n",
-            "default",
-            "0",
-            "default.audio.sink",
-        ]:
-            fake.calls.append(argv)
-            return ""
-        return run(argv, timeout)
-
-    eq._runner = ignore_metadata_change
-
-    assert eq.ensure_sink([0] * 10) is False
-    assert not any(
-        call[:3] == ["pactl", "set-default-sink", "X EQ"] for call in fake.calls
-    )
+    assert fake._configured_default == "X EQ"
+    assert eq._route_state() == {
+        "sink": "alsa_speaker",
+        "volume": "40%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": False,
+        "pending_restores": [],
+    }
 
 
 def test_empty_readbacks_never_confirm_bypass_or_sink_absence(tmp_path):
@@ -859,15 +1340,10 @@ def test_ensure_sink_default_confirmation_retry_is_bounded(tmp_path):
     fake = _FakeRunner()
     eq = _make_eq(tmp_path, fake, conf_exists=True)
     eq._sleep = lambda _delay: None
-    attempts = 0
     run = eq._runner
 
     def never_confirm(argv, timeout=8):
-        nonlocal attempts
-        if argv[:5] == [
-            "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
-            attempts += 1
+        if argv == ["pactl", "set-default-sink", "X EQ"]:
             fake.calls.append(argv)
             return ""
         return run(argv, timeout)
@@ -875,7 +1351,7 @@ def test_ensure_sink_default_confirmation_retry_is_bounded(tmp_path):
     eq._runner = never_confirm
 
     assert eq.ensure_sink([0] * 10) is False
-    assert 1 < attempts <= 6
+    assert fake.calls.count(["pactl", "set-default-sink", "X EQ"]) == 3
 
 
 def test_failed_restart_does_not_publish_new_curve_or_restart_again_immediately(tmp_path):
@@ -1004,7 +1480,7 @@ def test_default_confirmation_failure_has_one_finite_retry_budget(tmp_path):
     def reject_eq_default(argv, timeout=8):
         if argv[:5] == [
             "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
+        ] or argv == ["pactl", "set-default-sink", "X EQ"]:
             fake.calls.append(argv)
             return ""
         return run(argv, timeout)
@@ -1018,12 +1494,7 @@ def test_default_confirmation_failure_has_one_finite_retry_budget(tmp_path):
     assert fake.calls.count(
         ["systemctl", "--user", "restart", "filter-chain.service"]
     ) == 1
-    assert sum(
-        call[:5] == [
-            "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]
-        for call in fake.calls
-    ) == 15
+    assert fake.calls.count(["pactl", "set-default-sink", "X EQ"]) == 9
     assert eq.apply_diagnostics()["reason"] == "default_sink_retry_exhausted"
 
 
@@ -1055,6 +1526,15 @@ def test_support_requires_pw_link_for_route_readback(monkeypatch):
     monkeypatch.setattr(pipewire.shutil, "which", lambda _name: None)
     eq = PipeWireEq(runner=_FakeRunner(), name="X")
     eq._session = (1000, "/run/user/1000", "deck")
+
+    assert eq.is_supported() is False
+
+
+def test_support_requires_pactl_for_confirmed_handoffs(monkeypatch):
+    monkeypatch.setattr(pipewire, "filter_chain_module", lambda: "/lib/filter-chain.so")
+    eq = PipeWireEq(runner=_FakeRunner(), name="X")
+    eq._session = (1000, "/run/user/1000", "deck")
+    eq._binary_available = lambda name: name != "pactl"
 
     assert eq.is_supported() is False
 
@@ -1092,7 +1572,7 @@ def test_ensure_sink_requires_default_sink_readback(tmp_path):
     def ignore_default_change(argv, timeout=8):
         if argv[:5] == [
             "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
+        ] or argv == ["pactl", "set-default-sink", "X EQ"]:
             fake.calls.append(argv)
             return ""
         return fake(argv, timeout)
@@ -1101,13 +1581,15 @@ def test_ensure_sink_requires_default_sink_readback(tmp_path):
 
     assert eq.ensure_sink([0] * 10) is False
 
-    assert fake.volume_sets("alsa_speaker") == []
+    assert fake.volume_sets("alsa_speaker") == [
+        ["pactl", "set-sink-volume", "alsa_speaker", "40%"],
+    ]
     assert eq.apply_diagnostics() == {
         "ok": False,
         "reason": "default_sink_not_confirmed",
         "downstream": "alsa_speaker",
         "bypass_confirmed": True,
-        "rollback_confirmed": True,
+        "current": "alsa_speaker",
     }
 
 
@@ -1122,26 +1604,32 @@ def test_failed_first_enable_rolls_back_and_retry_preserves_volume(tmp_path):
     run = eq._runner
 
     def fail_first_default_change(argv, timeout=8):
-        if argv[:5] == [
-            "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
-            if block_default["enabled"]:
-                fake.calls.append(argv)
-                return ""
+        targets_eq = (
+            argv[:5]
+            == ["pw-metadata", "-n", "default", "0", "default.audio.sink"]
+            or argv == ["pactl", "set-default-sink", "X EQ"]
+        )
+        if targets_eq and block_default["enabled"]:
+            fake.calls.append(argv)
+            return ""
         return run(argv, timeout)
 
     eq._runner = fail_first_default_change
 
     assert eq.ensure_sink([0] * 10) is False
-    assert not Path(conf).exists()
+    assert Path(conf).exists()
+    assert eq._route_state()["phase"] == "prepared"
     block_default["enabled"] = False
     now["value"] += 16
     assert eq.ensure_sink([0] * 10) is True
 
     assert fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
         ["pactl", "set-sink-volume", "X EQ", "40%"],
     ]
     assert fake.volume_sets("alsa_speaker") == [
+        ["pactl", "set-sink-volume", "alsa_speaker", "40%"],
         ["pactl", "set-sink-volume", "alsa_speaker", "100%"],
     ]
 
@@ -1166,6 +1654,7 @@ def test_first_enable_restart_retry_still_carries_the_physical_volume(tmp_path):
     now["value"] += 16
     assert eq.ensure_sink([0] * 10) is True
     assert fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
         ["pactl", "set-sink-volume", "X EQ", "40%"],
     ]
 
@@ -1188,6 +1677,7 @@ def test_first_enable_volume_handoff_survives_a_process_restart(tmp_path):
     recovered = _make_eq(tmp_path, recovered_fake, conf_exists=True)
     assert recovered.ensure_sink([0] * 10) is True
     assert recovered_fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "100%"],
         ["pactl", "set-sink-volume", "X EQ", "40%"],
     ]
 
@@ -1201,7 +1691,7 @@ def test_disable_after_failed_first_enable_does_not_change_physical_volume(tmp_p
     def ignore_default_change(argv, timeout=8):
         if argv[:5] == [
             "pw-metadata", "-n", "default", "0", "default.audio.sink"
-        ]:
+        ] or argv == ["pactl", "set-default-sink", "X EQ"]:
             fake.calls.append(argv)
             return ""
         return fake(argv, timeout)
@@ -1211,7 +1701,9 @@ def test_disable_after_failed_first_enable_does_not_change_physical_volume(tmp_p
 
     eq.teardown()
 
-    assert fake.volume_sets("alsa_speaker") == []
+    assert fake.volume_sets("alsa_speaker")[-1] == [
+        "pactl", "set-sink-volume", "alsa_speaker", "40%"
+    ]
     assert eq.is_active() is False
 
 
@@ -1343,7 +1835,7 @@ def test_first_enable_volume_survives_a_crash_after_config_publish(tmp_path):
         "X EQ",
         "40%",
     ]
-    assert not os.path.exists(f"{eq._conf_path()}.first-enable-pending")
+    assert recovered._route_state()["phase"] == "active"
 
 
 def test_first_enable_rejects_a_crash_marker_from_another_output(tmp_path):
@@ -1427,7 +1919,7 @@ def test_failed_config_removal_keeps_the_route_scoped_volume_marker(
     ]
 
 
-def test_marker_cleanup_failure_bypasses_eq_until_cleanup_can_retry(
+def test_route_state_cleanup_failure_is_retained_until_teardown_can_retry(
     tmp_path, monkeypatch
 ):
     fake = _FakeRunner(downstream_vol="40%")
@@ -1444,19 +1936,20 @@ def test_marker_cleanup_failure_bypasses_eq_until_cleanup_can_retry(
 
     monkeypatch.setattr(eq, "_remove_entry", reject_marker_removal)
 
-    assert eq.ensure_sink([0] * 10) is False
-    assert fake._default == "alsa_speaker"
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake._default == "X EQ"
     assert os.path.exists(marker_path)
+    assert eq.teardown() is False
+    assert fake._default == "alsa_speaker"
     assert eq.apply_diagnostics() == {
         "ok": False,
-        "reason": "pending_marker_cleanup_failed",
+        "reason": "teardown_marker_cleanup_failed",
         "downstream": "alsa_speaker",
-        "bypass_confirmed": True,
     }
 
     monkeypatch.setattr(eq, "_remove_entry", remove_entry)
     now["value"] += 120
-    assert eq.ensure_sink([0] * 10) is True
+    assert eq.teardown() is True
     assert not os.path.exists(marker_path)
 
 
@@ -1520,7 +2013,7 @@ def test_teardown_without_runtime_reports_pending_marker_cleanup_failure(
     assert eq.apply_diagnostics() == {
         "ok": False,
         "reason": "teardown_marker_cleanup_failed",
-        "downstream": None,
+        "downstream": "alsa_speaker",
     }
     assert ["systemctl", "--user", "restart", "filter-chain.service"] not in fake.calls
 
@@ -1586,6 +2079,94 @@ def test_teardown_cleans_a_persisted_eq_from_a_fresh_process(tmp_path):
     assert eq.teardown() is True
     assert fake._default == "alsa_speaker"
     assert "\tX EQ\t" not in fake._sinks
+
+
+def test_fresh_process_recovers_target_from_its_config_without_a_live_link(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "alsa_output.hdmi": "65%",
+        "X EQ": "65%",
+    })
+    fake._default = "X EQ"
+    fake._configured_default = "X EQ"
+    fake._link_target = ""
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._conf_path()).write_text('target.object = "alsa_output.hdmi"')
+
+    assert eq._downstream_sink() == "alsa_output.hdmi"
+    assert eq.teardown() is True
+    assert fake._default == "alsa_output.hdmi"
+
+
+def test_fresh_process_rejects_ambiguous_targets_instead_of_guessing(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "alsa_output.hdmi": "65%",
+        "X EQ": "40%",
+    })
+    fake._default = "X EQ"
+    fake._configured_default = "X EQ"
+    fake._link_target = ""
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._conf_path()).write_text("invalid")
+
+    assert eq._downstream_sink() is None
+    assert eq.teardown() is False
+    assert fake._default == "X EQ"
+
+
+def test_teardown_hands_off_volume_and_default_before_removing_eq(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    checkpoint = len(fake.calls)
+
+    assert eq.teardown() is True
+
+    teardown = fake.calls[checkpoint:]
+    volume = teardown.index([
+        "pactl", "set-sink-volume", "alsa_speaker", "40%"
+    ])
+    default = teardown.index(["pactl", "set-default-sink", "alsa_speaker"])
+    restart = teardown.index([
+        "systemctl", "--user", "restart", "filter-chain.service"
+    ])
+    assert volume < default < restart
+
+
+def test_fresh_teardown_prefers_pending_volume_over_staged_eq_volume(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "X EQ": "100%",
+    })
+    fake._default = "X EQ"
+    fake._configured_default = "alsa_speaker"
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(
+        '{"sink":"alsa_speaker","volume":"40%","phase":"prepared",'
+        '"muted":false,"physical_volumes":["40%"],"physical_muted":false}'
+    )
+
+    assert eq.teardown() is True
+    assert fake._default == "alsa_speaker"
+    assert fake.volume_sets("alsa_speaker")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "alsa_speaker",
+        "40%",
+    ]
+    assert not Path(eq._pending_path()).exists()
 
 
 def test_teardown_removes_an_orphan_eq_sink_without_a_config_file(tmp_path):
@@ -1687,6 +2268,629 @@ def test_teardown_does_not_publish_success_without_default_handoff(tmp_path):
         "reason": "teardown_default_not_confirmed",
         "downstream": "alsa_speaker",
     }
+
+
+def test_route_state_rejects_schema_without_physical_ownership(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    Path(eq._pending_path()).write_text(
+        '{"sink":"alsa_speaker","volume":"40%",'
+        '"phase":"active","muted":true}'
+    )
+
+    assert eq._route_state() is None
+    assert fake.volume_sets("alsa_speaker") == []
+
+
+def test_route_state_migrates_the_original_two_field_journal(tmp_path):
+    fake = _FakeRunner()
+    fake._default = "X EQ"
+    fake._mutes["X EQ"] = True
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    Path(eq._pending_path()).write_text(
+        '{"sink":"alsa_speaker","volume":"40%"}'
+    )
+
+    assert eq._route_state() == {
+        "sink": "alsa_speaker",
+        "volume": "40%",
+        "phase": "prepared",
+        "muted": True,
+        "physical_volumes": ["40%"],
+        "physical_muted": False,
+        "pending_restores": [],
+    }
+
+
+def test_two_field_journal_uses_live_physical_channels_and_default_mute(tmp_path):
+    fake = _FakeRunner()
+    fake._volume_channels["alsa_speaker"] = ("35%", "45%")
+    fake._mutes["alsa_speaker"] = True
+    fake._mutes["X EQ"] = False
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    Path(eq._pending_path()).write_text(
+        '{"sink":"alsa_speaker","volume":"35%"}'
+    )
+
+    state = eq._route_state()
+    assert state["muted"] is True
+    assert state["physical_volumes"] == ["35%", "45%"]
+    assert state["physical_muted"] is True
+
+
+def test_route_state_rejects_incomplete_ownership_data(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    Path(eq._pending_path()).write_text(
+        '{"sink":"alsa_speaker","volume":"40%","phase":"active"}'
+    )
+
+    assert eq._route_state() is None
+
+
+def test_pin_aborts_before_mutation_without_a_complete_snapshot(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    run = eq._runner
+
+    def omit_mute(argv, timeout=8):
+        if argv == ["pactl", "get-sink-mute", "alsa_speaker"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = omit_mute
+
+    assert eq._pin_downstream("alsa_speaker", 0) is False
+    assert fake.volume_sets("alsa_speaker") == []
+
+
+def test_restore_retains_ownership_until_readback_confirms_it(tmp_path):
+    fake = _FakeRunner(downstream_vol="100%")
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._downstream_volumes["alsa_speaker"] = ("40%",)
+    eq._downstream_mutes["alsa_speaker"] = True
+    run = eq._runner
+
+    def ignore_restore(argv, timeout=8):
+        if argv == ["pactl", "set-sink-volume", "alsa_speaker", "40%"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_restore
+
+    assert eq._restore_downstream("alsa_speaker") is False
+    assert eq._downstream_volumes["alsa_speaker"] == ("40%",)
+    assert eq._downstream_mutes["alsa_speaker"] is True
+
+
+def test_active_reapply_refreshes_live_volume_and_mute_in_the_journal(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+    assert eq._route_state()["physical_volumes"] == ["40%"]
+
+
+def test_active_state_sync_refreshes_live_volume_and_mute(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+
+    assert eq.sync_state() is True
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+    assert eq._route_state()["physical_volumes"] == ["40%"]
+
+
+def test_active_state_sync_restores_a_replugged_old_sink(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "bluez_output.headset": "100%",
+        "X EQ": "25%",
+    })
+    fake._default = "X EQ"
+    fake._link_target = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "bluez_output.headset",
+        "volume": "25%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["65%"],
+        "physical_muted": False,
+        "pending_restores": [{
+            "sink": "alsa_speaker",
+            "volumes": ["40%"],
+            "muted": True,
+        }],
+    }))
+
+    assert eq.sync_state() is True
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert fake._volumes["bluez_output.headset"] == "100%"
+    assert eq._route_state()["pending_restores"] == []
+
+
+def test_curve_restart_restores_journaled_eq_volume_and_mute(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+    run = eq._runner
+
+    def reset_eq_controls_on_restart(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake._volumes["X EQ"] = "100%"
+            fake._volume_channels["X EQ"] = ("100%",)
+            fake._mutes["X EQ"] = False
+        return result
+
+    eq._runner = reset_eq_controls_on_restart
+
+    assert eq.ensure_sink([1] * 10) is True
+    assert fake._volumes["X EQ"] == "25%"
+    assert fake._mutes["X EQ"] is True
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+
+
+def test_route_restart_preserves_live_state_newer_than_journal(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    run = eq._runner
+
+    def reset_eq_controls_on_restart(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake._volumes["X EQ"] = "100%"
+            fake._volume_channels["X EQ"] = ("100%",)
+            fake._mutes["X EQ"] = False
+        return result
+
+    eq._runner = reset_eq_controls_on_restart
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake._volumes["X EQ"] == "25%"
+    assert fake._mutes["X EQ"] is True
+    assert eq._route_state()["sink"] == "bluez_output.headset"
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+
+
+def test_curve_restart_crash_recovers_prepared_eq_volume_and_mute(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+    assert eq.sync_state() is True
+    restart = eq._restart
+
+    def crash_after_restart():
+        assert restart() is True
+        fake._volumes["X EQ"] = "100%"
+        fake._volume_channels["X EQ"] = ("100%",)
+        fake._mutes["X EQ"] = False
+        raise RuntimeError("process terminated")
+
+    eq._restart = crash_after_restart
+
+    try:
+        eq.ensure_sink([1] * 10)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected simulated process termination")
+
+    assert eq._route_state()["phase"] == "prepared"
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+
+    assert recovered.ensure_sink([1] * 10) is True
+    assert fake._volumes["X EQ"] == "25%"
+    assert fake._mutes["X EQ"] is True
+
+
+def test_activation_rejects_a_missing_final_mute_readback(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    run = eq._runner
+    reads = {"eq_mute": 0}
+
+    def lose_final_mute(argv, timeout=8):
+        if argv == ["pactl", "get-sink-mute", "X EQ"]:
+            reads["eq_mute"] += 1
+            if reads["eq_mute"] == 2:
+                fake.calls.append(argv)
+                return ""
+        return run(argv, timeout)
+
+    eq._runner = lose_final_mute
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert eq.apply_diagnostics()["reason"] == "route_state_write_failed"
+
+
+def test_fresh_backend_preserves_live_eq_state_and_physical_snapshot(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    fake._volumes["X EQ"] = "25%"
+    fake._volume_channels["X EQ"] = ("25%",)
+    fake._mutes["X EQ"] = True
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+
+    assert recovered.ensure_sink([0] * 10) is True
+    state = recovered._route_state()
+    assert state["volume"] == "25%"
+    assert state["muted"] is True
+    assert state["physical_volumes"] == ["40%"]
+    assert state["physical_muted"] is False
+
+
+def test_upgrade_without_journal_captures_live_eq_before_restart(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "X EQ": "25%",
+    })
+    fake._default = "X EQ"
+    fake._link_target = "alsa_speaker"
+    fake._mutes["X EQ"] = True
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    run = eq._runner
+
+    def reset_eq_controls_on_restart(argv, timeout=8):
+        result = run(argv, timeout)
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake._volumes["X EQ"] = "100%"
+            fake._volume_channels["X EQ"] = ("100%",)
+            fake._mutes["X EQ"] = False
+        return result
+
+    eq._runner = reset_eq_controls_on_restart
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake._volumes["X EQ"] == "25%"
+    assert fake._mutes["X EQ"] is True
+    assert eq._route_state()["volume"] == "25%"
+    assert eq._route_state()["muted"] is True
+
+
+def test_journal_only_teardown_restores_last_active_user_state(tmp_path):
+    fake = _FakeRunner(downstream_vol="100%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "alsa_speaker",
+        "volume": "25%",
+        "phase": "active",
+        "muted": True,
+        "physical_volumes": ["40%"],
+        "physical_muted": False,
+        "pending_restores": [],
+    }))
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "25%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert not Path(eq._pending_path()).exists()
+
+
+def test_fresh_teardown_restores_owned_sink_after_external_default_change(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "bluez_output.headset": "65%",
+        "X EQ": "25%",
+    })
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "alsa_speaker",
+        "volume": "25%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": True,
+        "pending_restores": [],
+    }))
+
+    assert eq.teardown() is True
+    assert fake._default == "bluez_output.headset"
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert not Path(eq._pending_path()).exists()
+
+
+def test_fresh_teardown_transfers_state_when_owned_sink_is_already_default(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "X EQ": "25%",
+    })
+    fake._default = "alsa_speaker"
+    fake._mutes["X EQ"] = True
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tIDLE\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "alsa_speaker",
+        "volume": "40%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": False,
+        "pending_restores": [],
+    }))
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "25%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert not Path(eq._pending_path()).exists()
+
+
+def test_fresh_teardown_retains_unplugged_owned_sink_until_replug(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "bluez_output.headset": "65%",
+        "X EQ": "25%",
+    })
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "alsa_speaker",
+        "volume": "25%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": True,
+        "pending_restores": [],
+    }))
+
+    assert eq.teardown() is False
+    assert eq._route_state()["pending_restores"] == [{
+        "sink": "alsa_speaker",
+        "volumes": ["40%"],
+        "muted": True,
+    }]
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+    )
+    eq._monotonic = lambda: 100.0
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert not Path(eq._pending_path()).exists()
+
+
+def test_fresh_eq_teardown_retains_unplugged_link_target_until_replug(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "100%",
+        "bluez_output.headset": "65%",
+        "X EQ": "25%",
+    })
+    fake._default = "X EQ"
+    fake._link_target = "alsa_speaker"
+    fake._sinks = (
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    Path(eq._pending_path()).write_text(json.dumps({
+        "sink": "alsa_speaker",
+        "volume": "25%",
+        "phase": "active",
+        "muted": False,
+        "physical_volumes": ["40%"],
+        "physical_muted": True,
+        "pending_restores": [],
+    }))
+
+    assert eq.teardown() is False
+    assert fake._default == "bluez_output.headset"
+    assert eq._route_state()["pending_restores"][0]["sink"] == "alsa_speaker"
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+    )
+    eq._monotonic = lambda: 100.0
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert fake._mutes["alsa_speaker"] is True
+    assert not Path(eq._pending_path()).exists()
+
+
+def test_route_handoff_recovers_after_crash_before_new_journal(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    persist = eq._persist_route_state
+
+    def crash_before_new_journal(downstream, *args):
+        if downstream == "bluez_output.headset":
+            raise RuntimeError("process terminated")
+        return persist(downstream, *args)
+
+    eq._persist_route_state = crash_before_new_journal
+
+    try:
+        eq.ensure_sink([0] * 10)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected simulated process termination")
+
+    assert fake._volumes["alsa_speaker"] == "100%"
+    assert eq._route_state()["sink"] == "alsa_speaker"
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+
+    assert recovered.ensure_sink([0] * 10) is True
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert recovered._route_state()["sink"] == "bluez_output.headset"
+    assert recovered._route_state()["physical_volumes"] == ["65%"]
+
+
+def test_eq_default_route_handoff_journals_target_before_pin(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    persist = eq._persist_route_state
+
+    def crash_after_target_pin(
+        downstream,
+        volume,
+        phase,
+        muted,
+        physical_volumes,
+        physical_muted,
+    ):
+        if downstream == "bluez_output.headset" and phase == "active":
+            raise RuntimeError("process terminated")
+        return persist(
+            downstream,
+            volume,
+            phase,
+            muted,
+            physical_volumes,
+            physical_muted,
+        )
+
+    eq._persist_route_state = crash_after_target_pin
+
+    try:
+        eq.ensure_sink([0] * 10)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected simulated process termination")
+
+    state = eq._route_state()
+    assert state["sink"] == "bluez_output.headset"
+    assert state["phase"] == "prepared"
+    assert state["physical_volumes"] == ["65%"]
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+
+    assert recovered.ensure_sink([0] * 10) is True
+    assert recovered._route_state()["physical_volumes"] == ["65%"]
+
+
+def test_hot_unplug_restore_survives_retry_exhaustion_and_replug(tmp_path):
+    fake = _FakeRunner(downstream_vol={
+        "alsa_speaker": "40%",
+        "bluez_output.headset": "65%",
+    })
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._configured_default = "bluez_output.headset"
+    fake._sinks = (
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq._route_state()["pending_restores"] == [{
+        "sink": "alsa_speaker",
+        "volumes": ["40%"],
+        "muted": False,
+    }]
+
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    assert eq.teardown() is False
+    for _attempt in range(4):
+        now["value"] += 20
+        assert eq.teardown() is False
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+    )
+    now["value"] += 20
+
+    assert eq.teardown() is True
+    assert fake._volumes["alsa_speaker"] == "40%"
+    assert fake._mutes["alsa_speaker"] is False
+    assert not Path(eq._pending_path()).exists()
 
 
 _PW_LINK = """effect_output.pdc_eq:output_FL

--- a/tests/test_audio_pipewire.py
+++ b/tests/test_audio_pipewire.py
@@ -439,6 +439,14 @@ def test_secure_remove_does_not_confirm_through_a_symlinked_parent(tmp_path):
     assert entry.read_text() == "keep"
 
 
+def test_missing_parent_confirms_pending_marker_absence(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._conf_path = lambda: str(tmp_path / "missing" / "pdc-eq.conf")
+
+    assert eq._clear_first_enable_pending() is True
+
+
 def test_secure_entry_io_rejects_oversized_files(tmp_path):
     fake = _FakeRunner()
     eq = _make_eq(tmp_path, fake, conf_exists=False)
@@ -1489,6 +1497,58 @@ def test_disable_after_failed_reapply_restores_owned_eq_volume(tmp_path):
         "40%",
     ]
     assert fake._default == "alsa_speaker"
+
+
+def test_teardown_without_runtime_reports_pending_marker_cleanup_failure(
+    tmp_path, monkeypatch
+):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    marker_path = eq._pending_path()
+    Path(marker_path).write_text('{"sink":"alsa_speaker","volume":"40%"}')
+    remove_entry = eq._remove_entry
+
+    def reject_marker_removal(path):
+        if path == marker_path:
+            return False
+        return remove_entry(path)
+
+    monkeypatch.setattr(eq, "_remove_entry", reject_marker_removal)
+
+    assert eq.teardown() is False
+    assert Path(marker_path).exists()
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "teardown_marker_cleanup_failed",
+        "downstream": None,
+    }
+    assert ["systemctl", "--user", "restart", "filter-chain.service"] not in fake.calls
+
+
+def test_teardown_reports_marker_failure_after_restoring_audio(tmp_path, monkeypatch):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    marker_path = eq._pending_path()
+    Path(marker_path).write_text('{"sink":"alsa_speaker","volume":"40%"}')
+    remove_entry = eq._remove_entry
+
+    def reject_marker_removal(path):
+        if path == marker_path:
+            return False
+        return remove_entry(path)
+
+    monkeypatch.setattr(eq, "_remove_entry", reject_marker_removal)
+
+    assert eq.teardown() is False
+    assert fake._default == "alsa_speaker"
+    assert "\tX EQ\t" not in fake._sinks
+    assert Path(marker_path).exists()
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "teardown_marker_cleanup_failed",
+        "downstream": "alsa_speaker",
+    }
 
 
 def test_teardown_failure_bypasses_eq_and_retains_state_for_cleanup_retry(tmp_path):

--- a/tests/test_audio_pipewire.py
+++ b/tests/test_audio_pipewire.py
@@ -68,8 +68,6 @@ def test_choose_downstream_prefers_the_active_default():
 
 
 def test_choose_downstream_falls_back_to_the_running_sink_when_default_is_our_eq():
-    # EQ is the default → enumerate, and prefer the RUNNING output (headphones here) so the
-    # per-route curve + volume-pin follow the active device, not just the first-listed one.
     assert choose_downstream("X EQ", _DECK_SHORT, "X EQ").endswith("Headphones__sink")
 
 
@@ -349,8 +347,6 @@ def _make_eq(tmp_path, fake, conf_exists):
 
 
 def test_ensure_sink_first_enable_carries_downstream_volume(tmp_path):
-    # Genuine first-ever enable (no persisted conf): carry the downstream's real level
-    # onto our sink so enabling the EQ doesn't jump loudness to unity.
     fake = _FakeRunner(downstream_vol="40%")
     eq = _make_eq(tmp_path, fake, conf_exists=False)
     assert eq.ensure_sink([0] * 10) is True
@@ -521,9 +517,6 @@ def test_trusted_home_alias_is_resolved_before_secure_directory_walk(
 
 
 def test_ensure_sink_boot_reassert_preserves_user_volume(tmp_path):
-    # A persisted conf already exists → the EQ sink comes back with the user's level
-    # (WirePlumber restores it by node.name). A boot/reload re-assert must NOT copy the
-    # always-unity downstream onto it, or the user's volume is wiped to 100% every boot.
     fake = _FakeRunner(downstream_vol="100%")
     eq = _make_eq(tmp_path, fake, conf_exists=True)
     assert eq.ensure_sink([0] * 10) is True
@@ -1666,11 +1659,10 @@ def test_linked_downstream_returns_only_a_current_physical_candidate():
 
 def test_relevant_links_keeps_eq_and_hardware_drops_noise():
     out = _relevant_links(_PW_LINK)
-    assert "effect_output.pdc_eq" in out          # our node
-    assert "alsa_output.pci-0000_c2_00.6" in out   # hardware output
-    assert "loopback" in out                        # the virtual hop it routes through
-    assert "some_unrelated_node" not in out         # noise dropped
-    # the indented continuation of a kept node is preserved
+    assert "effect_output.pdc_eq" in out
+    assert "alsa_output.pci-0000_c2_00.6" in out
+    assert "loopback" in out
+    assert "some_unrelated_node" not in out
     assert "|-> alsa_loopback_device" in out
 
 

--- a/tests/test_audio_pipewire.py
+++ b/tests/test_audio_pipewire.py
@@ -1,7 +1,16 @@
+import json
+import os
+import stat
 from pathlib import Path
+
+import audio.pipewire as pipewire
 
 from audio.pipewire import (
     PipeWireEq,
+    _MAX_ENTRY_BYTES,
+    _configured_default_sink,
+    _linked_downstream,
+    _link_reaches,
     _relevant_links,
     choose_downstream,
     pick_downstream,
@@ -68,19 +77,187 @@ def test_pick_downstream_prefers_running_analog():
     assert pick_downstream(_DECK_SHORT, "X EQ").endswith("Headphones__sink")
 
 
-def test_choose_downstream_skips_a_digital_default():
+def test_choose_downstream_honors_a_selected_digital_default():
     short = (
         "73\talsa_output.HiFi__HDMI1__sink\tPipeWire\t...\tSUSPENDED\n"
         "79\talsa_output.HiFi__Speaker__sink\tPipeWire\t...\tIDLE\n"
     )
-    assert choose_downstream("alsa_output.HiFi__HDMI1__sink", short, "X EQ").endswith("Speaker__sink")
+    assert choose_downstream("alsa_output.HiFi__HDMI1__sink", short, "X EQ").endswith("HDMI1__sink")
 
+
+def test_pick_downstream_prefers_running_hdmi_over_idle_speaker():
+    short = (
+        "73\talsa_output.HiFi__HDMI1__sink\tPipeWire\t...\tRUNNING\n"
+        "79\talsa_output.HiFi__Speaker__sink\tPipeWire\t...\tIDLE\n"
+    )
+
+    assert pick_downstream(short, "X EQ").endswith("HDMI1__sink")
+
+
+def test_choose_downstream_ignores_a_stale_missing_default():
+    assert (
+        choose_downstream("alsa_output.missing", _DECK_SHORT, "X EQ")
+        == "alsa_output.HiFi__Headphones__sink"
+    )
+
+
+def test_choose_downstream_retains_confirmed_idle_target_while_eq_is_default():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream("X EQ", short, "X EQ", preferred="bluez_output.headset")
+        == "bluez_output.headset"
+    )
+
+
+def test_choose_downstream_prefers_the_current_link_over_the_previous_target():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream(
+            "X EQ",
+            short,
+            "X EQ",
+            preferred="alsa_speaker",
+            linked="alsa_output.hdmi",
+        )
+        == "alsa_output.hdmi"
+    )
+
+
+def test_choose_downstream_prefers_a_new_configured_default_while_eq_is_default():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream(
+            "X EQ",
+            short,
+            "X EQ",
+            preferred="alsa_speaker",
+            linked="alsa_speaker",
+            configured="alsa_output.hdmi",
+            configured_changed=True,
+        )
+        == "alsa_output.hdmi"
+    )
+
+
+def test_choose_downstream_uses_configured_default_when_recovering_an_existing_eq():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream(
+            "X EQ",
+            short,
+            "X EQ",
+            linked="alsa_speaker",
+            configured="alsa_output.hdmi",
+        )
+        == "alsa_output.hdmi"
+    )
+
+
+def test_choose_downstream_honors_a_manual_link_move_when_configured_default_is_unchanged():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream(
+            "X EQ",
+            short,
+            "X EQ",
+            preferred="alsa_speaker",
+            linked="bluez_output.headset",
+            configured="alsa_speaker",
+        )
+        == "bluez_output.headset"
+    )
+
+
+def test_choose_downstream_keeps_confirmed_link_when_configured_default_is_stale():
+    short = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert (
+        choose_downstream(
+            "X EQ",
+            short,
+            "X EQ",
+            preferred="bluez_output.headset",
+            linked="bluez_output.headset",
+            configured="alsa_speaker",
+            configured_changed=False,
+        )
+        == "bluez_output.headset"
+    )
+
+
+def test_configured_default_sink_parses_wireplumber_metadata():
+    metadata = """Found \"default\" metadata 41
+update: id:0 key:'default.configured.audio.sink' value:'{ \"name\": \"alsa_output.hdmi\" }' type:'Spa:String:JSON'
+update: id:0 key:'default.audio.sink' value:'{\"name\":\"X EQ\"}' type:'Spa:String:JSON'
+"""
+
+    assert _configured_default_sink(metadata) == "alsa_output.hdmi"
+    assert _configured_default_sink("") is None
+
+
+def test_link_readback_requires_exact_node_names():
+    links = (
+        "effect_output.pdc_eq:output_FL\n"
+        "  |-> alsa_output.hdmi-stereo-extra1:playback_FL\n"
+    )
+
+    assert not _link_reaches(
+        links,
+        "effect_output.pdc_eq",
+        "alsa_output.hdmi-stereo",
+    )
+    assert _linked_downstream(
+        links,
+        "effect_output.pdc_eq",
+        ["alsa_output.hdmi-stereo", "alsa_output.hdmi-stereo-extra1"],
+    ) == "alsa_output.hdmi-stereo-extra1"
 
 class _FakeRunner:
     def __init__(self, downstream_vol="40%"):
         self.calls = []
-        self._vol = downstream_vol
+        if isinstance(downstream_vol, dict):
+            self._volumes = dict(downstream_vol)
+            self._vol = next(iter(self._volumes.values()), "40%")
+        else:
+            self._volumes = {}
+            self._vol = downstream_vol
         self._default = "alsa_speaker"
+        self._link_target = "alsa_speaker"
+        self._configured_target = None
+        self._configured_default = None
+        self._sinks = "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        self._service_generation = 1
+        self._conf_path = None
+        self._keep_eq_on_restart = False
 
     def __call__(self, argv, timeout=8):
         self.calls.append(argv)
@@ -90,10 +267,62 @@ class _FakeRunner:
         if argv[:2] == ["pactl", "set-default-sink"]:
             self._default = argv[2]
             return ""
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            self._service_generation += 1
+            if self._configured_target:
+                self._link_target = self._configured_target
+            elif not self._default.endswith(" EQ"):
+                self._link_target = self._default
+            if (
+                self._conf_path
+                and not Path(self._conf_path).exists()
+                and not self._keep_eq_on_restart
+            ):
+                self._sinks = "\n".join(
+                    line for line in self._sinks.splitlines() if "\tX EQ\t" not in line
+                )
+                if self._sinks:
+                    self._sinks += "\n"
+            return ""
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            return "active"
+        if argv == [
+            "systemctl",
+            "--user",
+            "show",
+            "filter-chain.service",
+            "--property=InvocationID",
+            "--property=MainPID",
+            "--value",
+        ]:
+            return f"inv-{self._service_generation}\n{1000 + self._service_generation}"
+        if argv == ["pw-link", "-l"]:
+            return (
+                "effect_output.pdc_eq:output_FL\n"
+                f"  |-> {self._link_target}:playback_FL\n"
+            )
+        if argv == ["pw-metadata", "-n", "default"]:
+            if self._configured_default:
+                return (
+                    "update: id:0 key:'default.configured.audio.sink' "
+                    f"value:'{{ \"name\": \"{self._configured_default}\" }}' "
+                    "type:'Spa:String:JSON'"
+                )
+            return ""
+        if argv[:5] == [
+            "pw-metadata",
+            "-n",
+            "default",
+            "0",
+            "default.audio.sink",
+        ]:
+            self._default = json.loads(argv[5])["name"]
+            return ""
         if "list" in s and "sinks" in s:
-            return "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+            return self._sinks
         if "get-sink-volume" in s:
-            return f"Volume: front-left: 26214 / {self._vol} / ..."
+            volume = self._volumes.get(argv[-1], self._vol)
+            return f"Volume: front-left: 26214 / {volume} / ..."
         return ""
 
     def volume_sets(self, sink):
@@ -103,13 +332,19 @@ class _FakeRunner:
 
 def _make_eq(tmp_path, fake, conf_exists):
     eq = PipeWireEq(runner=fake, name="X")
-    eq._session = (1000, "/run/user/1000", "deck")
+    eq._session = (os.getuid(), f"/run/user/{os.getuid()}", "deck")
     conf = tmp_path / "pdc-eq.conf"
     if conf_exists:
         conf.write_text("x")
     eq._conf_path = lambda: str(conf)
+    fake._conf_path = str(conf)
     eq.is_supported = lambda: True
-    eq._write_conf = lambda *a, **k: True
+    def write_conf(*args, **kwargs):
+        fake._configured_target = kwargs.get("downstream") or args[-1]
+        conf.write_text("x")
+        return True
+
+    eq._write_conf = write_conf
     return eq
 
 
@@ -123,6 +358,168 @@ def test_ensure_sink_first_enable_carries_downstream_volume(tmp_path):
     assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] in fake.calls
 
 
+def test_first_enable_creates_a_missing_pipewire_config_directory(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    conf = tmp_path / "missing" / "filter-chain.conf.d" / "pdc-eq.conf"
+    eq._conf_path = lambda: str(conf)
+    fake._conf_path = str(conf)
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert conf.exists()
+    assert not Path(f"{conf}.first-enable-pending").exists()
+
+
+def test_volume_marker_refuses_to_follow_a_symlink(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    victim = tmp_path / "victim"
+    victim.write_text("unchanged")
+    marker = Path(eq._pending_path())
+    marker.symlink_to(victim)
+    eq._first_enable_downstream = "alsa_speaker"
+    eq._first_enable_volume = "40%"
+
+    assert eq._persist_first_enable_pending() is False
+    assert victim.read_text() == "unchanged"
+    assert marker.is_symlink()
+
+
+def test_config_refuses_to_replace_a_symlink(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    victim = tmp_path / "victim"
+    victim.write_text("unchanged")
+    conf = Path(eq._conf_path())
+    conf.symlink_to(victim)
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    assert eq._write_conf([0] * 10, 0, False, "alsa_speaker") is False
+    assert victim.read_text() == "unchanged"
+    assert conf.is_symlink()
+
+
+def test_config_ignores_the_old_deterministic_pending_symlink(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    victim = tmp_path / "victim"
+    victim.write_text("unchanged")
+    legacy_pending = Path(f"{eq._conf_path()}.pending")
+    legacy_pending.symlink_to(victim)
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    assert eq._write_conf([0] * 10, 0, False, "alsa_speaker") is True
+    assert victim.read_text() == "unchanged"
+    assert legacy_pending.is_symlink()
+
+
+def test_config_refuses_to_traverse_a_symlinked_parent(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    conf = linked_parent / "pdc-eq.conf"
+    eq._conf_path = lambda: str(conf)
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    assert eq._write_conf([0] * 10, 0, False, "alsa_speaker") is False
+    assert not (real_parent / "pdc-eq.conf").exists()
+
+
+def test_secure_remove_does_not_confirm_through_a_symlinked_parent(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    real_parent = tmp_path / "real-remove"
+    real_parent.mkdir()
+    entry = real_parent / "marker"
+    entry.write_text("keep")
+    linked_parent = tmp_path / "linked-remove"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+
+    assert eq._remove_entry(str(linked_parent / "marker")) is False
+    assert entry.read_text() == "keep"
+
+
+def test_secure_entry_io_rejects_oversized_files(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    oversized = tmp_path / "oversized"
+    oversized.write_bytes(b"x" * (_MAX_ENTRY_BYTES + 1))
+
+    assert eq._read_entry(str(oversized)) is None
+    assert eq._write_entry(str(tmp_path / "new"), "x" * (_MAX_ENTRY_BYTES + 1)) is False
+    assert not (tmp_path / "new").exists()
+
+
+def test_secure_read_rejects_a_fifo_without_blocking(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    fifo = tmp_path / "fifo"
+    os.mkfifo(fifo)
+
+    assert eq._read_entry(str(fifo)) is None
+
+
+def test_config_and_volume_marker_are_private_to_the_session_user(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._first_enable_downstream = "alsa_speaker"
+    eq._first_enable_volume = "40%"
+
+    assert eq._persist_first_enable_pending() is True
+    assert stat.S_IMODE(os.stat(eq._pending_path()).st_mode) == 0o600
+
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+    assert eq._write_conf([0] * 10, 0, False, "alsa_speaker") is True
+    assert stat.S_IMODE(os.stat(eq._conf_path()).st_mode) == 0o600
+
+
+def test_secure_write_refuses_to_publish_with_the_wrong_owner(tmp_path, monkeypatch):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+
+    def reject_chown(_fd, _uid, _gid):
+        raise OSError("ownership unsupported")
+
+    class WrongOwner:
+        st_uid = os.getuid() + 1
+
+    monkeypatch.setattr(os, "fchown", reject_chown)
+    monkeypatch.setattr(os, "fstat", lambda _fd: WrongOwner())
+
+    target = tmp_path / "wrong-owner"
+    assert eq._write_entry(str(target), "data") is False
+    assert not target.exists()
+
+
+def test_trusted_home_alias_is_resolved_before_secure_directory_walk(
+    tmp_path, monkeypatch
+):
+    real_home = tmp_path / "var-home" / "deck"
+    real_home.mkdir(parents=True)
+    home_alias = tmp_path / "home-deck"
+    home_alias.symlink_to(real_home, target_is_directory=True)
+
+    class Account:
+        pw_dir = str(home_alias)
+        pw_uid = os.getuid()
+        pw_gid = os.getgid()
+
+    monkeypatch.setattr(pipewire.pwd, "getpwuid", lambda _uid: Account())
+    fake = _FakeRunner()
+    eq = PipeWireEq(runner=fake, name="X")
+    eq._session = (os.getuid(), "/run/user/test", "deck")
+    eq.is_supported = lambda: True
+    fake._conf_path = eq._conf_path()
+
+    assert eq._conf_path().startswith(str(real_home))
+    assert eq.ensure_sink([0] * 10) is True
+    assert Path(eq._conf_path()).exists()
+
+
 def test_ensure_sink_boot_reassert_preserves_user_volume(tmp_path):
     # A persisted conf already exists → the EQ sink comes back with the user's level
     # (WirePlumber restores it by node.name). A boot/reload re-assert must NOT copy the
@@ -132,6 +529,543 @@ def test_ensure_sink_boot_reassert_preserves_user_volume(tmp_path):
     assert eq.ensure_sink([0] * 10) is True
     assert fake.volume_sets("X EQ") == []
     assert ["pactl", "set-sink-volume", "alsa_speaker", "100%"] in fake.calls
+
+
+def test_same_curve_restarts_filter_chain_when_output_changes(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    initial_restarts = fake.calls.count(["systemctl", "--user", "restart", "filter-chain.service"])
+
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == initial_restarts + 1
+
+
+def test_configured_output_change_survives_probe_then_apply(tmp_path):
+    fake = _FakeRunner()
+    fake._configured_default = "alsa_speaker"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq._downstream_sink() == "alsa_speaker"
+
+    fake._configured_default = "alsa_output.hdmi"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert eq._downstream_sink() == "alsa_output.hdmi"
+    assert eq._downstream_sink() == "alsa_output.hdmi"
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq._active_downstream == "alsa_output.hdmi"
+
+
+def test_configured_output_change_makes_active_readback_fail_before_handoff(tmp_path):
+    fake = _FakeRunner()
+    fake._configured_default = "alsa_speaker"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    assert eq.is_active() is True
+
+    fake._configured_default = "alsa_output.hdmi"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert eq.is_active() is False
+    assert eq._requested_downstream == "alsa_output.hdmi"
+
+
+def test_route_change_restores_the_previous_output_volume(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._vol = "65%"
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    assert eq.ensure_sink([0] * 10) is True
+
+    assert fake.volume_sets("alsa_speaker")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "alsa_speaker",
+        "40%",
+    ]
+
+
+def test_teardown_restores_the_latest_selected_output(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    assert eq.ensure_sink([0] * 10) is True
+
+    eq.teardown()
+
+    assert fake._default == "bluez_output.headset"
+
+
+def test_teardown_preserves_a_new_external_default_before_watcher_handoff(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    checkpoint = len(fake.calls)
+
+    eq.teardown()
+
+    assert fake._default == "bluez_output.headset"
+    assert not any(call[:2] == ["pactl", "set-default-sink"] for call in fake.calls[checkpoint:])
+
+
+def test_teardown_falls_back_to_a_live_sink_after_hot_unplug(tmp_path):
+    fake = _FakeRunner()
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10, balance=30) is True
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+
+    eq.teardown()
+
+    assert fake._default == "alsa_speaker"
+    assert eq.apply_diagnostics()["ok"] is True
+
+
+def test_route_handoff_retargets_while_eq_remains_default(tmp_path):
+    fake = _FakeRunner()
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    checkpoint = len(fake.calls)
+
+    assert eq.ensure_sink([0] * 10) is True
+
+    handoff = fake.calls[checkpoint:]
+    restart = handoff.index(["systemctl", "--user", "restart", "filter-chain.service"])
+    eq_default = next(
+        index
+        for index, call in enumerate(handoff)
+        if call[:5]
+        == ["pw-metadata", "-n", "default", "0", "default.audio.sink"]
+    )
+    assert ["pactl", "set-default-sink", "alsa_speaker"] not in handoff
+    assert restart < eq_default
+    assert fake._link_target == "alsa_speaker"
+
+
+def test_route_handoff_fails_honestly_when_target_link_is_not_confirmed(tmp_path):
+    fake = _FakeRunner()
+    fake._default = "bluez_output.headset"
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tIDLE\n"
+        "2\tbluez_output.headset\tPipeWire\t...\tRUNNING\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    )
+    checkpoint = len(fake.calls)
+    fake._configured_target = None
+    run = eq._runner
+
+    def keep_stale_link(argv, timeout=8):
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake.calls.append(argv)
+            fake._service_generation += 1
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = keep_stale_link
+
+    assert eq.ensure_sink([0] * 10) is False
+
+    handoff = fake.calls[checkpoint:]
+    assert ["systemctl", "--user", "restart", "filter-chain.service"] in handoff
+    assert fake._default == "alsa_speaker"
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "target_link_not_confirmed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+    }
+
+
+def test_output_change_during_apply_aborts_before_restarting_old_target(tmp_path):
+    fake = _FakeRunner()
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+
+    def change_output_while_writing(*_args, **_kwargs):
+        fake._default = "alsa_output.hdmi"
+        return True
+
+    eq._write_conf = change_output_while_writing
+
+    assert eq.ensure_sink([0] * 10) is False
+
+    assert ["systemctl", "--user", "restart", "filter-chain.service"] not in fake.calls
+    assert not os.path.exists(eq._conf_path())
+    assert not os.path.exists(f"{eq._conf_path()}.first-enable-pending")
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "downstream_changed",
+        "downstream": "alsa_speaker",
+        "current": "alsa_output.hdmi",
+    }
+
+
+def test_ensure_sink_retries_until_default_readback_confirms(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._sleep = lambda _delay: None
+    attempts = 0
+    run = eq._runner
+
+    def confirm_on_third_attempt(argv, timeout=8):
+        nonlocal attempts
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
+            attempts += 1
+            if attempts < 3:
+                fake.calls.append(argv)
+                return ""
+        return run(argv, timeout)
+
+    eq._runner = confirm_on_third_attempt
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert attempts == 3
+
+
+def test_ensure_sink_sets_effective_default_without_overwriting_configured_output(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    run = eq._runner
+
+    def metadata_default(argv, timeout=8):
+        if argv[:5] == [
+            "pw-metadata",
+            "-n",
+            "default",
+            "0",
+            "default.audio.sink",
+        ]:
+            fake.calls.append(argv)
+            fake._default = "X EQ"
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = metadata_default
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert not any(
+        call[:3] == ["pactl", "set-default-sink", "X EQ"] for call in fake.calls
+    )
+
+
+def test_eq_default_confirmation_never_falls_back_to_pactl(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+
+    def ignore_metadata_change(argv, timeout=8):
+        if argv[:5] == [
+            "pw-metadata",
+            "-n",
+            "default",
+            "0",
+            "default.audio.sink",
+        ]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_metadata_change
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert not any(
+        call[:3] == ["pactl", "set-default-sink", "X EQ"] for call in fake.calls
+    )
+
+
+def test_empty_readbacks_never_confirm_bypass_or_sink_absence(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._sleep = lambda _delay: None
+    eq._runner = lambda _argv, timeout=8: ""
+
+    assert eq._bypass_eq_default("alsa_speaker") is False
+    assert eq._sink_absent_confirmed("X EQ") is False
+
+
+def test_ensure_sink_default_confirmation_retry_is_bounded(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._sleep = lambda _delay: None
+    attempts = 0
+    run = eq._runner
+
+    def never_confirm(argv, timeout=8):
+        nonlocal attempts
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
+            attempts += 1
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = never_confirm
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert 1 < attempts <= 6
+
+
+def test_failed_restart_does_not_publish_new_curve_or_restart_again_immediately(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._monotonic = lambda: 100.0
+    run = eq._runner
+
+    def fail_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return "failed"
+        return run(argv, timeout)
+
+    eq._runner = fail_restart
+
+    assert eq.ensure_sink([3] * 10) is False
+    restarts = fake.calls.count(["systemctl", "--user", "restart", "filter-chain.service"])
+    assert eq.is_active() is False
+    assert eq.apply_diagnostics()["reason"] == "service_restart_failed"
+
+    assert eq.ensure_sink([3] * 10) is False
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == restarts
+    assert eq.apply_diagnostics()["reason"] == "service_restart_backoff"
+
+
+def test_noop_restart_does_not_publish_a_new_curve(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    assert eq.ensure_sink([0] * 10) is True
+    run = eq._runner
+
+    def ignore_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_restart
+
+    assert eq.ensure_sink([3] * 10) is False
+    assert eq.apply_diagnostics()["reason"] == "service_restart_failed"
+
+
+def test_missing_restart_token_before_a_noop_fails_closed(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    reads = 0
+    run = eq._runner
+
+    def missing_before(argv, timeout=8):
+        nonlocal reads
+        if argv == [
+            "systemctl",
+            "--user",
+            "show",
+            "filter-chain.service",
+            "--property=InvocationID",
+            "--property=MainPID",
+            "--value",
+        ]:
+            reads += 1
+            if reads == 1:
+                fake.calls.append(argv)
+                return ""
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = missing_before
+
+    assert eq._restart() is False
+
+
+def test_restart_retry_budget_is_finite_for_an_unchanged_request(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    run = eq._runner
+
+    def fail_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return "failed"
+        return run(argv, timeout)
+
+    eq._runner = fail_restart
+
+    for _ in range(10):
+        assert eq.ensure_sink([3] * 10) is False
+        now["value"] += 120
+
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == 3
+    assert eq.apply_diagnostics()["reason"] == "service_restart_retry_exhausted"
+
+    restarts = fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    )
+
+    def lose_service_readback(argv, timeout=8):
+        if argv[:3] == ["systemctl", "--user", "show"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = lose_service_readback
+    assert eq.ensure_sink([3] * 10) is False
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == restarts
+
+
+def test_default_confirmation_failure_has_one_finite_retry_budget(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    run = eq._runner
+
+    def reject_eq_default(argv, timeout=8):
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = reject_eq_default
+
+    for _ in range(10):
+        assert eq.ensure_sink([0] * 10) is False
+        now["value"] += 120
+
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == 1
+    assert sum(
+        call[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]
+        for call in fake.calls
+    ) == 15
+    assert eq.apply_diagnostics()["reason"] == "default_sink_retry_exhausted"
+
+
+def test_link_readback_failure_does_not_restart_same_config_repeatedly(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    eq._sleep = lambda _delay: None
+    run = eq._runner
+
+    def hide_links(argv, timeout=8):
+        if argv == ["pw-link", "-l"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = hide_links
+
+    assert eq.ensure_sink([0] * 10) is False
+    restarts = fake.calls.count(["systemctl", "--user", "restart", "filter-chain.service"])
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == restarts
+
+
+def test_support_requires_pw_link_for_route_readback(monkeypatch):
+    monkeypatch.setattr(pipewire, "filter_chain_module", lambda: "/lib/filter-chain.so")
+    monkeypatch.setattr(pipewire, "resolve_bin", lambda name: name)
+    monkeypatch.setattr(pipewire.shutil, "which", lambda _name: None)
+    eq = PipeWireEq(runner=_FakeRunner(), name="X")
+    eq._session = (1000, "/run/user/1000", "deck")
+
+    assert eq.is_supported() is False
+
+
+def test_support_accepts_tools_resolved_outside_the_process_path(monkeypatch):
+    monkeypatch.setattr(pipewire, "filter_chain_module", lambda: "/lib/filter-chain.so")
+    monkeypatch.setattr(pipewire, "resolve_bin", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(pipewire.shutil, "which", lambda _name: None)
+    eq = PipeWireEq(runner=_FakeRunner(), name="X")
+    eq._session = (1000, "/run/user/1000", "deck")
+
+    assert eq.is_supported() is True
 
 
 def test_ensure_sink_refuses_to_enable_without_physical_downstream(tmp_path):
@@ -155,7 +1089,9 @@ def test_ensure_sink_requires_default_sink_readback(tmp_path):
     eq = _make_eq(tmp_path, fake, conf_exists=False)
 
     def ignore_default_change(argv, timeout=8):
-        if argv[:2] == ["pactl", "set-default-sink"]:
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
             fake.calls.append(argv)
             return ""
         return fake(argv, timeout)
@@ -169,21 +1105,26 @@ def test_ensure_sink_requires_default_sink_readback(tmp_path):
         "ok": False,
         "reason": "default_sink_not_confirmed",
         "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+        "rollback_confirmed": True,
     }
 
 
 def test_failed_first_enable_rolls_back_and_retry_preserves_volume(tmp_path):
     fake = _FakeRunner(downstream_vol="40%")
     eq = _make_eq(tmp_path, fake, conf_exists=False)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
     conf = eq._conf_path()
     eq._write_conf = lambda *a, **k: Path(conf).write_text("x") > 0
-    failures = {"remaining": 1}
+    block_default = {"enabled": True}
     run = eq._runner
 
     def fail_first_default_change(argv, timeout=8):
-        if argv[:3] == ["pactl", "set-default-sink", "X EQ"]:
-            if failures["remaining"]:
-                failures["remaining"] -= 1
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
+            if block_default["enabled"]:
                 fake.calls.append(argv)
                 return ""
         return run(argv, timeout)
@@ -192,6 +1133,8 @@ def test_failed_first_enable_rolls_back_and_retry_preserves_volume(tmp_path):
 
     assert eq.ensure_sink([0] * 10) is False
     assert not Path(conf).exists()
+    block_default["enabled"] = False
+    now["value"] += 16
     assert eq.ensure_sink([0] * 10) is True
 
     assert fake.volume_sets("X EQ") == [
@@ -202,6 +1145,52 @@ def test_failed_first_enable_rolls_back_and_retry_preserves_volume(tmp_path):
     ]
 
 
+def test_first_enable_restart_retry_still_carries_the_physical_volume(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    run = eq._runner
+
+    def fail_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return "failed"
+        return run(argv, timeout)
+
+    eq._runner = fail_restart
+    assert eq.ensure_sink([0] * 10) is False
+
+    eq._runner = run
+    now["value"] += 16
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "40%"],
+    ]
+
+
+def test_first_enable_volume_handoff_survives_a_process_restart(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    run = eq._runner
+
+    def fail_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return "failed"
+        return run(argv, timeout)
+
+    eq._runner = fail_restart
+    assert eq.ensure_sink([0] * 10) is False
+
+    recovered_fake = _FakeRunner(downstream_vol="100%")
+    recovered = _make_eq(tmp_path, recovered_fake, conf_exists=True)
+    assert recovered.ensure_sink([0] * 10) is True
+    assert recovered_fake.volume_sets("X EQ") == [
+        ["pactl", "set-sink-volume", "X EQ", "40%"],
+    ]
+
+
 def test_disable_after_failed_first_enable_does_not_change_physical_volume(tmp_path):
     fake = _FakeRunner(downstream_vol="40%")
     eq = _make_eq(tmp_path, fake, conf_exists=False)
@@ -209,7 +1198,9 @@ def test_disable_after_failed_first_enable_does_not_change_physical_volume(tmp_p
     eq._write_conf = lambda *a, **k: Path(conf).write_text("x") > 0
 
     def ignore_default_change(argv, timeout=8):
-        if argv[:2] == ["pactl", "set-default-sink"]:
+        if argv[:5] == [
+            "pw-metadata", "-n", "default", "0", "default.audio.sink"
+        ]:
             fake.calls.append(argv)
             return ""
         return fake(argv, timeout)
@@ -239,6 +1230,16 @@ def test_active_state_drops_when_downstream_disappears(tmp_path):
     }
 
 
+def test_active_state_drops_when_eq_output_is_linked_to_another_sink(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    fake._link_target = "bluez_output.wrong"
+
+    assert eq.is_active() is False
+
+
 def test_failed_changed_curve_invalidates_previous_active_state(tmp_path):
     fake = _FakeRunner()
     eq = _make_eq(tmp_path, fake, conf_exists=False)
@@ -248,9 +1249,233 @@ def test_failed_changed_curve_invalidates_previous_active_state(tmp_path):
     assert eq.ensure_sink([3] * 10) is False
 
     assert eq.is_active() is False
+    assert fake._default == "alsa_speaker"
     assert eq.apply_diagnostics() == {
         "ok": False,
         "reason": "config_write_failed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+    }
+
+
+def test_config_write_exception_bypasses_the_previous_eq(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk unavailable")
+
+    eq._write_conf = fail_write
+
+    assert eq.ensure_sink([3] * 10) is False
+
+    assert fake._default == "alsa_speaker"
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "config_write_failed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+        "error": "OSError",
+    }
+
+
+def test_interrupted_first_config_write_is_safe_across_process_restart(
+    tmp_path, monkeypatch
+):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    eq._write_conf = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+    replace = os.replace
+    attempts = 0
+
+    def interrupt_first_replace(source, destination, *args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("interrupted write")
+        return replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", interrupt_first_replace)
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert not os.path.exists(eq._conf_path())
+    assert not os.path.exists(f"{eq._conf_path()}.pending")
+    assert fake._default == "alsa_speaker"
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=False)
+    recovered._write_conf = PipeWireEq._write_conf.__get__(recovered, PipeWireEq)
+    assert recovered.ensure_sink([0] * 10) is True
+    assert fake.volume_sets("X EQ")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "X EQ",
+        "40%",
+    ]
+
+
+def test_first_enable_volume_survives_a_crash_after_config_publish(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    real_write = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    def crash_after_publish(*args, **kwargs):
+        assert real_write(*args, **kwargs) is True
+        raise RuntimeError("process terminated")
+
+    eq._write_conf = crash_after_publish
+
+    crashed = False
+    try:
+        eq.ensure_sink([0] * 10)
+    except RuntimeError:
+        crashed = True
+    assert crashed is True
+    assert os.path.exists(eq._conf_path())
+    assert os.path.exists(f"{eq._conf_path()}.first-enable-pending")
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+    assert recovered.ensure_sink([0] * 10) is True
+    assert fake.volume_sets("X EQ")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "X EQ",
+        "40%",
+    ]
+    assert not os.path.exists(f"{eq._conf_path()}.first-enable-pending")
+
+
+def test_first_enable_rejects_a_crash_marker_from_another_output(tmp_path):
+    fake = _FakeRunner(
+        downstream_vol={"alsa_speaker": "40%", "alsa_output.hdmi": "20%"}
+    )
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    real_write = PipeWireEq._write_conf.__get__(eq, PipeWireEq)
+
+    def change_output_and_crash(*args, **kwargs):
+        assert real_write(*args, **kwargs) is True
+        fake._default = "alsa_output.hdmi"
+        raise RuntimeError("process terminated")
+
+    eq._write_conf = change_output_and_crash
+
+    try:
+        eq.ensure_sink([0] * 10)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected simulated process termination")
+
+    recovered = _make_eq(tmp_path, fake, conf_exists=True)
+    assert recovered.ensure_sink([0] * 10) is True
+    assert fake.volume_sets("X EQ")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "X EQ",
+        "20%",
+    ]
+
+
+def test_failed_config_removal_keeps_the_route_scoped_volume_marker(
+    tmp_path, monkeypatch
+):
+    fake = _FakeRunner(
+        downstream_vol={"alsa_speaker": "40%", "alsa_output.hdmi": "20%"}
+    )
+    fake._sinks = (
+        "1\talsa_speaker\tPipeWire\t...\tRUNNING\n"
+        "2\talsa_output.hdmi\tPipeWire\t...\tIDLE\n"
+    )
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    conf_path = eq._conf_path()
+    writes = 0
+
+    def write_and_change_output(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        Path(conf_path).write_text("x")
+        fake._configured_target = kwargs.get("downstream") or args[-1]
+        if writes == 1:
+            fake._default = "alsa_output.hdmi"
+        return True
+
+    eq._write_conf = write_and_change_output
+    remove_entry = eq._remove_entry
+
+    def reject_config_removal(path):
+        if path == conf_path:
+            return False
+        return remove_entry(path)
+
+    monkeypatch.setattr(eq, "_remove_entry", reject_config_removal)
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert os.path.exists(conf_path)
+    assert os.path.exists(f"{conf_path}.first-enable-pending")
+
+    assert eq.ensure_sink([0] * 10) is True
+    assert fake.volume_sets("X EQ")[-1] == [
+        "pactl",
+        "set-sink-volume",
+        "X EQ",
+        "20%",
+    ]
+
+
+def test_marker_cleanup_failure_bypasses_eq_until_cleanup_can_retry(
+    tmp_path, monkeypatch
+):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    marker_path = f"{eq._conf_path()}.first-enable-pending"
+    remove_entry = eq._remove_entry
+
+    def reject_marker_removal(path):
+        if path == marker_path:
+            return False
+        return remove_entry(path)
+
+    monkeypatch.setattr(eq, "_remove_entry", reject_marker_removal)
+
+    assert eq.ensure_sink([0] * 10) is False
+    assert fake._default == "alsa_speaker"
+    assert os.path.exists(marker_path)
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "pending_marker_cleanup_failed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+    }
+
+    monkeypatch.setattr(eq, "_remove_entry", remove_entry)
+    now["value"] += 120
+    assert eq.ensure_sink([0] * 10) is True
+    assert not os.path.exists(marker_path)
+
+
+def test_config_write_failure_has_one_finite_retry_budget(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    writes = []
+    eq._write_conf = lambda *_args, **_kwargs: writes.append(True) and False
+
+    for _ in range(10):
+        assert eq.ensure_sink([3] * 10) is False
+        now["value"] += 120
+
+    assert len(writes) == 3
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "config_write_retry_exhausted",
         "downstream": "alsa_speaker",
     }
 
@@ -273,6 +1498,144 @@ def test_disable_after_failed_reapply_restores_owned_eq_volume(tmp_path):
     assert fake._default == "alsa_speaker"
 
 
+def test_teardown_failure_bypasses_eq_and_retains_state_for_cleanup_retry(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    run = eq._runner
+
+    def ignore_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_restart
+
+    assert eq.teardown() is False
+    assert fake._default == "alsa_speaker"
+    assert eq._orig_default == "alsa_speaker"
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "teardown_restart_failed",
+        "downstream": "alsa_speaker",
+        "bypass_confirmed": True,
+    }
+
+
+def test_teardown_cleans_a_persisted_eq_from_a_fresh_process(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    fake._default = "X EQ"
+    fake._configured_default = "alsa_speaker"
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+
+    assert eq.teardown() is True
+    assert fake._default == "alsa_speaker"
+    assert "\tX EQ\t" not in fake._sinks
+
+
+def test_teardown_removes_an_orphan_eq_sink_without_a_config_file(tmp_path):
+    fake = _FakeRunner()
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tIDLE\n"
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+
+    assert eq.teardown() is True
+    assert fake.calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == 1
+    assert "\tX EQ\t" not in fake._sinks
+
+
+def test_orphan_cleanup_retries_after_the_config_was_removed(tmp_path):
+    fake = _FakeRunner(downstream_vol="40%")
+    fake._default = "X EQ"
+    fake._configured_default = "alsa_speaker"
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    eq = _make_eq(tmp_path, fake, conf_exists=True)
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    run = eq._runner
+
+    def ignore_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "restart", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = ignore_restart
+    assert eq.teardown() is False
+    assert fake._default == "alsa_speaker"
+
+    eq._runner = run
+    now["value"] += 16
+    assert eq.teardown() is True
+    assert "\tX EQ\t" not in fake._sinks
+
+
+def test_teardown_retry_budget_is_finite(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    now = {"value": 100.0}
+    eq._monotonic = lambda: now["value"]
+    run = eq._runner
+    checkpoint = len(fake.calls)
+
+    def fail_restart(argv, timeout=8):
+        if argv == ["systemctl", "--user", "is-active", "filter-chain.service"]:
+            fake.calls.append(argv)
+            return "failed"
+        return run(argv, timeout)
+
+    eq._runner = fail_restart
+
+    for _ in range(10):
+        assert eq.teardown() is False
+        now["value"] += 120
+
+    calls = fake.calls[checkpoint:]
+    assert calls.count(
+        ["systemctl", "--user", "restart", "filter-chain.service"]
+    ) == 3
+    assert eq.apply_diagnostics()["reason"] == "teardown_retry_exhausted"
+
+
+def test_teardown_rejects_a_restarted_service_that_still_exposes_eq_sink(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    fake._sinks += "3\tX EQ\tPipeWire\t...\tRUNNING\n"
+    fake._keep_eq_on_restart = True
+    eq._sleep = lambda _delay: None
+
+    assert eq.teardown() is False
+    assert eq.apply_diagnostics()["reason"] == "teardown_sink_still_present"
+
+
+def test_teardown_does_not_publish_success_without_default_handoff(tmp_path):
+    fake = _FakeRunner()
+    eq = _make_eq(tmp_path, fake, conf_exists=False)
+    assert eq.ensure_sink([0] * 10) is True
+    run = eq._runner
+
+    def reject_physical_default(argv, timeout=8):
+        if argv == ["pactl", "set-default-sink", "alsa_speaker"]:
+            fake.calls.append(argv)
+            return ""
+        return run(argv, timeout)
+
+    eq._runner = reject_physical_default
+
+    assert eq.teardown() is False
+    assert eq._orig_default == "alsa_speaker"
+    assert eq.apply_diagnostics() == {
+        "ok": False,
+        "reason": "teardown_default_not_confirmed",
+        "downstream": "alsa_speaker",
+    }
+
+
 _PW_LINK = """effect_output.pdc_eq:output_FL
   |-> alsa_loopback_device.alsa_output.pci-0000_c2_00.6.analog-stereo:playback_FL
 alsa_output.pci-0000_c2_00.6.analog-stereo:playback_FL
@@ -280,6 +1643,25 @@ alsa_output.pci-0000_c2_00.6.analog-stereo:playback_FL
 some_unrelated_node:port
   |-> another_unrelated:in
 """
+
+
+def test_link_reaches_requires_the_eq_output_to_reach_the_expected_sink():
+    assert _link_reaches(
+        _PW_LINK,
+        "effect_output.pdc_eq",
+        "alsa_loopback_device.alsa_output.pci-0000_c2_00.6.analog-stereo",
+    )
+    assert not _link_reaches(_PW_LINK, "effect_output.pdc_eq", "bluez_output.headset")
+
+
+def test_linked_downstream_returns_only_a_current_physical_candidate():
+    candidates = [
+        "alsa_loopback_device.alsa_output.pci-0000_c2_00.6.analog-stereo",
+        "bluez_output.headset",
+    ]
+
+    assert _linked_downstream(_PW_LINK, "effect_output.pdc_eq", candidates) == candidates[0]
+    assert _linked_downstream(_PW_LINK, "effect_output.pdc_eq", [candidates[1]]) is None
 
 
 def test_relevant_links_keeps_eq_and_hardware_drops_noise():

--- a/tests/test_audio_route.py
+++ b/tests/test_audio_route.py
@@ -34,3 +34,31 @@ def test_route_of_sink_reads_the_named_sinks_port():
 def test_route_of_sink_defaults_to_speaker_when_sink_absent():
     assert route_of_sink(_MULTI_SINKS, "nonexistent") == "speaker"
     assert route_of_sink(_MULTI_SINKS, None) == "speaker"
+
+
+def test_route_of_sink_uses_sink_name_when_active_port_is_missing():
+    sinks = """Sink #91
+\tName: bluez_output.00_11_22_33_44_55.1
+\tDescription: WH-1000XM4
+"""
+
+    assert route_of_sink(sinks, "bluez_output.00_11_22_33_44_55.1") == "headphone"
+
+
+def test_route_of_sink_uses_description_when_active_port_is_missing():
+    sinks = """Sink #92
+\tName: alsa_output.pci-0000_64_00.1.pro-output-3
+\tDescription: HDMI / DisplayPort 4 Output
+"""
+
+    assert route_of_sink(sinks, "alsa_output.pci-0000_64_00.1.pro-output-3") == "headphone"
+
+
+def test_route_of_sink_keeps_usb_external_when_port_name_is_generic_analog():
+    sinks = """Sink #93
+\tName: alsa_output.usb-DAC.analog-stereo
+\tDescription: USB Audio
+\tActive Port: analog-output
+"""
+
+    assert route_of_sink(sinks, "alsa_output.usb-DAC.analog-stereo") == "headphone"

--- a/tests/test_audio_rpc.py
+++ b/tests/test_audio_rpc.py
@@ -56,6 +56,7 @@ class _FakePipeWireEq:
 
     def teardown(self):
         self.torn_down += 1
+        return True
 
 
 def _make_plugin(tmp_path, monkeypatch, audio=None):
@@ -166,6 +167,26 @@ def test_audio_apply_exception_is_preserved_in_state(tmp_path, monkeypatch):
     }
 
 
+def test_apply_exception_is_not_hidden_by_stale_backend_diagnostics(tmp_path, monkeypatch):
+    class StaleDiagnostics(_FakePipeWireEq):
+        def apply_diagnostics(self):
+            return {"ok": True}
+
+    p, _fake = _make_plugin(
+        tmp_path,
+        monkeypatch,
+        audio=StaleDiagnostics(raise_apply=True),
+    )
+
+    state = asyncio.run(p.set_audio_enabled(True))
+
+    assert state["last_apply"] == {
+        "ok": False,
+        "reason": "exception",
+        "error": "RuntimeError",
+    }
+
+
 def test_audio_watcher_retries_inactive_eq_on_unchanged_route(tmp_path, monkeypatch):
     async def scenario():
         p, fake = _make_plugin(
@@ -193,12 +214,100 @@ def test_audio_watcher_retries_inactive_eq_on_unchanged_route(tmp_path, monkeypa
     assert asyncio.run(scenario()) == [True]
 
 
+def test_audio_watcher_cleans_runtime_when_required_tools_disappear(tmp_path, monkeypatch):
+    async def scenario():
+        p, fake = _make_plugin(
+            tmp_path,
+            monkeypatch,
+            audio=_FakePipeWireEq(supported=False),
+        )
+        await p.get_audio_state()
+        p._settings["audio_eq_enabled"] = True
+        sleeps = 0
+
+        async def one_iteration(_delay):
+            nonlocal sleeps
+            sleeps += 1
+            if sleeps > 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", one_iteration)
+        await p._audio_loop()
+        return fake.torn_down
+
+    assert asyncio.run(scenario()) == 1
+
+
+def test_audio_watcher_replaces_a_failed_teardown_with_its_recovery(tmp_path, monkeypatch):
+    class RecoveringTeardown(_FakePipeWireEq):
+        def __init__(self):
+            super().__init__()
+            self._diagnostics = {"ok": False, "reason": "teardown_restart_failed"}
+
+        def teardown(self):
+            self.torn_down += 1
+            self._diagnostics = {"ok": True, "operation": "teardown"}
+            return True
+
+        def apply_diagnostics(self):
+            return self._diagnostics
+
+    async def scenario():
+        p, _fake = _make_plugin(tmp_path, monkeypatch, audio=RecoveringTeardown())
+        await p.get_audio_state()
+        p._settings["audio_eq_enabled"] = False
+        p._audio_last_apply = {"ok": False, "reason": "teardown_restart_failed"}
+        sleeps = 0
+
+        async def one_iteration(_delay):
+            nonlocal sleeps
+            sleeps += 1
+            if sleeps > 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", one_iteration)
+        await p._audio_loop()
+        return await p.get_audio_state()
+
+    state = asyncio.run(scenario())
+    assert state["last_apply"] == {"ok": True, "operation": "teardown"}
+
+
 def test_disable_tears_down(tmp_path, monkeypatch):
     p, fake = _make_plugin(tmp_path, monkeypatch)
     asyncio.run(p.set_audio_enabled(True))
     st = asyncio.run(p.set_audio_enabled(False))
     assert st["enabled"] is False
     assert fake.torn_down >= 1
+
+
+def test_disable_reports_a_teardown_failure_instead_of_the_previous_apply(tmp_path, monkeypatch):
+    class TeardownFailure(_FakePipeWireEq):
+        def __init__(self):
+            super().__init__()
+            self._teardown_diagnostics = None
+
+        def teardown(self):
+            self.torn_down += 1
+            self._teardown_diagnostics = {
+                "ok": False,
+                "reason": "teardown_restart_failed",
+            }
+            return False
+
+        def apply_diagnostics(self):
+            return self._teardown_diagnostics or super().apply_diagnostics()
+
+    p, _fake = _make_plugin(tmp_path, monkeypatch, audio=TeardownFailure())
+    asyncio.run(p.set_audio_enabled(True))
+
+    state = asyncio.run(p.set_audio_enabled(False))
+
+    assert state["enabled"] is False
+    assert state["last_apply"] == {
+        "ok": False,
+        "reason": "teardown_restart_failed",
+    }
 
 
 def test_apply_preset_persists(tmp_path, monkeypatch):
@@ -220,6 +329,18 @@ def test_set_bands_replaces_all(tmp_path, monkeypatch):
     st = asyncio.run(p.set_audio_bands([2] * 10, "global"))
     assert st["gains"] == [2.0] * 10
     assert st["preset"] == "custom"
+
+
+def test_stale_route_commit_does_not_overwrite_the_new_output_profile(tmp_path, monkeypatch):
+    p, fake = _make_plugin(tmp_path, monkeypatch)
+
+    st = asyncio.run(
+        p.set_audio_bands([8] * 10, "global", expected_route="headphone")
+    )
+
+    assert st["route"] == "speaker"
+    assert st["gains"] == [0.0] * 10
+    assert p._audio_eq.effective(None, "headphone")["gains"] == [0.0] * 10
 
 
 def test_set_curve_sets_gains_and_bass_together(tmp_path, monkeypatch):

--- a/tests/test_audio_rpc.py
+++ b/tests/test_audio_rpc.py
@@ -238,6 +238,28 @@ def test_audio_watcher_cleans_runtime_when_required_tools_disappear(tmp_path, mo
     assert asyncio.run(scenario()) == 1
 
 
+def test_audio_watcher_does_not_repeat_confirmed_cleanup_when_disabled(
+    tmp_path, monkeypatch
+):
+    async def scenario():
+        p, fake = _make_plugin(tmp_path, monkeypatch)
+        await p.get_audio_state()
+        p._settings["audio_eq_enabled"] = False
+        sleeps = 0
+
+        async def three_iterations(_delay):
+            nonlocal sleeps
+            sleeps += 1
+            if sleeps > 3:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", three_iterations)
+        await p._audio_loop()
+        return fake.torn_down
+
+    assert asyncio.run(scenario()) == 1
+
+
 def test_audio_watcher_replaces_a_failed_teardown_with_its_recovery(tmp_path, monkeypatch):
     class RecoveringTeardown(_FakePipeWireEq):
         def __init__(self):

--- a/tests/test_audio_rpc.py
+++ b/tests/test_audio_rpc.py
@@ -21,6 +21,7 @@ class _FakePipeWireEq:
         self._raise_apply = raise_apply
         self.applied = []
         self.torn_down = 0
+        self.synced = 0
 
     def is_supported(self):
         return self._supported
@@ -44,6 +45,10 @@ class _FakePipeWireEq:
 
     def is_active(self):
         return self._apply_ok
+
+    def sync_state(self):
+        self.synced += 1
+        return True
 
     def start_test(self, path):
         self._playing = True
@@ -212,6 +217,27 @@ def test_audio_watcher_retries_inactive_eq_on_unchanged_route(tmp_path, monkeypa
         return reapplies
 
     assert asyncio.run(scenario()) == [True]
+
+
+def test_audio_watcher_syncs_active_ownership_state(tmp_path, monkeypatch):
+    async def scenario():
+        p, fake = _make_plugin(tmp_path, monkeypatch)
+        await p.get_audio_state()
+        p._settings["audio_eq_enabled"] = True
+        p._audio_route_last = "speaker"
+        sleeps = 0
+
+        async def one_iteration(_delay):
+            nonlocal sleeps
+            sleeps += 1
+            if sleeps > 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", one_iteration)
+        await p._audio_loop()
+        return fake.synced
+
+    assert asyncio.run(scenario()) == 1
 
 
 def test_audio_watcher_cleans_runtime_when_required_tools_disappear(tmp_path, monkeypatch):

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -142,6 +142,12 @@ def test_redact_text_keeps_device_names():
     assert redact_text("Steam Deck OLED") == "Steam Deck OLED"
 
 
+def test_redact_text_scrubs_bluez_mac_with_underscore_separators():
+    out = redact_text("bluez_output.AA_BB_CC_DD_EE_FF.1")
+
+    assert out == "bluez_output.[mac].1"
+
+
 def test_redact_text_scrubs_labeled_serials():
     # DMI/dmesg serial lines: keep the label for context, drop the value.
     out = redact_text("board_serial: ABCD1234EFGH")
@@ -173,6 +179,12 @@ def test_redact_obj_scrubs_serial_like_keys():
     assert out["product_serial"] == "[redacted]"
     assert out["board_uuid"] == "[redacted]"
     assert out["model"] == "Ally"
+
+
+def test_redact_obj_scrubs_session_username_keys():
+    out = redact_obj({"audio": {"session": {"user": "alice", "uid": 1000}}})
+
+    assert out == {"audio": {"session": {"user": "[redacted]", "uid": 1000}}}
 
 
 def test_redact_obj_recurses_and_redacts_paths():


### PR DESCRIPTION
## Español

Corrige el enrutado del ecualizador cuando cambia la salida física entre altavoces, auriculares, Bluetooth, USB y HDMI.

- Distingue el sink efectivo, la salida configurada por WirePlumber y el enlace real del filtro; `target.object` siempre sigue el destino confirmado.
- Usa `pactl` con readback estable para cambiar el default y mantiene `pw-metadata` como fuente opcional de solo lectura, evitando dependencias entre versiones de SteamOS, Bazzite, PipeWire y WirePlumber.
- Persiste antes de cada reinicio o handoff un journal de ownership con volumen, mute, snapshot físico y restauraciones pendientes.
- Recupera de forma segura tras crash, suspensión, reinicio del filter-chain, desconexión y reconexión de salidas, sin dejar dispositivos anteriores al 100 % o desmuteados.
- Conserva el estado del usuario durante bypass y teardown, y falla de forma cerrada si falta cualquier readback o el destino es ambiguo.
- Endurece la configuración local frente a symlinks, FIFO, ownership incorrecto y archivos sobredimensionados, manteniendo el layout `/home` → `/var/home` de Bazzite.
- Elimina identificadores BlueZ y nombres de usuario de los reportes de diagnóstico.

## English

Fixes EQ routing when the physical output changes between speakers, headphones, Bluetooth, USB, and HDMI.

- Separates the effective sink, WirePlumber's configured output, and the filter's actual link; `target.object` always follows the confirmed destination.
- Uses `pactl` with stable readback for default changes and keeps `pw-metadata` as an optional read-only signal, avoiding version-specific dependencies across SteamOS, Bazzite, PipeWire, and WirePlumber.
- Persists an ownership journal with volume, mute, physical snapshots, and pending restores before every restart or handoff.
- Recovers safely from crashes, suspend, filter-chain restarts, disconnects, and reconnects without leaving previous devices at 100% or unmuted.
- Preserves user state during bypass and teardown, and fails closed when any readback is missing or the destination is ambiguous.
- Hardens local configuration against symlinks, FIFOs, incorrect ownership, and oversized files while preserving Bazzite's `/home` → `/var/home` layout.
- Removes BlueZ identifiers and usernames from diagnostic reports.

## Italiano

Corregge il routing dell'equalizzatore quando l'uscita fisica cambia tra altoparlanti, cuffie, Bluetooth, USB e HDMI.

- Distingue il sink effettivo, l'uscita configurata da WirePlumber e il collegamento reale del filtro; `target.object` segue sempre la destinazione confermata.
- Usa `pactl` con readback stabile per cambiare l'uscita predefinita e mantiene `pw-metadata` come segnale opzionale di sola lettura, evitando dipendenze specifiche tra versioni di SteamOS, Bazzite, PipeWire e WirePlumber.
- Salva prima di ogni riavvio o handoff un journal di ownership con volume, mute, snapshot fisico e ripristini pendenti.
- Recupera in sicurezza dopo crash, sospensione, riavvio del filter-chain, disconnessione e riconnessione delle uscite, senza lasciare dispositivi precedenti al 100% o senza mute.
- Conserva lo stato dell'utente durante bypass e teardown e fallisce in modo sicuro se manca un readback o la destinazione è ambigua.
- Protegge la configurazione locale da symlink, FIFO, ownership errata e file troppo grandi, mantenendo il layout `/home` → `/var/home` di Bazzite.
- Rimuove identificatori BlueZ e nomi utente dai report diagnostici.

## Validación / Validation / Validazione

- Backend: 2062 passed, 1 skipped, 55 subtests passed.
- Frontend: 652 passed; TypeScript, Ruff, build y diff-check correctos.
- SteamOS: snapshot exacto validado físicamente en MSI Claw 8 AI+, ROG Xbox Ally X y Legion Go S con audio real, enlace confirmado, volumen/mute, configuración 0600, estabilidad, teardown, restauración e idempotencia.
- Bazzite: cobertura sintética capability-first y fallo cerrado; sin validación física en esta revisión.

Fixes #310
Fixes #381
Fixes #393
Fixes #406
Fixes #458
