### PR TITLE
fix: confirm asynchronous TDP readback on Legion Go S 83L3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sin publicar / Unreleased / Non pubblicato
+
+### Español
+
+* **TDP:** Corrige falsos rechazos del TDP manual en Lenovo Legion Go S 83L3 mientras el firmware actualiza PL1, PL2 y PL3 de forma asíncrona. Panel de Control confirma el readback durante una ventana acotada sin repetir escrituras y conserva el fallo real si los límites no convergen. Las demás variantes y backends mantienen su ruta anterior.
+
+### English
+
+* **TDP:** Fixes false manual TDP rejections on the Lenovo Legion Go S 83L3 while the firmware updates PL1, PL2, and PL3 asynchronously. Panel de Control confirms readback within a bounded window without repeating writes and preserves the real failure if the limits do not converge. Other variants and backends keep their previous path.
+
+### Italiano
+
+* **TDP:** Corregge i falsi rifiuti del TDP manuale su Lenovo Legion Go S 83L3 mentre il firmware aggiorna PL1, PL2 e PL3 in modo asincrono. Panel de Control conferma il readback entro una finestra limitata senza ripetere le scritture e conserva l'errore reale se i limiti non convergono. Le altre varianti e gli altri backend mantengono il percorso precedente.
+
 ## [0.37.4](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.3...panel-de-control-v0.37.4) (2026-08-17)
 
 

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -25,6 +25,16 @@ def is_legion_go_s_83n6(device, root: str = "/") -> bool:
     )
 
 
+def legion_go_s_83l3_firmware_attr_quirks(device, root: str = "/") -> dict:
+    if (
+        getattr(device, "key", None) != "legion_go_s"
+        or _read_dmi(root, "sys_vendor").casefold() != "lenovo"
+        or _read_dmi(root, "product_name").casefold() != "83l3"
+    ):
+        return {}
+    return {"readback_settle_delays": (0.05, 0.10, 0.20, 0.40)}
+
+
 def legion_go_s_83n6_rail_floors(device, root: str = "/") -> dict[str, int]:
     if is_legion_go_s_83n6(device, root):
         return {"pl2": 15, "pl3": 20}

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -1,5 +1,6 @@
 from device_quirks import (
     is_gpd_win_mini_2025,
+    legion_go_s_83l3_firmware_attr_quirks,
     legion_go_s_83n6_firmware_attr_quirks,
     legion_go_s_83n6_rail_floors,
 )
@@ -34,6 +35,7 @@ def _candidates(device, fallback, root, ryzenadj):
             profile_name="lenovo-wmi-gamezone",
             is_generic=generic,
             rail_floors=legion_go_s_83n6_rail_floors(device, root),
+            **legion_go_s_83l3_firmware_attr_quirks(device, root),
             **legion_go_s_83n6_firmware_attr_quirks(device, root),
         )
 

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import time
 
 from sysfs import read_str
 from tdp.backend import TDPBackend
@@ -71,6 +72,7 @@ class FirmwareAttrBackend(TDPBackend):
         rail_floors=None,
         ignored_live_maxes=None,
         cap_boost_to_active=False,
+        readback_settle_delays=None,
     ):
         self.name = f"firmware-attr:{driver_prefix}"
         self._fallback = fallback
@@ -80,6 +82,9 @@ class FirmwareAttrBackend(TDPBackend):
         self._rail_floors = _normalise_rail_floors(rail_floors)
         self._ignored_live_maxes = _normalise_rail_values(ignored_live_maxes)
         self.cap_boost_to_active = bool(cap_boost_to_active)
+        self._readback_settle_delays = tuple(
+            float(delay) for delay in (readback_settle_delays or ())
+        )
         self._dir = self._find_driver_dir(driver_prefix)
         self.supported = self._dir is not None and os.path.exists(self._attr("ppt_pl1_spl"))
         self._pp_dir = self._find_profile_dir()  # static, resolved once
@@ -287,6 +292,16 @@ class FirmwareAttrBackend(TDPBackend):
         failed.extend(self._write_legacy(targets))
         observation = self.observe()
         mismatches = self._observation_mismatches(observation, targets)
