### PR TITLE
fix: evita pestañas y paneles duplicados en el QAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sin publicar / Unreleased / Non pubblicato
+
+### Español
+
+* **QAM:** Evita que Decky duplique iconos y paneles al recargar plugins o cambiar de pestaña. Panel de Control solo usa su acceso directo cuando Decky puede reconciliar las pestañas exactamente; en caso contrario, conserva el panel completo desde la entrada estándar de Decky. Los nuevos reportes incluyen conteos QAM acotados para distinguir pestañas duplicadas de problemas de layout. Este diagnóstico no incluye texto ni identificadores de las pestañas.
+
+### English
+
+* **QAM:** Prevents Decky from duplicating icons and panels when plugins reload or tabs change. Panel de Control uses its direct shortcut only when Decky can reconcile tabs exactly; otherwise, the full panel remains available through the standard Decky entry. New reports include bounded QAM counts to distinguish duplicate tabs from layout problems. These diagnostics contain no tab text or identifiers.
+
+### Italiano
+
+* **QAM:** Impedisce a Decky di duplicare icone e pannelli durante il ricaricamento dei plugin o il cambio di scheda. Panel de Control usa il proprio accesso diretto solo quando Decky riesce a riconciliare esattamente le schede; in caso contrario, il pannello completo resta disponibile dalla voce standard di Decky. I nuovi report includono conteggi QAM limitati per distinguere le schede duplicate dai problemi di layout. Questa diagnostica non include testo né identificatori delle schede.
+
 ## [0.37.5](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.4...panel-de-control-v0.37.5) (2026-08-17)
 
 ### Español

--- a/src/components/ReportModal.tsx
+++ b/src/components/ReportModal.tsx
@@ -7,16 +7,17 @@ import { getDevice, submitReport, DeviceInfo, ReportResult } from "../api";
 import {
   REPORT_CATEGORIES,
   ReportCategory,
+  buildReportContext,
   canSubmit,
-  displayReportContext,
   toggleCategory,
 } from "../report/logic";
 import { FocusRoot } from "./FocusRoot";
 import { launchReportContext } from "../launch/reportContext";
+import { quickAccessTabDiagnostics } from "../deckyInternal";
+import { getQamDocument } from "../qamDocument";
 
 type Phase = "form" | "sending" | "done" | "error";
 