+        if not failed:
+            for delay in self._readback_settle_delays:
+                if not mismatches:
+                    break
+                time.sleep(delay)
+                observation = self.observe()
+                mismatches = self._observation_mismatches(
+                    observation,
+                    targets,
+                )
         applied = observation.surfaces.get(self.name, {}).get("pl1")
         applied_w = applied.applied_w if applied else None
         problems = failed + mismatches
@@ -344,6 +359,9 @@ class FirmwareAttrBackend(TDPBackend):
         return {
             "boost_capped_to_active": self.cap_boost_to_active,
             "ignored_live_maxes": dict(self._ignored_live_maxes),
+            "readback_settle_ms": round(
+                sum(self._readback_settle_delays) * 1000
+            ),
             "reported_live_bounds": reported,
         }
 

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -6,6 +6,7 @@ from tdp import factory
 from tdp.backend import NullBackend
 from tdp.factory import select_backend
 from tdp.reconcile import build_targets
+from tdp.types import RailReading, TdpObservation
 
 
 def _p(key):
@@ -56,6 +57,19 @@ def _set_fw_max(root, rail, value):
         handle.write(str(value))
 
 
+def _observation(backend, pl1, pl2, pl3):
+    return TdpObservation(
+        readable=True,
+        surfaces={
+            backend.name: {
+                "pl1": RailReading(pl1),
+                "pl2": RailReading(pl2),
+                "pl3": RailReading(pl3),
+            },
+        },
+    )
+
+
 _NO_RYZENADJ = lambda: None  # noqa: E731
 
 
@@ -69,6 +83,7 @@ def test_rog_uses_asus_armoury_firmware_attr(tmp_path):
         "backend": "firmware-attr:asus-armoury",
         "supported": True,
     },)
+    assert b.diagnostics()["readback_settle_ms"] == 0
 
 
 def test_legion_uses_lenovo_firmware_attr(tmp_path):
@@ -76,6 +91,7 @@ def test_legion_uses_lenovo_firmware_attr(tmp_path):
     _mk_fw(root, "lenovo-wmi-other-0")
     b = select_backend(_p("legion_go_2"), root=root, ryzenadj_resolve=_NO_RYZENADJ)
     assert b.supported and "lenovo-wmi-other" in b.name
+    assert b.diagnostics()["readback_settle_ms"] == 0
 
 
 def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
@@ -99,6 +115,35 @@ def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
 
     assert getattr(exact, "_rail_floors", None) == {"pl2": 15, "pl3": 20}
     assert getattr(nearby, "_rail_floors", None) == {}