-// One selectable category row: a checkbox box + label, accent-outlined when on.
 const CategoryChip: FC<{ label: string; on: boolean; onClick: () => void }> = ({
   label,
   on,
@@ -75,16 +76,17 @@ const ReportBody: FC<{ closeModal?: () => void }> = ({ closeModal }) => {
 
   const submit = async () => {
     setPhase("sending");
-    // Collect category-specific signals that exist only in the frontend.
     const launchContext = selected.includes("launch")
       ? await launchReportContext().catch(() => ({}))
       : {};
     const steamDisplay =
       typeof SteamClient === "undefined" ? undefined : SteamClient?.System?.Display;
-    const context = {
-      ...launchContext,
-      ...displayReportContext(selected, steamDisplay),
-    };
+    const context = buildReportContext(
+      selected,
+      steamDisplay,
+      launchContext,
+      quickAccessTabDiagnostics(window, getQamDocument()),
+    );
     submitReport(selected, text, context)
       .then((r) => {
         setResult(r);
@@ -101,9 +103,7 @@ const ReportBody: FC<{ closeModal?: () => void }> = ({ closeModal }) => {
     try {
       navigator.clipboard?.writeText(result.code);
       setCopied(true);
-    } catch {
-      /* clipboard may be unavailable in gamescope - ignore */
-    }
+    } catch {}
   };
 
   const wrap = (children: React.ReactNode) => (
@@ -183,7 +183,6 @@ const ReportBody: FC<{ closeModal?: () => void }> = ({ closeModal }) => {
     );
   }
 
-  // phase === "form"
   return wrap(
     <>
       <div style={{ fontSize: theme.font.body, color: theme.color.textMuted }}>
@@ -254,7 +253,6 @@ const ReportModal: FC<{ closeModal?: () => void }> = ({ closeModal }) => (
   </ModalRoot>
 );
 
-/** Open the full-screen "report a problem" flow. */
 export function openReportModal(): void {
   showModal(<ReportModal />, window);
 }

--- a/src/deckyInternal.test.ts
+++ b/src/deckyInternal.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   PDC_QAM_TAB_ID,
+  quickAccessTabDiagnostics,
   registerQuickAccessTab,
   removeOwnedQuickAccessTabs,
 } from "./deckyInternal";
 
 type FakeTab = Record<string, unknown> & { id: number };
+type RenderedTab = Record<string, unknown> & { decky?: boolean; key: number | string };
 
 function createHook() {
   const hook = {
@@ -17,8 +19,26 @@ function createHook() {
     removeById(id: number) {
       hook.tabs = hook.tabs.filter((tab) => tab.id !== id);
     },
+    render(this: { tabs: FakeTab[] }, existingTabs: RenderedTab[]) {
+      const nativeTabs = existingTabs.filter((tab) => !tab.decky);
+      existingTabs.splice(
+        0,
+        existingTabs.length,
+        ...nativeTabs,
+        ...this.tabs.map((tab) => ({ decky: true, key: tab.id })),
+      );
+    },
   };
   return hook;
+}
+
+function appendRegistryOnCountChange(
+  this: { tabs: FakeTab[] },
+  existingTabs: RenderedTab[],
+) {
+  const deckyTabCount = existingTabs.filter((tab) => tab.decky).length;
+  if (deckyTabCount === this.tabs.length) return;
+  existingTabs.push(...this.tabs.map((tab) => ({ decky: true, key: tab.id })));
 }
 
 describe("registerQuickAccessTab", () => {
@@ -46,6 +66,32 @@ describe("registerQuickAccessTab", () => {
     result.dispose();
 
     expect(hook.tabs.filter((tab) => tab.id === PDC_QAM_TAB_ID)).toHaveLength(0);
+  });
+
+  it("falls back when Decky appends the full registry after a tab count change", () => {
+    const hook = createHook();
+    hook.render = appendRegistryOnCountChange;
+
+    const result = registerQuickAccessTab(
+      { title: "Panel de Control", content: "panel", icon: "icon" },
+      { __TABS_HOOK_INSTANCE: hook },
+    );
+
+    expect(result.registered).toBe(false);
+    expect(hook.tabs.map((tab) => tab.id)).toEqual([999]);
+  });
+
+  it("does not remove a registered tab if Decky stops reconciling exactly", () => {
+    const hook = createHook();
+    const result = registerQuickAccessTab(
+      { title: "Panel de Control", content: "panel", icon: "icon" },
+      { __TABS_HOOK_INSTANCE: hook },
+    );
+    hook.render = appendRegistryOnCountChange;
+
+    result.dispose();
+
+    expect(hook.tabs.filter((tab) => tab.id === PDC_QAM_TAB_ID)).toHaveLength(1);
   });
 
   it("replaces its stale registration without allowing the stale disposer to remove the new one", () => {
@@ -182,6 +228,7 @@ describe("registerQuickAccessTab", () => {
       { __TABS_HOOK_INSTANCE: withoutDecky },
       { __TABS_HOOK_INSTANCE: { tabs: [{ id: 999 }], removeById() {} } },
       { __TABS_HOOK_INSTANCE: { tabs: [{ id: 999 }], add() {} } },
+      { __TABS_HOOK_INSTANCE: { tabs: [{ id: 999 }], add() {}, removeById() {} } },
     ];
 
     for (const host of hosts) {
@@ -189,5 +236,63 @@ describe("registerQuickAccessTab", () => {
       expect(result.registered).toBe(false);
       expect(() => result.dispose()).not.toThrow();
     }
+  });
+});
+
+describe("quickAccessTabDiagnostics", () => {
+  it("uses null counts when QAM internals are unavailable", () => {
+    expect(quickAccessTabDiagnostics({}, null)).toEqual({
+      hook_available: false,
+      registry_count: null,
+      registry_unique_count: null,
+      registry_decky_count: null,
+      registry_pdc_count: null,
+      qam_document_available: false,
+      qam_document_hidden: null,
+      rendered_count: null,
+      rendered_unique_count: null,
+      rendered_decky_count: null,
+      rendered_pdc_count: null,
+      panel_root_count: null,
+      visible_panel_root_count: null,
+    });
+  });
+
+  it("reports bounded QAM counts without exposing tab identifiers", () => {
+    const host = {
+      __TABS_HOOK_INSTANCE: {
+        tabs: [{ id: 999 }, { id: PDC_QAM_TAB_ID }, { id: PDC_QAM_TAB_ID }],
+      },
+    };
+    const visibleRoot = { getBoundingClientRect: () => ({ width: 320, height: 600 }) };
+    const hiddenRoot = { getBoundingClientRect: () => ({ width: 0, height: 0 }) };
+    const doc = {
+      hidden: false,
+      querySelectorAll(selector: string) {
+        if (selector === ".pdc-root") return [visibleRoot, hiddenRoot];
+        return [
+          { id: "quickaccess_tab_0" },
+          { id: "quickaccess_tab_999" },
+          { id: "quickaccess_tab_999" },
+          { id: `quickaccess_tab_${PDC_QAM_TAB_ID}` },
+        ];
+      },
+    };
+
+    expect(quickAccessTabDiagnostics(host, doc as unknown as Document)).toEqual({
+      hook_available: true,
+      registry_count: 3,
+      registry_unique_count: 2,
+      registry_decky_count: 1,
+      registry_pdc_count: 2,
+      qam_document_available: true,
+      qam_document_hidden: false,
+      rendered_count: 4,
+      rendered_unique_count: 3,
+      rendered_decky_count: 2,
+      rendered_pdc_count: 1,
+      panel_root_count: 2,
+      visible_panel_root_count: 1,
+    });
   });
 });

--- a/src/deckyInternal.ts
+++ b/src/deckyInternal.ts
@@ -1,10 +1,5 @@
 import type { ReactNode } from "react";
 
-// The one place that reaches INTERNAL Decky Loader globals
-// (`window.DeckyPluginLoader`, `window.DeckyBackend`) — NOT part of @decky/api.
-// Centralised + guarded so a Decky version that moves them degrades in one spot.
-// No @decky/ui import here so pure modules can consume it.
-
 export const PDC_QAM_TAB_ID = 0x504443;
 
 const PDC_QAM_TAB_OWNER = "panel-de-control";
@@ -21,10 +16,16 @@ interface DeckyQuickAccessTab extends QuickAccessTabView {
   __pdcOwner?: string;
 }
 
+interface RenderedQuickAccessTab {
+  decky?: boolean;
+  key: unknown;
+}
+
 interface DeckyTabsHook {
   tabs: DeckyQuickAccessTab[];
   add(tab: DeckyQuickAccessTab): void;
   removeById(id: number): void;
+  render(existingTabs: RenderedQuickAccessTab[], visible: boolean): void;
 }
 
 export interface QuickAccessTabRegistration {
@@ -45,6 +46,7 @@ function tabsHookOf(host: unknown): DeckyTabsHook | null {
     || !Array.isArray(hook.tabs)
     || typeof hook.add !== "function"
     || typeof hook.removeById !== "function"
+    || typeof hook.render !== "function"
     || !hook.tabs.some((tab) => tab?.id === DECKY_PLUGIN_TAB_ID)
   ) {
     return null;
@@ -60,10 +62,87 @@ function ownsQamTab(tab: DeckyQuickAccessTab): boolean {
   return tab.__pdcOwner === PDC_QAM_TAB_OWNER;
 }
 
+export function quickAccessTabDiagnostics(
+  host: unknown = window,
+  qamDocument: Document | null = null,
+) {
+  let hook: { tabs?: unknown } | null = null;
+  try {
+    const candidate = (host as { __TABS_HOOK_INSTANCE?: unknown } | null)
+      ?.__TABS_HOOK_INSTANCE;
+    if (candidate && typeof candidate === "object") hook = candidate;
+  } catch {}
+
+  const tabs = Array.isArray(hook?.tabs) ? hook.tabs : null;
+  const registryIds = tabs?.map((tab) => (
+    tab && typeof tab === "object" ? (tab as { id?: unknown }).id : undefined
+  )) ?? null;
+
+  let renderedIds: string[] | null = null;
+  let roots: Element[] | null = null;
+  try {
+    if (qamDocument) {
+      renderedIds = Array.from(
+        qamDocument.querySelectorAll<HTMLElement>("[id^='quickaccess_tab_']"),
+        (node) => node.id,
+      );
+      roots = Array.from(qamDocument.querySelectorAll(".pdc-root"));
+    }
+  } catch {}
+
+  return {
+    hook_available: hook !== null,
+    registry_count: registryIds?.length ?? null,
+    registry_unique_count: registryIds ? new Set(registryIds).size : null,
+    registry_decky_count: registryIds?.filter((id) => id === DECKY_PLUGIN_TAB_ID).length ?? null,
+    registry_pdc_count: registryIds?.filter((id) => id === PDC_QAM_TAB_ID).length ?? null,
+    qam_document_available: qamDocument !== null,
+    qam_document_hidden: qamDocument?.hidden ?? null,
+    rendered_count: renderedIds?.length ?? null,
+    rendered_unique_count: renderedIds ? new Set(renderedIds).size : null,
+    rendered_decky_count:
+      renderedIds?.filter((id) => id === `quickaccess_tab_${DECKY_PLUGIN_TAB_ID}`).length ?? null,
+    rendered_pdc_count:
+      renderedIds?.filter((id) => id === `quickaccess_tab_${PDC_QAM_TAB_ID}`).length ?? null,
+    panel_root_count: roots?.length ?? null,
+    visible_panel_root_count: roots?.filter((node) => {
+      const rect = node.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }).length ?? null,
+  };
+}
+
+function reconcilesTabsExactly(
+  hook: DeckyTabsHook,
+  desiredTabs: DeckyQuickAccessTab[],
+): boolean {
+  const nativeTab = Object.freeze({ key: "pdc-native-probe" });
+  const renderedTabs: RenderedQuickAccessTab[] = [
+    nativeTab,
+    ...hook.tabs.map((tab) => ({ decky: true, key: tab.id })),
+  ];
+  const probeTabs = desiredTabs.map((tab) => Object.freeze({ ...tab }));
+  if (new Set(probeTabs.map((tab) => tab.id)).size !== probeTabs.length) return false;
+
+  const probeHook = Object.create(hook) as DeckyTabsHook;
+  Object.defineProperty(probeHook, "tabs", { value: Object.freeze(probeTabs) });
+  hook.render.call(probeHook, renderedTabs, false);
+
+  return renderedTabs.length === probeTabs.length + 1
+    && renderedTabs[0] === nativeTab
+    && renderedTabs.slice(1).every((tab, index) => (
+      tab.decky === true && tab.key === probeTabs[index].id
+    ));
+}
+
 function removeOwnedQamTabs(hook: DeckyTabsHook): boolean {
   const matching = matchingQamTabs(hook);
   if (matching.some((tab) => !ownsQamTab(tab))) return false;
-  if (matching.length > 0) hook.removeById(PDC_QAM_TAB_ID);
+  if (matching.length > 0) {
+    const remaining = hook.tabs.filter((tab) => tab.id !== PDC_QAM_TAB_ID);
+    if (!reconcilesTabsExactly(hook, remaining)) return false;
+    hook.removeById(PDC_QAM_TAB_ID);
+  }
   return matchingQamTabs(hook).length === 0;
 }
 
@@ -89,6 +168,7 @@ export function registerQuickAccessTab(
       id: PDC_QAM_TAB_ID,
       __pdcOwner: PDC_QAM_TAB_OWNER,
     };
+    if (!reconcilesTabsExactly(hook, [...hook.tabs, tab])) return NO_QAM_TAB;
     try {
       hook.add(tab);
     } catch {
@@ -108,10 +188,7 @@ export function registerQuickAccessTab(
         if (disposed) return;
         disposed = true;
         try {
-          const matching = matchingQamTabs(hook);
-          if (matching.includes(tab) && matching.every(ownsQamTab)) {
-            hook.removeById(PDC_QAM_TAB_ID);
-          }
+          if (matchingQamTabs(hook).includes(tab)) removeOwnedQamTabs(hook);
         } catch {}
       },
     };
@@ -139,7 +216,6 @@ export function disabledPlugins(): string[] {
   return pluginNames("disabledPlugins");
 }
 
-// Rejects if the global is absent or the call throws, so callers decide how to degrade.
 export async function callBackend(method: string, ...args: unknown[]): Promise<unknown> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const backend = (window as any).DeckyBackend;
@@ -147,13 +223,9 @@ export async function callBackend(method: string, ...args: unknown[]): Promise<u
   return backend.call(method, ...args);
 }
 
-// Make a plugin the active QAM plugin. No-op (user lands on the Decky plugin list)
-// if the setter is gone.
 export function setActivePlugin(name: string): void {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).DeckyPluginLoader?.deckyState?.setActivePlugin?.(name);
-  } catch {
-    /* land on the Decky plugin list */
-  }
+  } catch {}
 }

--- a/src/qamDocument.test.ts
+++ b/src/qamDocument.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getQamDocument, setQamDocument } from "./qamDocument";
+
+describe("getQamDocument", () => {
+  it("returns the document published by the panel shell", () => {
+    const doc = { hidden: false } as Document;
+    setQamDocument(doc);
+
+    expect(getQamDocument()).toBe(doc);
+  });
+});

--- a/src/qamDocument.ts
+++ b/src/qamDocument.ts
@@ -13,10 +13,12 @@ export function setQamDocument(doc: Document): void {
   for (const l of listeners) {
     try {
       l(doc);
-    } catch {
-      /* a listener must never break the mount */
-    }
+    } catch {}
   }
+}
+
+export function getQamDocument(): Document | null {
+  return current;
 }
 
 export function onQamDocument(cb: Listener): () => void {
@@ -24,9 +26,7 @@ export function onQamDocument(cb: Listener): () => void {
   if (current) {
     try {
       cb(current);
-    } catch {
-      /* best-effort */
-    }
+    } catch {}
   }
   return () => {
     listeners.delete(cb);

--- a/src/report/logic.test.ts
+++ b/src/report/logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   REPORT_CATEGORIES,
+  buildReportContext,
   canSubmit,
   displayReportContext,
   toggleCategory,
@@ -82,5 +83,19 @@ describe("displayReportContext", () => {
 
   it("does not collect display context for unrelated reports", () => {
     expect(displayReportContext(["fans"], {})).toEqual({});
+  });
+});
+
+describe("buildReportContext", () => {
+  it("includes bounded QAM diagnostics with the existing frontend context", () => {
+    expect(buildReportContext(
+      ["other"],
+      {},
+      { runningGame: { appid: "123" } },
+      { rendered_count: 9, rendered_unique_count: 8 },
+    )).toEqual({
+      runningGame: { appid: "123" },
+      qam: { rendered_count: 9, rendered_unique_count: 8 },
+    });
   });
 });

--- a/src/report/logic.ts
+++ b/src/report/logic.ts
@@ -1,7 +1,3 @@
-// Pure logic for the bug-report modal. Kept free of @decky/ui imports so it stays
-// unit-testable (importing @decky/ui in a tested module breaks vitest - no window).
-
-// Category ids the backend + collector understand. Labels are i18n `report.cat.<id>`.
 export const REPORT_CATEGORIES = [
   "tdp",
   "cpu_gpu",
@@ -18,7 +14,6 @@ export const REPORT_CATEGORIES = [
 
 export type ReportCategory = (typeof REPORT_CATEGORIES)[number];
 
-/** Toggle a category in the selection (add if absent, remove if present). */
 export function toggleCategory(
   selected: ReportCategory[],
   id: ReportCategory,
@@ -28,9 +23,6 @@ export function toggleCategory(
     : [...selected, id];
 }
 
-/** A report is sendable once the user has written something. Without a description
- *  a report is almost impossible to act on, so the text is required; categories
- *  alone are not enough. */
 export function canSubmit(_selected: ReportCategory[], text: string): boolean {
   return text.trim().length > 0;
 }
@@ -54,5 +46,18 @@ export function displayReportContext(
         set_available: typeof api.SetBrightness === "function",
       },
     },
+  };
+}
+
+export function buildReportContext(
+  selected: ReportCategory[],
+  display: unknown,
+  launch: Record<string, unknown>,
+  qam: object,
+): Record<string, unknown> {
+  return {
+    ...launch,
+    ...displayReportContext(selected, display),
+    qam,
   };
 }

--- a/tests/test_tdp_guard_rpc.py
+++ b/tests/test_tdp_guard_rpc.py
@@ -481,6 +481,10 @@ def test_report_contains_tdp_transition_history(plugin, monkeypatch):
                         "set_available": True,
                     },
                 },
+                "qam": {
+                    "rendered_count": 8,
+                    "rendered_unique_count": 7,
+                },
             },
         )
     )
@@ -518,6 +522,10 @@ def test_report_contains_tdp_transition_history(plugin, monkeypatch):
     assert {"supported", "probe_detail", "wayland_display", "last_apply"} <= (
         display["backend"].keys()
     )
+    assert bundle["state"]["launch"]["frontend"]["qam"] == {
+        "rendered_count": 8,
+        "rendered_unique_count": 7,
+    }
     hud = bundle["state"]["hud_diagnostics"]
     assert hud["capability"] == "inactive"
 


### PR DESCRIPTION
## Español

### Qué cambia

- Comprueba que el renderer interno de Decky puede reconciliar exactamente las pestañas antes de añadir o retirar el acceso directo de Panel de Control.
- Si esa comprobación falla, conserva el panel completo desde la entrada estándar de Decky.
- Añade a los nuevos reportes conteos QAM acotados para distinguir pestañas duplicadas de problemas de layout, sin incluir texto ni identificadores de las pestañas.

### Causa

Al cambiar el número de pestañas, algunas versiones de Decky añaden el registro completo sobre las pestañas ya renderizadas. Tras recargar plugins, esto podía repetir iconos y paneles. Los reportes #449 y #461 no permitían aislar por separado el solape exacto; este cambio elimina la causa común confirmada y aporta diagnóstico para un nuevo reporte si el problema persiste.

### Validación

- Pruebas de regresión para reconciliación segura, renderer incompatible, limpieza, fallback y diagnóstico.
- Cinco ciclos de recarga en Legion Go S, MSI Claw 8 AI+ y ROG Xbox Ally X: pestañas únicas, una entrada Decky y una sola raíz de Panel de Control.
- La ruta de Steam Deck queda cubierta por las pruebas de capacidad y fallback; no hubo una unidad accesible para repetir el smoke físico.

## English

### What changed

- Checks whether Decky's internal renderer can reconcile tabs exactly before adding or removing Panel de Control's direct shortcut.
- Keeps the full panel available through Decky's standard entry when that check fails.
- Adds bounded QAM counts to new reports so duplicate tabs can be distinguished from layout problems, without including tab text or identifiers.

### Root cause

When the tab count changes, some Decky versions append the full registry to tabs that are already rendered. Plugin reloads could therefore duplicate icons and panels. Reports #449 and #461 did not contain enough context to isolate their exact overlap independently; this change removes the confirmed common cause and adds diagnostics for a new report if the problem persists.

### Validation

- Regression tests cover safe reconciliation, incompatible renderers, cleanup, fallback and diagnostics.
- Five reload cycles on Legion Go S, MSI Claw 8 AI+ and ROG Xbox Ally X: unique tabs, one Decky entry and a single Panel de Control root.
- The Steam Deck path is covered by capability and fallback tests; no unit was reachable for another physical smoke test.

## Italiano

### Cosa cambia

- Verifica che il renderer interno di Decky possa riconciliare esattamente le schede prima di aggiungere o rimuovere l'accesso diretto di Panel de Control.
- Se la verifica fallisce, mantiene disponibile il pannello completo dalla voce standard di Decky.
- Aggiunge ai nuovi report conteggi QAM limitati per distinguere le schede duplicate dai problemi di layout, senza includere testo né identificatori delle schede.

### Causa

Quando cambia il numero di schede, alcune versioni di Decky aggiungono l'intero registro alle schede già renderizzate. Il ricaricamento dei plugin poteva quindi duplicare icone e pannelli. I report #449 e #461 non contenevano informazioni sufficienti per isolare separatamente la sovrapposizione esatta; questa modifica elimina la causa comune confermata e aggiunge la diagnostica per un nuovo report se il problema persiste.

### Validazione

- Test di regressione per riconciliazione sicura, renderer incompatibile, pulizia, fallback e diagnostica.
- Cinque cicli di ricaricamento su Legion Go S, MSI Claw 8 AI+ e ROG Xbox Ally X: schede uniche, una voce Decky e una sola radice di Panel de Control.
- Il percorso Steam Deck è coperto dai test di capacità e fallback; nessuna unità era raggiungibile per ripetere lo smoke test fisico.

Closes #440
Closes #448
Closes #449
Closes #461