+
+
+def test_exact_legion_go_s_83l3_waits_for_async_firmware_readback(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0")
+    _mk_dmi(root, "LENOVO", "83L3")
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    stale = _observation(backend, 15, 15, 15)
+    original_observe = backend.observe
+    observations = iter((stale,))
+
+    def observe_after_firmware_settles():
+        return next(observations, None) or original_observe()
+
+    monkeypatch.setattr(backend, "observe", observe_after_firmware_settles)
+    monkeypatch.setattr("tdp.firmware_attr.time.sleep", lambda _delay: None)
+
+    result = backend.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 20
+    assert backend.diagnostics()["readback_settle_ms"] == 750
 
 
 def test_exact_legion_go_s_83n6_applies_profile_safe_target_despite_low_firmware_max(tmp_path):
@@ -179,6 +224,7 @@ def test_exact_legion_go_s_83n6_diagnostics_keep_reported_sentinel_max(tmp_path)
     assert backend.diagnostics() == {
         "boost_capped_to_active": True,
         "ignored_live_maxes": {"pl1": 15, "pl2": 15, "pl3": 20},
+        "readback_settle_ms": 0,
         "reported_live_bounds": {
             "pl1": {"min": 5, "max": 15},
             "pl2": {"min": 5, "max": 15},

--- a/tests/test_tdp_firmware_attr.py
+++ b/tests/test_tdp_firmware_attr.py
@@ -3,7 +3,7 @@ import inspect
 
 from device_registry import detect
 from tdp.firmware_attr import FirmwareAttrBackend
-from tdp.types import TdpLimits
+from tdp.types import RailReading, TdpLimits, TdpObservation
 
 FALLBACK = TdpLimits(min_w=4, default_w=15, max_w=30, max_ac_w=30)
 
@@ -20,6 +20,29 @@ def _mk_full(root, driver="lenovo-wmi-other-0"):
     _mk_attr(root, driver, "ppt_pl1_spl", 35, 5, 35)
     _mk_attr(root, driver, "ppt_pl2_sppt", 37, 5, 37)
     _mk_attr(root, driver, "ppt_pl3_fppt", 45, 5, 45)
+
+
+def _settling_backend(root, *delays):
+    _mk_full(root)
+    return FirmwareAttrBackend(
+        "lenovo-wmi-other",
+        FALLBACK,
+        root=root,
+        readback_settle_delays=delays,
+    )
+
+
+def _observation(backend, pl1, pl2, pl3):
+    return TdpObservation(
+        readable=True,
+        surfaces={
+            backend.name: {
+                "pl1": RailReading(pl1),
+                "pl2": RailReading(pl2),
+                "pl3": RailReading(pl3),
+            },
+        },
+    )
 
 
 def _mk_profile(root, name="lenovo-wmi-gamezone", cur="balanced",
@@ -74,6 +97,83 @@ def test_set_tdp_writes_pl1_and_reads_back(tmp_path):
     spl = open(os.path.join(root, "sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/ppt_pl1_spl/current_value")).read().strip()
     assert spl == "25"
     assert b.read_applied() == 25
+
+
+def test_set_levels_rechecks_async_readback_without_rewriting(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    b = _settling_backend(root, 0)
+    stale = _observation(b, 35, 37, 45)
+    original_observe = b.observe
+    observations = iter((stale,))
+
+    def observe_after_firmware_settles():
+        return next(observations, None) or original_observe()
+
+    writes = []
+    original_write = b._write
+
+    def record_write(path, value):
+        writes.append((path, value))
+        return original_write(path, value)
+
+    monkeypatch.setattr(b, "observe", observe_after_firmware_settles)
+    monkeypatch.setattr(b, "_write", record_write)
+
+    result = b.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 20
+    assert [
+        value
+        for path, value in writes
+        if path.endswith("current_value")
+    ] == [20, 20, 20]
+
+
+def test_set_levels_keeps_failure_when_async_readback_never_converges(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    b = _settling_backend(root, 0, 0)
+    stale = _observation(b, 35, 37, 45)
+    monkeypatch.setattr(b, "observe", lambda: stale)
+
+    result = b.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w == 35
+    assert f"{b.name}/pl1=35" in result.detail
+
+
+def test_set_levels_does_not_wait_after_a_write_error(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    b = _settling_backend(root, 0)
+    original_write = b._write
+    pl2_path = b._attr("ppt_pl2_sppt")
+
+    def reject_pl2(path, value):
+        return False if path == pl2_path else original_write(path, value)
+
+    observations = 0
+    original_observe = b.observe
+
+    def count_observations():
+        nonlocal observations
+        observations += 1
+        return original_observe()
+
+    monkeypatch.setattr(b, "_write", reject_pl2)
+    monkeypatch.setattr(b, "observe", count_observations)
+
+    result = b.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is False
+    assert observations == 1
+    assert f"{b.name}/pl2" in result.detail
 
 
 def test_set_tdp_clamps_to_profile_then_live_firmware(tmp_path):


### PR DESCRIPTION
## Español

Corrige falsos rechazos del TDP manual en Lenovo Legion Go S 83L3. El firmware actualiza los raíles de forma asíncrona, por lo que Panel de Control ahora confirma el readback durante una ventana acotada sin repetir escrituras. Los errores reales siguen siendo visibles y las demás máquinas conservan su comportamiento anterior.

## English

Fixes false manual TDP rejections on the Lenovo Legion Go S 83L3. The firmware updates its rails asynchronously, so Panel de Control now confirms readback within a bounded window without repeating writes. Real failures remain visible, while other devices retain their previous behavior.

## Italiano

Corregge i falsi rifiuti del TDP manuale su Lenovo Legion Go S 83L3. Il firmware aggiorna i limiti in modo asincrono, quindi Panel de Control ora conferma il readback entro una finestra limitata senza ripetere le scritture. Gli errori reali restano visibili e gli altri dispositivi mantengono il comportamento precedente.

Related to #379, #395, #438 and #347.