### PR TITLE
fix(battery): recupera límites de carga restablecidos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Español
 
-* **Batería:** Separa el límite solicitado del valor leído y recupera, durante una ventana acotada, los umbrales que el firmware o el sistema restablecen después del arranque, la reanudación o un cambio de contexto. La redetección queda limitada a perfiles ROG y Steam Deck confirmados; Lenovo conserva su modo booleano y MSI y los equipos genéricos no ganan soporte. Los reportes incluyen el backend, el readback y el resultado de cada comprobación sin rutas ni salida cruda.
+* **Batería:** Separa el límite solicitado del valor leído y recupera, durante una ventana acotada, los umbrales que el firmware o el sistema restablecen después del arranque, la reanudación o un cambio de contexto. Solo la adquisición de un backend desde un estado inicialmente no compatible queda limitada a perfiles ROG y Steam Deck confirmados; la recuperación de la misma clase continúa en las rutas que ya tenían soporte. Lenovo conserva su modo booleano y MSI y los equipos genéricos no ganan soporte. Los reportes incluyen el backend, el readback y el resultado de cada comprobación sin rutas ni salida cruda.
 
 ### English
 
-* **Battery:** Separates the requested charge limit from hardware readback and restores thresholds reset by firmware or the operating system within a bounded window after startup, resume, or a context change. Re-detection is limited to confirmed ROG and Steam Deck profiles; Lenovo keeps its boolean conservation mode, while MSI and generic devices gain no new support. Reports include the backend, readback, and each verification result without paths or raw output.
+* **Battery:** Separates the requested charge limit from hardware readback and restores thresholds reset by firmware or the operating system within a bounded window after startup, resume, or a context change. Only acquiring a backend from an initially unsupported state is limited to confirmed ROG and Steam Deck profiles; same-class recovery remains available on previously supported paths. Lenovo keeps its boolean conservation mode, while MSI and generic devices gain no new support. Reports include the backend, readback, and each verification result without paths or raw output.
 
 ### Italiano
 
-* **Batteria:** Separa il limite richiesto dal valore letto e ripristina, entro una finestra limitata, le soglie reimpostate dal firmware o dal sistema dopo l'avvio, la riattivazione o un cambio di contesto. Il nuovo rilevamento è limitato ai profili ROG e Steam Deck confermati; Lenovo mantiene la modalità di conservazione booleana, mentre MSI e i dispositivi generici non ottengono nuovo supporto. I report includono backend, valore letto e risultato di ogni verifica senza percorsi né output grezzo.
+* **Batteria:** Separa il limite richiesto dal valore letto e ripristina, entro una finestra limitata, le soglie reimpostate dal firmware o dal sistema dopo l'avvio, la riattivazione o un cambio di contesto. Solo l'acquisizione di un backend da uno stato inizialmente non supportato è limitata ai profili ROG e Steam Deck confermati; il recupero della stessa classe resta disponibile nei percorsi già supportati. Lenovo mantiene la modalità di conservazione booleana, mentre MSI e i dispositivi generici non ottengono nuovo supporto. I report includono backend, valore letto e risultato di ogni verifica senza percorsi né output grezzo.
 
 ## [0.37.6](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.5...panel-de-control-v0.37.6) (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sin publicar / Unreleased / Non pubblicato
+
+### Español
+
+* **Batería:** Separa el límite solicitado del valor leído y recupera, durante una ventana acotada, los umbrales que el firmware o el sistema restablecen después del arranque, la reanudación o un cambio de contexto. La redetección queda limitada a perfiles ROG y Steam Deck confirmados; Lenovo conserva su modo booleano y MSI y los equipos genéricos no ganan soporte. Los reportes incluyen el backend, el readback y el resultado de cada comprobación sin rutas ni salida cruda.
+
+### English
+
+* **Battery:** Separates the requested charge limit from hardware readback and restores thresholds reset by firmware or the operating system within a bounded window after startup, resume, or a context change. Re-detection is limited to confirmed ROG and Steam Deck profiles; Lenovo keeps its boolean conservation mode, while MSI and generic devices gain no new support. Reports include the backend, readback, and each verification result without paths or raw output.
+
+### Italiano
+
+* **Batteria:** Separa il limite richiesto dal valore letto e ripristina, entro una finestra limitata, le soglie reimpostate dal firmware o dal sistema dopo l'avvio, la riattivazione o un cambio di contesto. Il nuovo rilevamento è limitato ai profili ROG e Steam Deck confermati; Lenovo mantiene la modalità di conservazione booleana, mentre MSI e i dispositivi generici non ottengono nuovo supporto. I report includono backend, valore letto e risultato di ogni verifica senza percorsi né output grezzo.
+
 ## [0.37.6](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.5...panel-de-control-v0.37.6) (2026-08-17)
 
 ### Español

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from concurrent.futures import (
 )
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from typing import Literal
 
 import decky
 
@@ -149,9 +150,34 @@ class _TdpCommand:
 
 @dataclass(frozen=True)
 class _ChargeLimitProbe:
-    readback: int
-    confirmed: int
-    wrote: bool
+    backend: str
+    reason: Literal[
+        "matched",
+        "backend_recovered",
+        "no_candidate",
+        "wrong_class",
+        "unreadable",
+        "write_rejected",
+        "confirmation_failed",
+        "stale",
+    ]
+    readback: int | None = None
+    confirmed: int | None = None
+    write_attempted: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.reason in ("matched", "backend_recovered")
+
+    @property
+    def observed(self) -> int | None:
+        return self.confirmed if self.confirmed is not None else self.readback
+
+    @property
+    def action(self) -> Literal["hold", "write", "unavailable"]:
+        if self.write_attempted:
+            return "write"
+        return "hold" if self.ok else "unavailable"
 
 
 def _now_minutes() -> int:
@@ -3168,12 +3194,24 @@ class Plugin:
                 json.dumps(event, sort_keys=True, separators=(",", ":")),
             )
 
-    def _apply_charge_limit_operation(self, action, requested, operation) -> None:
+    def _charge_limit_apply_current(self, generation) -> bool:
+        return (
+            generation is None
+            or self._charge_limit_intent_current(generation)
+        )
+
+    def _apply_charge_limit_operation(
+        self, action, requested, operation, generation=None
+    ) -> None:
         attempts = 1
         result = operation()
+        if not self._charge_limit_apply_current(generation):
+            return
         if result is False:
             attempts = 2
             result = operation()
+        if not self._charge_limit_apply_current(generation):
+            return
         self._record_charge_limit_apply(
             action,
             requested,
@@ -3182,10 +3220,10 @@ class Plugin:
         )
 
     def _apply_charge_limit(self, generation=None) -> None:
-        self._apply_selected_charge_limit()
+        self._apply_selected_charge_limit(generation)
         self._apply_pending_charge_limit_candidate(generation)
 
-    def _apply_selected_charge_limit(self) -> None:
+    def _apply_selected_charge_limit(self, generation=None) -> None:
         """Write the persisted charge limit (or 100 = no cap when disabled). Safe to
         call on any device — a Null backend no-ops."""
         if not self._charge_limit.supported:
@@ -3196,6 +3234,7 @@ class Plugin:
                 "disable_module",
                 None,
                 self._charge_limit.disable,
+                generation,
             )
             return
         enabled = bool(self._settings.get("charge_limit_enabled", False))
@@ -3205,6 +3244,7 @@ class Plugin:
                 "set",
                 requested,
                 lambda: self._charge_limit.set(requested),
+                generation,
             )
         else:
             # backend-specific "no cap" (ASUS 100, Deck 0)
@@ -3212,6 +3252,7 @@ class Plugin:
                 "disable",
                 None,
                 self._charge_limit.disable,
+                generation,
             )
 
     def _apply_pending_charge_limit_candidate(self, generation=None) -> None:
@@ -3242,7 +3283,10 @@ class Plugin:
                 def operation():
                     return backend.set(requested)
             applied = operation()
-            if applied is False:
+            if (
+                applied is False
+                and self._charge_limit_apply_current(generation)
+            ):
                 operation()
         finally:
             generation_current = (
@@ -3383,15 +3427,16 @@ class Plugin:
 
     async def _reprobe_charge_limit(
         self, generation, requested
-    ) -> _ChargeLimitProbe | None:
+    ) -> _ChargeLimitProbe:
         current = self._charge_limit
         candidate = await self._offload_call(
             lambda: select_charge_limit(self._device)
         )
+        backend = getattr(candidate, "name", "unsupported")
         if not self._charge_limit_generation_current(generation):
-            return None
+            return _ChargeLimitProbe(backend, "stale")
         if not getattr(candidate, "supported", False):
-            return None
+            return _ChargeLimitProbe(backend, "no_candidate")
         if type(candidate) is not type(current):
             device_key = getattr(self._device, "key", "")
             allowed_late_probe = (
@@ -3409,15 +3454,12 @@ class Plugin:
                 )
             )
             if not allowed_late_probe:
-                return None
+                return _ChargeLimitProbe(backend, "wrong_class")
         readback = await self._offload_call(candidate.get)
-        if (
-            not self._charge_limit_generation_current(generation)
-            or readback is None
-        ):
-            return None
-        wrote = False
-        confirmed = readback
+        if not self._charge_limit_generation_current(generation):
+            return _ChargeLimitProbe(backend, "stale", readback)
+        if readback is None:
+            return _ChargeLimitProbe(backend, "unreadable")
         if readback != requested:
             pending = candidate
             self._charge_limit_candidate = pending
@@ -3430,21 +3472,55 @@ class Plugin:
 
                 applied = await self._offload_call(write_candidate_if_current)
                 if not self._charge_limit_generation_current(generation):
-                    return None
+                    return _ChargeLimitProbe(
+                        backend, "stale", readback, write_attempted=True
+                    )
+                if not applied:
+                    return _ChargeLimitProbe(
+                        backend,
+                        "write_rejected",
+                        readback,
+                        write_attempted=True,
+                    )
                 confirmed = await self._offload_call(candidate.get)
                 if not self._charge_limit_generation_current(generation):
-                    return None
-                if not applied or confirmed != requested:
-                    return None
-                wrote = True
+                    return _ChargeLimitProbe(
+                        backend,
+                        "stale",
+                        readback,
+                        confirmed,
+                        write_attempted=True,
+                    )
+                if confirmed != requested:
+                    return _ChargeLimitProbe(
+                        backend,
+                        "confirmation_failed",
+                        readback,
+                        confirmed,
+                        True,
+                    )
             finally:
                 if (
                     self._charge_limit_intent_current(generation)
                     and self._charge_limit_candidate is pending
                 ):
                     self._charge_limit_candidate = None
+            result = _ChargeLimitProbe(
+                backend,
+                "backend_recovered",
+                readback,
+                confirmed,
+                True,
+            )
+        else:
+            result = _ChargeLimitProbe(
+                backend,
+                "matched",
+                readback,
+                readback,
+            )
         self._charge_limit = candidate
-        return _ChargeLimitProbe(readback, confirmed, wrote)
+        return result
 
     async def _reconcile_charge_limit(self, generation, trigger) -> None:
         if not self._charge_limit_generation_current(generation):
@@ -3471,48 +3547,28 @@ class Plugin:
                 )
                 if not self._charge_limit_generation_current(generation):
                     return
-                if reprobe is None:
-                    checks += 1
-                    last_readback = None
-                    status = "failed"
-                    reason = "backend_unavailable"
-                    self._charge_limit_history.append({
-                        "trigger": trigger,
-                        "check": check,
-                        "requested": requested,
-                        "readback": None,
-                        "action": "unavailable",
-                        "ok": False,
-                        "backend": getattr(
-                            self._charge_limit, "name", "unsupported"
-                        ),
-                    })
-                    self._publish_charge_limit_reconciliation(
-                        generation,
-                        trigger,
-                        status,
-                        checks,
-                        writes,
-                        last_readback,
-                        reason,
-                    )
-                    continue
                 checks += 1
-                if reprobe.wrote:
+                last_readback = reprobe.observed
+                if reprobe.write_attempted:
                     writes += 1
-                    status = "recovered"
-                    reason = "backend_recovered"
-                last_readback = reprobe.confirmed
+                if reprobe.ok:
+                    status = (
+                        "recovered"
+                        if reprobe.write_attempted
+                        else "confirmed"
+                    )
+                else:
+                    status = "failed"
+                reason = reprobe.reason
                 self._charge_limit_history.append({
                     "trigger": trigger,
                     "check": check,
                     "requested": requested,
                     "readback": reprobe.readback,
-                    "action": "write" if reprobe.wrote else "hold",
-                    "ok": True,
-                    "backend": getattr(
-                        self._charge_limit, "name", "unsupported"
-                    ),
+                    "action": reprobe.action,
+                    "ok": reprobe.ok,
+                    "backend": reprobe.backend,
+                    "reason": reason,
                 })
                 self._publish_charge_limit_reconciliation(
                     generation,
@@ -3548,6 +3604,9 @@ class Plugin:
                 ok = bool(applied) and last_readback == requested
                 status = "recovered" if ok else "failed"
                 reason = "mismatch_corrected" if ok else "write_unconfirmed"
+            else:
+                status = "confirmed"
+                reason = "matched"
             event = {
                 "trigger": trigger,
                 "check": check,
@@ -3556,6 +3615,7 @@ class Plugin:
                 "action": action,
                 "ok": ok,
                 "backend": getattr(self._charge_limit, "name", "unsupported"),
+                "reason": reason,
             }
             self._charge_limit_history.append(event)
             self._publish_charge_limit_reconciliation(

--- a/main.py
+++ b/main.py
@@ -671,10 +671,14 @@ class Plugin:
         self._init()
         disabled = bool(disabled)
         if module_id in self._MODULE_SETTING:
-            self._cancel_charge_limit_reconcile("module_changed")
+            self._cancel_charge_limit_reconcile(
+                "module_changed", preserve_candidate=True
+            )
             self._settings[self._MODULE_SETTING[module_id]] = not disabled
         elif module_id in self._GENERIC_MODULES:
-            self._cancel_charge_limit_reconcile("module_changed")
+            self._cancel_charge_limit_reconcile(
+                "module_changed", preserve_candidate=True
+            )
             cur = set(self._disabled_modules())
             cur.add(module_id) if disabled else cur.discard(module_id)
             self._settings["disabled_modules"] = sorted(cur)
@@ -720,7 +724,9 @@ class Plugin:
         """Reset the customization layout. Leaves the functional switches (TDP control,
         telemetry) as-is; a visual reset must not silently re-enable them."""
         self._init()
-        self._cancel_charge_limit_reconcile("module_reset")
+        self._cancel_charge_limit_reconcile(
+            "module_reset", preserve_candidate=True
+        )
         self._settings["disabled_modules"] = []
         self._save()
         self._reapply_all()
@@ -3083,17 +3089,21 @@ class Plugin:
         self._last_reapply_trigger = "lifecycle_or_context"
         self._cancel_color_revert()
         self._color_preview = None
+        charge_limit_candidate = self._take_charge_limit_candidate()
         charge_generation = self._cancel_charge_limit_reconcile("reapply")
 
         def apply_charge_limit():
             if self._charge_limit_intent_current(charge_generation):
-                self._apply_charge_limit()
+                self._apply_charge_limit(charge_limit_candidate)
 
         def schedule_charge_limit_reconcile():
             if self._charge_limit_intent_current(charge_generation):
                 self._schedule_charge_limit_reconcile("reapply_all")
 
-        if bool(getattr(self._charge_limit, "supported", False)):
+        if (
+            bool(getattr(self._charge_limit, "supported", False))
+            or charge_limit_candidate is not None
+        ):
             self._offload(
                 apply_charge_limit,
                 done=schedule_charge_limit_reconcile,
@@ -3165,9 +3175,16 @@ class Plugin:
             attempts,
         )
 
-    def _apply_charge_limit(self) -> None:
+    def _take_charge_limit_candidate(self):
+        candidate = getattr(self, "_charge_limit_candidate", None)
+        self._charge_limit_candidate = None
+        return candidate
+
+    def _apply_charge_limit(self, candidate=None) -> None:
+        if candidate is None:
+            candidate = self._take_charge_limit_candidate()
         self._apply_selected_charge_limit()
-        self._apply_pending_charge_limit_candidate()
+        self._apply_pending_charge_limit_candidate(candidate)
 
     def _apply_selected_charge_limit(self) -> None:
         """Write the persisted charge limit (or 100 = no cap when disabled). Safe to
@@ -3198,13 +3215,11 @@ class Plugin:
                 self._charge_limit.disable,
             )
 
-    def _apply_pending_charge_limit_candidate(self) -> None:
-        pending = getattr(self, "_charge_limit_candidate", None)
-        if pending is None:
+    def _apply_pending_charge_limit_candidate(self, candidate) -> None:
+        if candidate is None:
             return
-        backend = pending
+        backend = candidate
         if backend is self._charge_limit:
-            self._charge_limit_candidate = None
             return
         if not getattr(backend, "supported", False):
             return
@@ -3220,9 +3235,7 @@ class Plugin:
                 return backend.set(requested)
         applied = operation()
         if applied is False:
-            applied = operation()
-        if applied and self._charge_limit_candidate is pending:
-            self._charge_limit_candidate = None
+            operation()
 
     def _charge_limit_generation_current(self, generation) -> bool:
         return (
@@ -3244,10 +3257,14 @@ class Plugin:
             or key in _STEAM_DECK_CHARGE_LIMIT_PROFILES
         )
 
-    def _cancel_charge_limit_reconcile(self, reason) -> int:
+    def _cancel_charge_limit_reconcile(
+        self, reason, preserve_candidate=False
+    ) -> int:
         self._charge_limit_generation = int(
             getattr(self, "_charge_limit_generation", 0)
         ) + 1
+        if not preserve_candidate:
+            self._charge_limit_candidate = None
         task = getattr(self, "_charge_limit_reconcile_task", None)
         self._charge_limit_reconcile_task = None
         if task is not None and not task.done():
@@ -3387,24 +3404,24 @@ class Plugin:
             pending = candidate
             self._charge_limit_candidate = pending
 
-            def write_candidate_if_current():
+            try:
+                def write_candidate_if_current():
+                    if not self._charge_limit_generation_current(generation):
+                        return None
+                    return candidate.set(requested)
+
+                applied = await self._offload_call(write_candidate_if_current)
                 if not self._charge_limit_generation_current(generation):
                     return None
-                return candidate.set(requested)
-
-            applied = await self._offload_call(write_candidate_if_current)
-            if not self._charge_limit_generation_current(generation):
-                return None
-            confirmed = await self._offload_call(candidate.get)
-            if not self._charge_limit_generation_current(generation):
-                return None
-            if not applied or confirmed != requested:
+                confirmed = await self._offload_call(candidate.get)
+                if not self._charge_limit_generation_current(generation):
+                    return None
+                if not applied or confirmed != requested:
+                    return None
+                wrote = True
+            finally:
                 if self._charge_limit_candidate is pending:
                     self._charge_limit_candidate = None
-                return None
-            wrote = True
-            if self._charge_limit_candidate is pending:
-                self._charge_limit_candidate = None
         self._charge_limit = candidate
         return _ChargeLimitProbe(readback, confirmed, wrote)
 
@@ -5482,6 +5499,7 @@ class Plugin:
         """Enable/disable the charge cap and set its threshold. Persists, applies via
         readback, and returns the resulting charge_limit block."""
         self._init()
+        charge_limit_candidate = self._take_charge_limit_candidate()
         generation = self._cancel_charge_limit_reconcile("new_intent")
         lo, hi = self._charge_limit.range()
         percent = max(lo, min(hi, int(percent)))
@@ -5490,7 +5508,7 @@ class Plugin:
         self._save()
         await self._offload_call(
             lambda: (
-                self._apply_charge_limit()
+                self._apply_charge_limit(charge_limit_candidate)
                 if self._charge_limit_intent_current(generation)
                 else None
             )

--- a/main.py
+++ b/main.py
@@ -3089,12 +3089,17 @@ class Plugin:
         self._last_reapply_trigger = "lifecycle_or_context"
         self._cancel_color_revert()
         self._color_preview = None
-        charge_limit_candidate = self._take_charge_limit_candidate()
-        charge_generation = self._cancel_charge_limit_reconcile("reapply")
+        charge_generation = self._cancel_charge_limit_reconcile(
+            "reapply",
+            preserve_candidate=not getattr(self, "_shutting_down", False),
+        )
+        charge_limit_candidate_pending = (
+            getattr(self, "_charge_limit_candidate", None) is not None
+        )
 
         def apply_charge_limit():
             if self._charge_limit_intent_current(charge_generation):
-                self._apply_charge_limit(charge_limit_candidate)
+                self._apply_charge_limit(charge_generation)
 
         def schedule_charge_limit_reconcile():
             if self._charge_limit_intent_current(charge_generation):
@@ -3102,7 +3107,7 @@ class Plugin:
 
         if (
             bool(getattr(self._charge_limit, "supported", False))
-            or charge_limit_candidate is not None
+            or charge_limit_candidate_pending
         ):
             self._offload(
                 apply_charge_limit,
@@ -3175,16 +3180,9 @@ class Plugin:
             attempts,
         )
 
-    def _take_charge_limit_candidate(self):
-        candidate = getattr(self, "_charge_limit_candidate", None)
-        self._charge_limit_candidate = None
-        return candidate
-
-    def _apply_charge_limit(self, candidate=None) -> None:
-        if candidate is None:
-            candidate = self._take_charge_limit_candidate()
+    def _apply_charge_limit(self, generation=None) -> None:
         self._apply_selected_charge_limit()
-        self._apply_pending_charge_limit_candidate(candidate)
+        self._apply_pending_charge_limit_candidate(generation)
 
     def _apply_selected_charge_limit(self) -> None:
         """Write the persisted charge limit (or 100 = no cap when disabled). Safe to
@@ -3215,27 +3213,46 @@ class Plugin:
                 self._charge_limit.disable,
             )
 
-    def _apply_pending_charge_limit_candidate(self, candidate) -> None:
+    def _apply_pending_charge_limit_candidate(self, generation=None) -> None:
+        candidate = getattr(self, "_charge_limit_candidate", None)
         if candidate is None:
             return
-        backend = candidate
-        if backend is self._charge_limit:
-            return
-        if not getattr(backend, "supported", False):
-            return
         if (
-            not self._module_enabled("system")
-            or not bool(self._settings.get("charge_limit_enabled", False))
+            generation is not None
+            and not self._charge_limit_intent_current(generation)
         ):
-            operation = backend.disable
-        else:
-            requested = int(self._settings.get("charge_limit_percent", 80))
+            return
+        try:
+            backend = candidate
+            if backend is self._charge_limit:
+                return
+            if not getattr(backend, "supported", False):
+                return
+            if (
+                not self._module_enabled("system")
+                or not bool(self._settings.get("charge_limit_enabled", False))
+            ):
+                operation = backend.disable
+            else:
+                requested = int(
+                    self._settings.get("charge_limit_percent", 80)
+                )
 
-            def operation():
-                return backend.set(requested)
-        applied = operation()
-        if applied is False:
-            operation()
+                def operation():
+                    return backend.set(requested)
+            applied = operation()
+            if applied is False:
+                operation()
+        finally:
+            generation_current = (
+                generation is None
+                or self._charge_limit_intent_current(generation)
+            )
+            if (
+                generation_current
+                and self._charge_limit_candidate is candidate
+            ):
+                self._charge_limit_candidate = None
 
     def _charge_limit_generation_current(self, generation) -> bool:
         return (
@@ -3420,7 +3437,10 @@ class Plugin:
                     return None
                 wrote = True
             finally:
-                if self._charge_limit_candidate is pending:
+                if (
+                    self._charge_limit_intent_current(generation)
+                    and self._charge_limit_candidate is pending
+                ):
                     self._charge_limit_candidate = None
         self._charge_limit = candidate
         return _ChargeLimitProbe(readback, confirmed, wrote)
@@ -5499,8 +5519,10 @@ class Plugin:
         """Enable/disable the charge cap and set its threshold. Persists, applies via
         readback, and returns the resulting charge_limit block."""
         self._init()
-        charge_limit_candidate = self._take_charge_limit_candidate()
-        generation = self._cancel_charge_limit_reconcile("new_intent")
+        generation = self._cancel_charge_limit_reconcile(
+            "new_intent",
+            preserve_candidate=not getattr(self, "_shutting_down", False),
+        )
         lo, hi = self._charge_limit.range()
         percent = max(lo, min(hi, int(percent)))
         self._settings["charge_limit_enabled"] = bool(enabled)
@@ -5508,7 +5530,7 @@ class Plugin:
         self._save()
         await self._offload_call(
             lambda: (
-                self._apply_charge_limit(charge_limit_candidate)
+                self._apply_charge_limit(generation)
                 if self._charge_limit_intent_current(generation)
                 else None
             )

--- a/main.py
+++ b/main.py
@@ -147,6 +147,13 @@ class _TdpCommand:
     on_ac: bool
 
 
+@dataclass(frozen=True)
+class _ChargeLimitProbe:
+    readback: int
+    confirmed: int
+    wrote: bool
+
+
 def _now_minutes() -> int:
     t = datetime.now()
     return t.hour * 60 + t.minute
@@ -3214,23 +3221,61 @@ class Plugin:
         self._charge_limit_reconcile_task = None
         if task is not None and not task.done():
             task.cancel()
+        self._publish_charge_limit_reconciliation(
+            self._charge_limit_generation,
+            None,
+            "cancelled",
+            0,
+            0,
+            None,
+            reason,
+        )
+        return self._charge_limit_generation
+
+    def _publish_charge_limit_reconciliation(
+        self,
+        generation,
+        trigger,
+        status,
+        checks,
+        writes,
+        readback,
+        reason,
+    ) -> None:
         self._charge_limit_reconciliation = {
-            "generation": self._charge_limit_generation,
-            "trigger": None,
-            "status": "cancelled",
-            "checks": 0,
-            "writes": 0,
-            "readback": None,
+            "generation": generation,
+            "trigger": trigger,
+            "status": status,
+            "checks": checks,
+            "writes": writes,
+            "readback": readback,
             "reason": reason,
             "history": list(getattr(self, "_charge_limit_history", ())),
         }
-        return self._charge_limit_generation
 
     def _schedule_charge_limit_reconcile(self, trigger) -> None:
         generation = self._cancel_charge_limit_reconcile("rescheduled")
-        eligible = (
+        active = (
             self._module_enabled("system")
             and bool(self._settings.get("charge_limit_enabled", False))
+        )
+        if (
+            active
+            and bool(getattr(self._charge_limit, "supported", False))
+            and not bool(getattr(self._charge_limit, "adjustable", True))
+        ):
+            self._publish_charge_limit_reconciliation(
+                generation,
+                trigger,
+                "unverifiable",
+                0,
+                0,
+                None,
+                "fixed_threshold",
+            )
+            return
+        eligible = (
+            active
             and bool(getattr(self._charge_limit, "adjustable", True))
             and (
                 bool(getattr(self._charge_limit, "supported", False))
@@ -3242,16 +3287,15 @@ class Plugin:
             self._charge_limit_reconciliation["status"] = "idle"
             self._charge_limit_reconciliation["reason"] = "not_applicable"
             return
-        self._charge_limit_reconciliation = {
-            "generation": generation,
-            "trigger": trigger,
-            "status": "scheduled",
-            "checks": 0,
-            "writes": 0,
-            "readback": None,
-            "reason": "verification_pending",
-            "history": list(self._charge_limit_history),
-        }
+        self._publish_charge_limit_reconciliation(
+            generation,
+            trigger,
+            "scheduled",
+            0,
+            0,
+            None,
+            "verification_pending",
+        )
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -3271,15 +3315,17 @@ class Plugin:
 
         task.add_done_callback(finished)
 
-    async def _reprobe_charge_limit(self, generation) -> bool:
+    async def _reprobe_charge_limit(
+        self, generation, requested
+    ) -> _ChargeLimitProbe | None:
         current = self._charge_limit
         candidate = await self._offload_call(
             lambda: select_charge_limit(self._device)
         )
         if not self._charge_limit_generation_current(generation):
-            return False
+            return None
         if not getattr(candidate, "supported", False):
-            return False
+            return None
         if type(candidate) is not type(current):
             device_key = getattr(self._device, "key", "")
             allowed_late_probe = (
@@ -3297,24 +3343,33 @@ class Plugin:
                 )
             )
             if not allowed_late_probe:
-                return False
+                return None
+        readback = await self._offload_call(candidate.get)
+        if (
+            not self._charge_limit_generation_current(generation)
+            or readback is None
+        ):
+            return None
+        wrote = False
+        confirmed = readback
+        if readback != requested:
+            def write_candidate_if_current():
+                if not self._charge_limit_generation_current(generation):
+                    return None
+                return candidate.set(requested)
+
+            applied = await self._offload_call(write_candidate_if_current)
+            if not self._charge_limit_generation_current(generation):
+                return None
+            confirmed = await self._offload_call(candidate.get)
+            if not applied or confirmed != requested:
+                return None
+            wrote = True
         self._charge_limit = candidate
-        return True
+        return _ChargeLimitProbe(readback, confirmed, wrote)
 
     async def _reconcile_charge_limit(self, generation, trigger) -> None:
         if not self._charge_limit_generation_current(generation):
-            return
-        if not bool(getattr(self._charge_limit, "adjustable", True)):
-            self._charge_limit_reconciliation = {
-                "generation": generation,
-                "trigger": trigger,
-                "status": "unverifiable",
-                "checks": 0,
-                "writes": 0,
-                "readback": None,
-                "reason": "fixed_threshold",
-                "history": list(self._charge_limit_history),
-            }
             return
         checks = 0
         writes = 0
@@ -3333,11 +3388,10 @@ class Plugin:
             if not self._charge_limit_generation_current(generation):
                 return
             if readback is None:
-                if await self._reprobe_charge_limit(generation):
-                    readback = await self._offload_call(self._charge_limit.get)
-                    if not self._charge_limit_generation_current(generation):
-                        return
-                else:
+                reprobe = await self._reprobe_charge_limit(
+                    generation, requested
+                )
+                if reprobe is None:
                     checks += 1
                     last_readback = None
                     status = "failed"
@@ -3353,7 +3407,43 @@ class Plugin:
                             self._charge_limit, "name", "unsupported"
                         ),
                     })
+                    self._publish_charge_limit_reconciliation(
+                        generation,
+                        trigger,
+                        status,
+                        checks,
+                        writes,
+                        last_readback,
+                        reason,
+                    )
                     continue
+                checks += 1
+                if reprobe.wrote:
+                    writes += 1
+                    status = "recovered"
+                    reason = "backend_recovered"
+                last_readback = reprobe.confirmed
+                self._charge_limit_history.append({
+                    "trigger": trigger,
+                    "check": check,
+                    "requested": requested,
+                    "readback": reprobe.readback,
+                    "action": "write" if reprobe.wrote else "hold",
+                    "ok": True,
+                    "backend": getattr(
+                        self._charge_limit, "name", "unsupported"
+                    ),
+                })
+                self._publish_charge_limit_reconciliation(
+                    generation,
+                    trigger,
+                    status,
+                    checks,
+                    writes,
+                    last_readback,
+                    reason,
+                )
+                continue
             checks += 1
             last_readback = readback
             action = "hold"
@@ -3386,16 +3476,15 @@ class Plugin:
                 "backend": getattr(self._charge_limit, "name", "unsupported"),
             }
             self._charge_limit_history.append(event)
-        self._charge_limit_reconciliation = {
-            "generation": generation,
-            "trigger": trigger,
-            "status": status,
-            "checks": checks,
-            "writes": writes,
-            "readback": last_readback,
-            "reason": reason,
-            "history": list(self._charge_limit_history),
-        }
+            self._publish_charge_limit_reconciliation(
+                generation,
+                trigger,
+                status,
+                checks,
+                writes,
+                last_readback,
+                reason,
+            )
 
     def _charge_limit_state(self) -> dict:
         lo, hi = self._charge_limit.range()

--- a/main.py
+++ b/main.py
@@ -446,6 +446,7 @@ class Plugin:
         self._charge_limit_verify_delays = _CHARGE_LIMIT_VERIFY_DELAYS
         self._charge_limit_generation = 0
         self._charge_limit_reconcile_task = None
+        self._charge_limit_apply_tasks = set()
         self._charge_limit_candidate = None
         self._charge_limit_history = deque(maxlen=8)
         self._charge_limit_reconciliation = {
@@ -5528,6 +5529,21 @@ class Plugin:
         self._settings["charge_limit_enabled"] = bool(enabled)
         self._settings["charge_limit_percent"] = percent
         self._save()
+        apply_task = asyncio.create_task(
+            self._apply_charge_limit_intent(generation)
+        )
+        self._charge_limit_apply_tasks.add(apply_task)
+
+        def finished(done):
+            self._charge_limit_apply_tasks.discard(done)
+            if not done.cancelled():
+                done.exception()
+
+        apply_task.add_done_callback(finished)
+        await asyncio.shield(apply_task)
+        return await self._offload_call(self._charge_limit_state)
+
+    async def _apply_charge_limit_intent(self, generation) -> None:
         await self._offload_call(
             lambda: (
                 self._apply_charge_limit(generation)
@@ -5537,7 +5553,6 @@ class Plugin:
         )
         if self._charge_limit_intent_current(generation):
             self._schedule_charge_limit_reconcile("set_charge_limit")
-        return await self._offload_call(self._charge_limit_state)
 
     # ---- Pantalla (panel color via gamescope) -------------------------------
     def _reapply_color(self) -> None:

--- a/main.py
+++ b/main.py
@@ -3223,37 +3223,27 @@ class Plugin:
         self._apply_selected_charge_limit(generation)
         self._apply_pending_charge_limit_candidate(generation)
 
-    def _apply_selected_charge_limit(self, generation=None) -> None:
-        """Write the persisted charge limit (or 100 = no cap when disabled). Safe to
-        call on any device — a Null backend no-ops."""
-        if not self._charge_limit.supported:
-            return
+    def _charge_limit_operation_for(self, backend):
         if not self._module_enabled("system"):
-            # Module off = step aside: release any cap, don't keep limiting.
-            self._apply_charge_limit_operation(
-                "disable_module",
-                None,
-                self._charge_limit.disable,
-                generation,
-            )
-            return
-        enabled = bool(self._settings.get("charge_limit_enabled", False))
-        if enabled:
+            return "disable_module", None, backend.disable
+        if bool(self._settings.get("charge_limit_enabled", False)):
             requested = int(self._settings.get("charge_limit_percent", 80))
-            self._apply_charge_limit_operation(
-                "set",
-                requested,
-                lambda: self._charge_limit.set(requested),
-                generation,
-            )
-        else:
-            # backend-specific "no cap" (ASUS 100, Deck 0)
-            self._apply_charge_limit_operation(
-                "disable",
-                None,
-                self._charge_limit.disable,
-                generation,
-            )
+            return "set", requested, lambda: backend.set(requested)
+        return "disable", None, backend.disable
+
+    def _apply_selected_charge_limit(self, generation=None) -> None:
+        backend = self._charge_limit
+        if not backend.supported:
+            return
+        action, requested, operation = self._charge_limit_operation_for(
+            backend
+        )
+        self._apply_charge_limit_operation(
+            action,
+            requested,
+            operation,
+            generation,
+        )
 
     def _apply_pending_charge_limit_candidate(self, generation=None) -> None:
         candidate = getattr(self, "_charge_limit_candidate", None)
@@ -3270,18 +3260,7 @@ class Plugin:
                 return
             if not getattr(backend, "supported", False):
                 return
-            if (
-                not self._module_enabled("system")
-                or not bool(self._settings.get("charge_limit_enabled", False))
-            ):
-                operation = backend.disable
-            else:
-                requested = int(
-                    self._settings.get("charge_limit_percent", 80)
-                )
-
-                def operation():
-                    return backend.set(requested)
+            _, _, operation = self._charge_limit_operation_for(backend)
             applied = operation()
             if (
                 applied is False
@@ -3541,13 +3520,13 @@ class Plugin:
             readback = await self._offload_call(self._charge_limit.get)
             if not self._charge_limit_generation_current(generation):
                 return
+            checks += 1
             if readback is None:
                 reprobe = await self._reprobe_charge_limit(
                     generation, requested
                 )
                 if not self._charge_limit_generation_current(generation):
                     return
-                checks += 1
                 last_readback = reprobe.observed
                 if reprobe.write_attempted:
                     writes += 1
@@ -3560,31 +3539,19 @@ class Plugin:
                 else:
                     status = "failed"
                 reason = reprobe.reason
-                self._charge_limit_history.append({
-                    "trigger": trigger,
-                    "check": check,
-                    "requested": requested,
-                    "readback": reprobe.readback,
-                    "action": reprobe.action,
-                    "ok": reprobe.ok,
-                    "backend": reprobe.backend,
-                    "reason": reason,
-                })
-                self._publish_charge_limit_reconciliation(
-                    generation,
-                    trigger,
-                    status,
-                    checks,
-                    writes,
-                    last_readback,
-                    reason,
+                event_readback = reprobe.readback
+                action = reprobe.action
+                ok = reprobe.ok
+                backend = reprobe.backend
+            else:
+                last_readback = readback
+                event_readback = readback
+                action = "hold"
+                ok = readback == requested
+                backend = getattr(
+                    self._charge_limit, "name", "unsupported"
                 )
-                continue
-            checks += 1
-            last_readback = readback
-            action = "hold"
-            ok = readback == requested
-            if readback != requested:
+            if readback is not None and readback != requested:
                 action = "write"
                 writes += 1
 
@@ -3593,9 +3560,7 @@ class Plugin:
                         return None
                     return self._charge_limit.set(requested)
 
-                applied = await self._offload_call(
-                    write_if_current
-                )
+                applied = await self._offload_call(write_if_current)
                 if not self._charge_limit_generation_current(generation):
                     return
                 last_readback = await self._offload_call(self._charge_limit.get)
@@ -3604,17 +3569,17 @@ class Plugin:
                 ok = bool(applied) and last_readback == requested
                 status = "recovered" if ok else "failed"
                 reason = "mismatch_corrected" if ok else "write_unconfirmed"
-            else:
+            elif readback is not None:
                 status = "confirmed"
                 reason = "matched"
             event = {
                 "trigger": trigger,
                 "check": check,
                 "requested": requested,
-                "readback": readback,
+                "readback": event_readback,
                 "action": action,
                 "ok": ok,
-                "backend": getattr(self._charge_limit, "name", "unsupported"),
+                "backend": backend,
                 "reason": reason,
             }
             self._charge_limit_history.append(event)

--- a/main.py
+++ b/main.py
@@ -446,6 +446,7 @@ class Plugin:
         self._charge_limit_verify_delays = _CHARGE_LIMIT_VERIFY_DELAYS
         self._charge_limit_generation = 0
         self._charge_limit_reconcile_task = None
+        self._charge_limit_candidate = None
         self._charge_limit_history = deque(maxlen=8)
         self._charge_limit_reconciliation = {
             "generation": 0,
@@ -3165,6 +3166,10 @@ class Plugin:
         )
 
     def _apply_charge_limit(self) -> None:
+        self._apply_selected_charge_limit()
+        self._apply_pending_charge_limit_candidate()
+
+    def _apply_selected_charge_limit(self) -> None:
         """Write the persisted charge limit (or 100 = no cap when disabled). Safe to
         call on any device — a Null backend no-ops."""
         if not self._charge_limit.supported:
@@ -3192,6 +3197,32 @@ class Plugin:
                 None,
                 self._charge_limit.disable,
             )
+
+    def _apply_pending_charge_limit_candidate(self) -> None:
+        pending = getattr(self, "_charge_limit_candidate", None)
+        if pending is None:
+            return
+        backend = pending
+        if backend is self._charge_limit:
+            self._charge_limit_candidate = None
+            return
+        if not getattr(backend, "supported", False):
+            return
+        if (
+            not self._module_enabled("system")
+            or not bool(self._settings.get("charge_limit_enabled", False))
+        ):
+            operation = backend.disable
+        else:
+            requested = int(self._settings.get("charge_limit_percent", 80))
+
+            def operation():
+                return backend.set(requested)
+        applied = operation()
+        if applied is False:
+            applied = operation()
+        if applied and self._charge_limit_candidate is pending:
+            self._charge_limit_candidate = None
 
     def _charge_limit_generation_current(self, generation) -> bool:
         return (
@@ -3353,6 +3384,9 @@ class Plugin:
         wrote = False
         confirmed = readback
         if readback != requested:
+            pending = candidate
+            self._charge_limit_candidate = pending
+
             def write_candidate_if_current():
                 if not self._charge_limit_generation_current(generation):
                     return None
@@ -3362,9 +3396,15 @@ class Plugin:
             if not self._charge_limit_generation_current(generation):
                 return None
             confirmed = await self._offload_call(candidate.get)
+            if not self._charge_limit_generation_current(generation):
+                return None
             if not applied or confirmed != requested:
+                if self._charge_limit_candidate is pending:
+                    self._charge_limit_candidate = None
                 return None
             wrote = True
+            if self._charge_limit_candidate is pending:
+                self._charge_limit_candidate = None
         self._charge_limit = candidate
         return _ChargeLimitProbe(readback, confirmed, wrote)
 
@@ -3391,6 +3431,8 @@ class Plugin:
                 reprobe = await self._reprobe_charge_limit(
                     generation, requested
                 )
+                if not self._charge_limit_generation_current(generation):
+                    return
                 if reprobe is None:
                     checks += 1
                     last_readback = None
@@ -3463,6 +3505,8 @@ class Plugin:
                 if not self._charge_limit_generation_current(generation):
                     return
                 last_readback = await self._offload_call(self._charge_limit.get)
+                if not self._charge_limit_generation_current(generation):
+                    return
                 ok = bool(applied) and last_readback == requested
                 status = "recovered" if ok else "failed"
                 reason = "mismatch_corrected" if ok else "write_unconfirmed"

--- a/main.py
+++ b/main.py
@@ -3143,19 +3143,12 @@ class Plugin:
         enabled = bool(self._settings.get("charge_limit_enabled", False))
         percent = int(self._settings.get("charge_limit_percent", 80))
         applied_percent = None
-        fixed = getattr(self._charge_limit, "fixed_percent", None)
-        if not self._charge_limit.adjustable and fixed is not None:
-            # Fixed-cap backend (Lenovo conservation): report the firmware level so
-            # the UI can state it explicitly (e.g. "caps at 80%").
-            percent = fixed
-            applied_percent = fixed
-        elif enabled and self._charge_limit.supported and self._charge_limit.adjustable:
-            # report what the firmware actually holds (it may clamp our write).
+        if enabled and self._charge_limit.supported:
             actual = self._charge_limit.get()
             if actual is not None:
-                percent = actual
                 applied_percent = actual
         return {
+            "backend": getattr(self._charge_limit, "name", "unsupported"),
             "supported": self._charge_limit.supported,
             "adjustable": self._charge_limit.adjustable,
             "enabled": enabled,
@@ -5096,8 +5089,10 @@ class Plugin:
         """Enable/disable the charge cap and set its threshold. Persists, applies via
         readback, and returns the resulting charge_limit block."""
         self._init()
+        lo, hi = self._charge_limit.range()
+        percent = max(lo, min(hi, int(percent)))
         self._settings["charge_limit_enabled"] = bool(enabled)
-        self._settings["charge_limit_percent"] = int(percent)
+        self._settings["charge_limit_percent"] = percent
         self._save()
         self._apply_charge_limit()
         return self._charge_limit_state()

--- a/main.py
+++ b/main.py
@@ -60,7 +60,12 @@ from gpu.clock import select_gpu_clock
 from gpu.profiles import GpuProfileStore
 from power.reader import PowerReader
 from battery.reader import BatteryReader
-from battery.charge_limit import select_charge_limit
+from battery.charge_limit import (
+    NullChargeLimit,
+    SteamDeckChargeLimit,
+    SysfsChargeLimit,
+    select_charge_limit,
+)
 from audio.eq_store import EqStore
 from audio.pipewire import PipeWireEq
 from audio.profile_store import AudioProfileStore
@@ -115,6 +120,17 @@ _monotonic = time.monotonic
 _HUD_OBSERVATION_MAX_AGE_S = 3.0
 _MIN_HUD_REFRESH_S = 1.0
 _HUD_RELOAD_MAX_ATTEMPTS = 4
+_CHARGE_LIMIT_VERIFY_DELAYS = (2.0, 8.0, 20.0)
+_ROG_CHARGE_LIMIT_PROFILES = frozenset({
+    "rog_ally",
+    "rog_ally_x",
+    "rog_xbox_ally",
+    "rog_xbox_ally_x",
+})
+_STEAM_DECK_CHARGE_LIMIT_PROFILES = frozenset({
+    "steam_deck_lcd",
+    "steam_deck_oled",
+})
 
 # "custom" = our TDP owns the rails, vs a named platform_profile mode.
 _CUSTOM_MODE = "custom"
@@ -420,6 +436,20 @@ class Plugin:
         self._charge_limit = select_charge_limit(self._device)
         self._charge_limit_last_apply = None
         self._charge_limit_failures = 0
+        self._charge_limit_verify_delays = _CHARGE_LIMIT_VERIFY_DELAYS
+        self._charge_limit_generation = 0
+        self._charge_limit_reconcile_task = None
+        self._charge_limit_history = deque(maxlen=8)
+        self._charge_limit_reconciliation = {
+            "generation": 0,
+            "trigger": None,
+            "status": "idle",
+            "checks": 0,
+            "writes": 0,
+            "readback": None,
+            "reason": "not_scheduled",
+            "history": [],
+        }
         self._smt = SmtControl()
         self._boost = select_boost()
         self._cores = CoreControl()
@@ -633,8 +663,10 @@ class Plugin:
         self._init()
         disabled = bool(disabled)
         if module_id in self._MODULE_SETTING:
+            self._cancel_charge_limit_reconcile("module_changed")
             self._settings[self._MODULE_SETTING[module_id]] = not disabled
         elif module_id in self._GENERIC_MODULES:
+            self._cancel_charge_limit_reconcile("module_changed")
             cur = set(self._disabled_modules())
             cur.add(module_id) if disabled else cur.discard(module_id)
             self._settings["disabled_modules"] = sorted(cur)
@@ -680,6 +712,7 @@ class Plugin:
         """Reset the customization layout. Leaves the functional switches (TDP control,
         telemetry) as-is; a visual reset must not silently re-enable them."""
         self._init()
+        self._cancel_charge_limit_reconcile("module_reset")
         self._settings["disabled_modules"] = []
         self._save()
         self._reapply_all()
@@ -3042,8 +3075,23 @@ class Plugin:
         self._last_reapply_trigger = "lifecycle_or_context"
         self._cancel_color_revert()
         self._color_preview = None
-        # sysfs (fast) → inline; subprocess-backed (tdp-ryzenadj/fans/color) → off-loop.
-        self._apply_charge_limit()
+        charge_generation = self._cancel_charge_limit_reconcile("reapply")
+
+        def apply_charge_limit():
+            if self._charge_limit_intent_current(charge_generation):
+                self._apply_charge_limit()
+
+        def schedule_charge_limit_reconcile():
+            if self._charge_limit_intent_current(charge_generation):
+                self._schedule_charge_limit_reconcile("reapply_all")
+
+        if bool(getattr(self._charge_limit, "supported", False)):
+            self._offload(
+                apply_charge_limit,
+                done=schedule_charge_limit_reconcile,
+            )
+        elif self._charge_limit_late_probe_eligible():
+            schedule_charge_limit_reconcile()
         self._apply_cpu()
         self._apply_gpu_clock()
         self._schedule_tdp_apply("lifecycle", on_ac)
@@ -3138,6 +3186,217 @@ class Plugin:
                 self._charge_limit.disable,
             )
 
+    def _charge_limit_generation_current(self, generation) -> bool:
+        return (
+            self._charge_limit_intent_current(generation)
+            and self._module_enabled("system")
+            and bool(self._settings.get("charge_limit_enabled", False))
+        )
+
+    def _charge_limit_intent_current(self, generation) -> bool:
+        return (
+            generation == self._charge_limit_generation
+            and not getattr(self, "_shutting_down", False)
+        )
+
+    def _charge_limit_late_probe_eligible(self) -> bool:
+        key = getattr(self._device, "key", "")
+        return (
+            key in _ROG_CHARGE_LIMIT_PROFILES
+            or key in _STEAM_DECK_CHARGE_LIMIT_PROFILES
+        )
+
+    def _cancel_charge_limit_reconcile(self, reason) -> int:
+        self._charge_limit_generation = int(
+            getattr(self, "_charge_limit_generation", 0)
+        ) + 1
+        task = getattr(self, "_charge_limit_reconcile_task", None)
+        self._charge_limit_reconcile_task = None
+        if task is not None and not task.done():
+            task.cancel()
+        self._charge_limit_reconciliation = {
+            "generation": self._charge_limit_generation,
+            "trigger": None,
+            "status": "cancelled",
+            "checks": 0,
+            "writes": 0,
+            "readback": None,
+            "reason": reason,
+            "history": list(getattr(self, "_charge_limit_history", ())),
+        }
+        return self._charge_limit_generation
+
+    def _schedule_charge_limit_reconcile(self, trigger) -> None:
+        generation = self._cancel_charge_limit_reconcile("rescheduled")
+        eligible = (
+            self._module_enabled("system")
+            and bool(self._settings.get("charge_limit_enabled", False))
+            and bool(getattr(self._charge_limit, "adjustable", True))
+            and (
+                bool(getattr(self._charge_limit, "supported", False))
+                or self._charge_limit_late_probe_eligible()
+            )
+        )
+        if not eligible:
+            self._charge_limit_reconciliation["trigger"] = trigger
+            self._charge_limit_reconciliation["status"] = "idle"
+            self._charge_limit_reconciliation["reason"] = "not_applicable"
+            return
+        self._charge_limit_reconciliation = {
+            "generation": generation,
+            "trigger": trigger,
+            "status": "scheduled",
+            "checks": 0,
+            "writes": 0,
+            "readback": None,
+            "reason": "verification_pending",
+            "history": list(self._charge_limit_history),
+        }
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._charge_limit_reconciliation["status"] = "idle"
+            self._charge_limit_reconciliation["reason"] = "no_event_loop"
+            return
+        task = loop.create_task(
+            self._reconcile_charge_limit(generation, trigger)
+        )
+        self._charge_limit_reconcile_task = task
+
+        def finished(done):
+            if self._charge_limit_reconcile_task is done:
+                self._charge_limit_reconcile_task = None
+            if not done.cancelled():
+                done.exception()
+
+        task.add_done_callback(finished)
+
+    async def _reprobe_charge_limit(self, generation) -> bool:
+        current = self._charge_limit
+        candidate = await self._offload_call(
+            lambda: select_charge_limit(self._device)
+        )
+        if not self._charge_limit_generation_current(generation):
+            return False
+        if not getattr(candidate, "supported", False):
+            return False
+        if type(candidate) is not type(current):
+            device_key = getattr(self._device, "key", "")
+            allowed_late_probe = (
+                type(current) is NullChargeLimit
+                and (
+                    (
+                        device_key in _ROG_CHARGE_LIMIT_PROFILES
+                        and type(candidate) is SysfsChargeLimit
+                    )
+                    or (
+                        device_key in _STEAM_DECK_CHARGE_LIMIT_PROFILES
+                        and type(candidate)
+                        in (SteamDeckChargeLimit, SysfsChargeLimit)
+                    )
+                )
+            )
+            if not allowed_late_probe:
+                return False
+        self._charge_limit = candidate
+        return True
+
+    async def _reconcile_charge_limit(self, generation, trigger) -> None:
+        if not self._charge_limit_generation_current(generation):
+            return
+        if not bool(getattr(self._charge_limit, "adjustable", True)):
+            self._charge_limit_reconciliation = {
+                "generation": generation,
+                "trigger": trigger,
+                "status": "unverifiable",
+                "checks": 0,
+                "writes": 0,
+                "readback": None,
+                "reason": "fixed_threshold",
+                "history": list(self._charge_limit_history),
+            }
+            return
+        checks = 0
+        writes = 0
+        last_readback = None
+        status = "confirmed"
+        reason = "matched"
+        started = asyncio.get_running_loop().time()
+        for check, delay in enumerate(self._charge_limit_verify_delays, 1):
+            remaining = started + delay - asyncio.get_running_loop().time()
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            if not self._charge_limit_generation_current(generation):
+                return
+            requested = int(self._settings.get("charge_limit_percent", 80))
+            readback = await self._offload_call(self._charge_limit.get)
+            if not self._charge_limit_generation_current(generation):
+                return
+            if readback is None:
+                if await self._reprobe_charge_limit(generation):
+                    readback = await self._offload_call(self._charge_limit.get)
+                    if not self._charge_limit_generation_current(generation):
+                        return
+                else:
+                    checks += 1
+                    last_readback = None
+                    status = "failed"
+                    reason = "backend_unavailable"
+                    self._charge_limit_history.append({
+                        "trigger": trigger,
+                        "check": check,
+                        "requested": requested,
+                        "readback": None,
+                        "action": "unavailable",
+                        "ok": False,
+                        "backend": getattr(
+                            self._charge_limit, "name", "unsupported"
+                        ),
+                    })
+                    continue
+            checks += 1
+            last_readback = readback
+            action = "hold"
+            ok = readback == requested
+            if readback != requested:
+                action = "write"
+                writes += 1
+
+                def write_if_current():
+                    if not self._charge_limit_generation_current(generation):
+                        return None
+                    return self._charge_limit.set(requested)
+
+                applied = await self._offload_call(
+                    write_if_current
+                )
+                if not self._charge_limit_generation_current(generation):
+                    return
+                last_readback = await self._offload_call(self._charge_limit.get)
+                ok = bool(applied) and last_readback == requested
+                status = "recovered" if ok else "failed"
+                reason = "mismatch_corrected" if ok else "write_unconfirmed"
+            event = {
+                "trigger": trigger,
+                "check": check,
+                "requested": requested,
+                "readback": readback,
+                "action": action,
+                "ok": ok,
+                "backend": getattr(self._charge_limit, "name", "unsupported"),
+            }
+            self._charge_limit_history.append(event)
+        self._charge_limit_reconciliation = {
+            "generation": generation,
+            "trigger": trigger,
+            "status": status,
+            "checks": checks,
+            "writes": writes,
+            "readback": last_readback,
+            "reason": reason,
+            "history": list(self._charge_limit_history),
+        }
+
     def _charge_limit_state(self) -> dict:
         lo, hi = self._charge_limit.range()
         enabled = bool(self._settings.get("charge_limit_enabled", False))
@@ -3161,6 +3420,7 @@ class Plugin:
                 if getattr(self, "_charge_limit_last_apply", None) is not None
                 else None
             ),
+            "reconciliation": dict(self._charge_limit_reconciliation),
         }
 
     async def get_battery_state(self) -> dict:
@@ -5089,13 +5349,22 @@ class Plugin:
         """Enable/disable the charge cap and set its threshold. Persists, applies via
         readback, and returns the resulting charge_limit block."""
         self._init()
+        generation = self._cancel_charge_limit_reconcile("new_intent")
         lo, hi = self._charge_limit.range()
         percent = max(lo, min(hi, int(percent)))
         self._settings["charge_limit_enabled"] = bool(enabled)
         self._settings["charge_limit_percent"] = percent
         self._save()
-        self._apply_charge_limit()
-        return self._charge_limit_state()
+        await self._offload_call(
+            lambda: (
+                self._apply_charge_limit()
+                if self._charge_limit_intent_current(generation)
+                else None
+            )
+        )
+        if self._charge_limit_intent_current(generation):
+            self._schedule_charge_limit_reconcile("set_charge_limit")
+        return await self._offload_call(self._charge_limit_state)
 
     # ---- Pantalla (panel color via gamescope) -------------------------------
     def _reapply_color(self) -> None:
@@ -6331,6 +6600,7 @@ class Plugin:
         decky.logger.info("Panel de Control unloaded")
 
     def _prepare_shutdown(self) -> None:
+        self._cancel_charge_limit_reconcile("shutdown")
         self._shutting_down = True
         if not getattr(self, "_hud_shutdown", False):
             self._hud_shutdown = True

--- a/py_modules/battery/charge_limit.py
+++ b/py_modules/battery/charge_limit.py
@@ -24,9 +24,7 @@ class ChargeLimitBackend:
 
     supported = False
     adjustable = True
-    # For fixed-cap (non-adjustable) backends, the percentage the firmware holds
-    # when enabled — surfaced so the UI can state it explicitly. None = unknown.
-    fixed_percent = None
+    name = "unsupported"
 
     def get(self):
         return None
@@ -81,6 +79,7 @@ class SysfsChargeLimit(_FileChargeLimit):
     it under power_supply/BAT*). 100 = no cap."""
 
     _OFF = _MAX
+    name = "sysfs-threshold"
 
     def __init__(self, root="/"):
         super().__init__(self._find(root))
@@ -100,6 +99,7 @@ class SteamDeckChargeLimit(_FileChargeLimit):
     from the ASUS/Lenovo 100)."""
 
     _OFF = 0
+    name = "steamdeck-hwmon"
 
     def __init__(self, root="/"):
         super().__init__(self._find(root))
@@ -117,12 +117,10 @@ class SteamDeckChargeLimit(_FileChargeLimit):
 
 class LenovoConservationMode(ChargeLimitBackend):
     """Lenovo (Legion Go) `conservation_mode`: a boolean (1=cap on) with a
-    firmware-fixed threshold, NOT a settable percent.
-    `adjustable=False` → the UI shows an on/off toggle (no slider) and states the
-    fixed cap (`fixed_percent`, the Legion Go conservation level ≈80%)."""
+    firmware-controlled threshold, NOT a settable percent."""
 
     adjustable = False
-    fixed_percent = 80
+    name = "lenovo-conservation"
 
     def __init__(self, root="/"):
         self._path = self._find(root)

--- a/src/api.ts
+++ b/src/api.ts
@@ -428,11 +428,13 @@ export interface BatteryInfo {
 }
 
 export interface ChargeLimit {
+  backend: string;
   supported: boolean;
-  // false = fixed firmware cap (on/off only, no slider — e.g. Lenovo conservation)
+  // false = firmware-controlled on/off cap (no slider — e.g. Lenovo conservation)
   adjustable: boolean;
   enabled: boolean;
   percent: number;
+  applied_percent: number | null;
   min: number;
   max: number;
 }

--- a/src/components/BatteryCard.tsx
+++ b/src/components/BatteryCard.tsx
@@ -165,9 +165,9 @@ export const BatteryCard: FC<Props> = ({ state, onSetLimit, hideHealth = false }
                 </span>
               </div>
             )}
-            {cl.enabled && !cl.adjustable && (
+            {cl.enabled && !cl.adjustable && cl.applied_percent !== null && (
               <div style={{ fontSize: theme.font.caption, color: theme.color.textMuted }}>
-                {t("system.battery.limit.fixed", { percent: cl.percent })}
+                {t("system.battery.limit.fixed", { percent: cl.applied_percent })}
               </div>
             )}
           </div>

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -68,6 +68,7 @@ def _make_plugin(tmp_path, monkeypatch, charge_limit=None):
 
 class _FakeChargeLimit:
     adjustable = True
+    name = "fake"
 
     def __init__(self, supported=True):
         self.supported = supported
@@ -134,6 +135,28 @@ def test_set_charge_limit_enables_and_applies(tmp_path, monkeypatch):
     assert cl_backend.value == 70  # applied to hardware
 
 
+def test_battery_state_keeps_saved_intent_separate_from_readback(tmp_path, monkeypatch):
+    backend = _FakeChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    asyncio.run(p.set_charge_limit(True, 80))
+    backend.value = 0
+
+    state = asyncio.run(p.get_battery_state())["charge_limit"]
+
+    assert state["percent"] == 80
+    assert state["applied_percent"] == 0
+    assert state["backend"] == "fake"
+
+
+def test_set_charge_limit_clamps_intent_before_persisting(tmp_path, monkeypatch):
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=_FakeChargeLimit())
+
+    result = asyncio.run(p.set_charge_limit(True, 140))
+
+    assert result["percent"] == 100
+    assert p._settings["charge_limit_percent"] == 100
+
+
 def test_failed_charge_limit_write_keeps_intent_and_reports_readback(tmp_path, monkeypatch):
     backend = _FailingChargeLimit()
     p = _make_plugin(
@@ -146,7 +169,8 @@ def test_failed_charge_limit_write_keeps_intent_and_reports_readback(tmp_path, m
 
     assert result["enabled"] is True
     assert backend.attempts == 2
-    assert result["percent"] == 100
+    assert result["percent"] == 70
+    assert result["applied_percent"] == 100
     assert result["last_apply"] == {
         "action": "set",
         "requested": 70,

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -522,6 +522,124 @@ def test_exact_profile_rejects_unwritable_late_probe_candidate(
     assert set_requests == [80]
 
 
+def test_failed_private_candidate_is_consumed_once(tmp_path, monkeypatch):
+    candidate = _FailingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_candidate = candidate
+
+    p._apply_charge_limit()
+    p._apply_charge_limit()
+
+    assert candidate.attempts == 2
+    assert p._charge_limit_candidate is None
+
+
+@pytest.mark.parametrize("action", ["cancel", "reschedule", "shutdown"])
+def test_private_candidate_is_cleared_at_lifecycle_boundary(
+    tmp_path, monkeypatch, action
+):
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._charge_limit_candidate = _FakeChargeLimit()
+
+    if action == "cancel":
+        p._cancel_charge_limit_reconcile("test")
+    elif action == "reschedule":
+        p._schedule_charge_limit_reconcile("test")
+    else:
+        p._prepare_shutdown()
+
+    assert p._charge_limit_candidate is None
+
+
+def test_cancelled_probe_task_clears_private_candidate(tmp_path, monkeypatch):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    generation = p._charge_limit_generation
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: candidate)
+    confirmation_started = asyncio.Event()
+    candidate_reads = 0
+
+    async def controlled_offload(operation):
+        nonlocal candidate_reads
+        if (
+            getattr(operation, "__self__", None) is candidate
+            and getattr(operation, "__name__", "") == "get"
+        ):
+            candidate_reads += 1
+            if candidate_reads == 2:
+                confirmation_started.set()
+                await asyncio.Event().wait()
+        return operation()
+
+    p._offload_call = controlled_offload
+
+    async def scenario():
+        reconcile = asyncio.create_task(
+            p._reconcile_charge_limit(generation, "test")
+        )
+        await confirmation_started.wait()
+        reconcile.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reconcile
+
+    asyncio.run(scenario())
+
+    assert p._charge_limit_candidate is None
+
+
+def test_reapply_transfers_private_candidate_once_for_null_backend(
+    tmp_path, monkeypatch
+):
+    candidate = _FailingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_candidate = candidate
+
+    for name in (
+        "_cancel_color_revert",
+        "_apply_cpu",
+        "_apply_gpu_clock",
+        "_schedule_tdp_apply",
+        "_reapply_fans",
+        "_reapply_hdr",
+        "_reapply_color",
+        "_reapply_audio",
+        "_reapply_controller",
+        "_schedule_hud_apply",
+    ):
+        monkeypatch.setattr(p, name, lambda *args: None)
+    monkeypatch.setattr(p, "_tdp_control_on", lambda: True)
+
+    def immediate_offload(operation, done=None):
+        operation()
+        if done is not None:
+            done()
+
+    monkeypatch.setattr(p, "_offload", immediate_offload)
+    monkeypatch.setattr(
+        p, "_schedule_charge_limit_reconcile", lambda trigger: None
+    )
+
+    p._reapply_all()
+    p._reapply_all()
+
+    assert candidate.attempts == 2
+    assert p._charge_limit_candidate is None
+
+
 def test_newer_disable_reaches_private_candidate_without_stale_promotion(
     tmp_path, monkeypatch
 ):

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -522,6 +522,102 @@ def test_exact_profile_rejects_unwritable_late_probe_candidate(
     assert set_requests == [80]
 
 
+def test_newer_disable_reaches_private_candidate_without_stale_promotion(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    generation = p._charge_limit_generation
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: candidate)
+    confirmation_started = asyncio.Event()
+    release_confirmation = asyncio.Event()
+    candidate_reads = 0
+
+    async def controlled_offload(operation):
+        nonlocal candidate_reads
+        if (
+            getattr(operation, "__self__", None) is candidate
+            and getattr(operation, "__name__", "") == "get"
+        ):
+            candidate_reads += 1
+            if candidate_reads == 2:
+                confirmation_started.set()
+                await release_confirmation.wait()
+        return operation()
+
+    p._offload_call = controlled_offload
+
+    async def scenario():
+        old_reconcile = asyncio.create_task(
+            p._reconcile_charge_limit(generation, "old")
+        )
+        await confirmation_started.wait()
+        disabled = await p.set_charge_limit(False, 80)
+        diagnostics = p._charge_limit_reconciliation
+        disabled_value = candidate.get()
+        release_confirmation.set()
+        await old_reconcile
+        return disabled, disabled_value, diagnostics
+
+    disabled, disabled_value, diagnostics = asyncio.run(scenario())
+
+    assert disabled["supported"] is False
+    assert disabled_value == 100
+    assert isinstance(p._charge_limit, NullChargeLimit)
+    assert p._charge_limit_reconciliation == diagnostics
+    assert p._charge_limit_reconciliation["generation"] > generation
+
+
+def test_newer_disable_prevents_stale_post_write_diagnostics(
+    tmp_path, monkeypatch
+):
+    backend = _RecordingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    generation = p._charge_limit_generation
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    confirmation_started = asyncio.Event()
+    release_confirmation = asyncio.Event()
+    backend_reads = 0
+
+    async def controlled_offload(operation):
+        nonlocal backend_reads
+        if operation == backend.get:
+            backend_reads += 1
+            if backend_reads == 2:
+                confirmation_started.set()
+                await release_confirmation.wait()
+        return operation()
+
+    p._offload_call = controlled_offload
+
+    async def scenario():
+        old_reconcile = asyncio.create_task(
+            p._reconcile_charge_limit(generation, "old")
+        )
+        await confirmation_started.wait()
+        await p.set_charge_limit(False, 80)
+        diagnostics = p._charge_limit_reconciliation
+        release_confirmation.set()
+        await old_reconcile
+        return diagnostics
+
+    diagnostics = asyncio.run(scenario())
+
+    assert backend.value == 100
+    assert p._charge_limit_reconciliation == diagnostics
+    assert p._charge_limit_reconciliation["generation"] > generation
+
+
 @pytest.mark.parametrize(
     "device_key",
     ["msi_claw_8_ai_plus", "generic", "rog_future"],

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -4,6 +4,7 @@ Bootstraps a real Plugin with a fake decky module and a fake TDP backend (so
 _init never touches live hardware), then injects a fake charge-limit backend.
 """
 import asyncio
+import concurrent.futures
 import importlib
 import sys
 import threading
@@ -683,6 +684,61 @@ def test_latest_of_two_queued_intents_applies_private_candidate(
     assert candidate.get() == 60
     assert p._charge_limit_candidate is None
     assert isinstance(p._charge_limit, NullChargeLimit)
+
+
+def test_cancelled_queued_intent_still_applies_private_candidate(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    candidate.set(80)
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_candidate = candidate
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = executor
+
+    def block_worker():
+        worker_started.set()
+        release_worker.wait(timeout=1)
+
+    executor.submit(block_worker)
+
+    async def scenario():
+        while not worker_started.is_set():
+            await asyncio.sleep(0)
+        rpc = asyncio.create_task(p.set_charge_limit(False, 80))
+        while not p._offload_futures:
+            await asyncio.sleep(0)
+        rpc.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await rpc
+        release_worker.set()
+        await p._drain_offloaded()
+        for _ in range(20):
+            if (
+                p._charge_limit_reconciliation["trigger"]
+                == "set_charge_limit"
+            ):
+                break
+            await asyncio.sleep(0)
+        reconcile = p._charge_limit_reconcile_task
+        if reconcile is not None:
+            reconcile.cancel()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        release_worker.set()
+        executor.shutdown(wait=True)
+
+    assert candidate.get() == 100
+    assert p._charge_limit_candidate is None
+    assert p._charge_limit_reconciliation["trigger"] == "set_charge_limit"
 
 
 def test_latest_of_two_queued_reapplies_applies_private_candidate(

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -640,6 +640,100 @@ def test_reapply_transfers_private_candidate_once_for_null_backend(
     assert p._charge_limit_candidate is None
 
 
+def test_latest_of_two_queued_intents_applies_private_candidate(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    candidate.set(80)
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_candidate = candidate
+    first_offload_started = asyncio.Event()
+    release_first_offload = asyncio.Event()
+    serial_lock = asyncio.Lock()
+    offload_calls = 0
+
+    async def controlled_offload(operation):
+        nonlocal offload_calls
+        async with serial_lock:
+            offload_calls += 1
+            if offload_calls == 1:
+                first_offload_started.set()
+                await release_first_offload.wait()
+            return operation()
+
+    p._offload_call = controlled_offload
+    monkeypatch.setattr(
+        p, "_schedule_charge_limit_reconcile", lambda trigger: None
+    )
+
+    async def scenario():
+        first = asyncio.create_task(p.set_charge_limit(False, 80))
+        await first_offload_started.wait()
+        second = asyncio.create_task(p.set_charge_limit(True, 60))
+        while p._settings["charge_limit_percent"] != 60:
+            await asyncio.sleep(0)
+        release_first_offload.set()
+        await asyncio.gather(first, second)
+
+    asyncio.run(scenario())
+
+    assert candidate.get() == 60
+    assert p._charge_limit_candidate is None
+    assert isinstance(p._charge_limit, NullChargeLimit)
+
+
+def test_latest_of_two_queued_reapplies_applies_private_candidate(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    candidate.set(80)
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 70
+    p._charge_limit_candidate = candidate
+
+    for name in (
+        "_cancel_color_revert",
+        "_apply_cpu",
+        "_apply_gpu_clock",
+        "_schedule_tdp_apply",
+        "_reapply_fans",
+        "_reapply_hdr",
+        "_reapply_color",
+        "_reapply_audio",
+        "_reapply_controller",
+        "_schedule_hud_apply",
+    ):
+        monkeypatch.setattr(p, name, lambda *args: None)
+    monkeypatch.setattr(p, "_tdp_control_on", lambda: True)
+    queued = []
+    monkeypatch.setattr(
+        p,
+        "_offload",
+        lambda operation, done=None: queued.append((operation, done)),
+    )
+    monkeypatch.setattr(
+        p, "_schedule_charge_limit_reconcile", lambda trigger: None
+    )
+
+    p._reapply_all()
+    p._settings["charge_limit_percent"] = 60
+    p._reapply_all()
+    for operation, done in queued:
+        operation()
+        if done is not None:
+            done()
+
+    assert candidate.get() == 60
+    assert p._charge_limit_candidate is None
+    assert isinstance(p._charge_limit, NullChargeLimit)
+
+
 def test_newer_disable_reaches_private_candidate_without_stale_promotion(
     tmp_path, monkeypatch
 ):

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -6,7 +6,16 @@ _init never touches live hardware), then injects a fake charge-limit backend.
 import asyncio
 import importlib
 import sys
+import threading
 import types
+
+import pytest
+
+from battery.charge_limit import (
+    NullChargeLimit,
+    SteamDeckChargeLimit,
+    SysfsChargeLimit,
+)
 
 
 def _make_plugin(tmp_path, monkeypatch, charge_limit=None):
@@ -113,6 +122,64 @@ class _FlakyChargeLimit(_FakeChargeLimit):
         if self.attempts == 1:
             return False
         return super().set(percent)
+
+
+class _RecordingChargeLimit(_FakeChargeLimit):
+    def __init__(self, supported=True):
+        super().__init__(supported=supported)
+        self.set_requests = []
+
+    def set(self, percent):
+        self.set_requests.append(percent)
+        return super().set(percent)
+
+
+class _ReplaceableChargeLimit(_RecordingChargeLimit):
+    def __init__(self, lost=False):
+        super().__init__()
+        self.lost = lost
+
+    def get(self):
+        return None if self.lost else super().get()
+
+    def set(self, percent):
+        self.set_requests.append(percent)
+        if self.lost:
+            return False
+        return _FakeChargeLimit.set(self, percent)
+
+
+class _BlockingChargeLimit(_FakeChargeLimit):
+    def __init__(self):
+        super().__init__()
+        self.release = threading.Event()
+
+    def set(self, percent):
+        if not self.release.wait(0.2):
+            return False
+        return super().set(percent)
+
+
+class _FixedChargeLimit(_RecordingChargeLimit):
+    adjustable = False
+    name = "lenovo-conservation"
+
+    def get(self):
+        return None
+
+
+def _late_probe_backend(tmp_path, kind):
+    if kind == "sysfs":
+        node = tmp_path / "sys/class/power_supply/BAT0/charge_control_end_threshold"
+        backend_class = SysfsChargeLimit
+    else:
+        node = tmp_path / "sys/class/hwmon/hwmon3/max_battery_charge_level"
+        backend_class = SteamDeckChargeLimit
+        node.parent.mkdir(parents=True, exist_ok=True)
+        (node.parent / "name").write_text("steamdeck_hwmon")
+    node.parent.mkdir(parents=True, exist_ok=True)
+    node.write_text("100")
+    return backend_class(root=str(tmp_path))
 
 
 def test_get_battery_state_shape(tmp_path, monkeypatch):
@@ -228,3 +295,337 @@ def test_unsupported_charge_limit_degrades(tmp_path, monkeypatch):
     p = _make_plugin(tmp_path, monkeypatch, charge_limit=_FakeChargeLimit(supported=False))
     result = asyncio.run(p.set_charge_limit(True, 70))
     assert result["supported"] is False
+
+
+def test_reconcile_restores_saved_limit_after_external_reset(tmp_path, monkeypatch):
+    backend = _FakeChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    backend.set(80)
+    backend.value = 100
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,), raising=False)
+
+    p._charge_limit_generation += 1
+    asyncio.run(p._reconcile_charge_limit(p._charge_limit_generation, "test"))
+
+    assert backend.value == 80
+    assert p._charge_limit_reconciliation == {
+        "generation": 1,
+        "trigger": "test",
+        "status": "recovered",
+        "checks": 1,
+        "writes": 1,
+        "readback": 80,
+        "reason": "mismatch_corrected",
+        "history": [
+            {
+                "trigger": "test",
+                "check": 1,
+                "requested": 80,
+                "readback": 100,
+                "action": "write",
+                "ok": True,
+                "backend": "fake",
+            }
+        ],
+    }
+
+
+def test_newer_disable_invalidates_reconcile_before_stale_write(tmp_path, monkeypatch):
+    backend = _RecordingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    generation = p._charge_limit_generation
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    read_started = asyncio.Event()
+    release_read = asyncio.Event()
+
+    async def paused_offload(operation):
+        if operation == backend.get and not read_started.is_set():
+            read_started.set()
+            await release_read.wait()
+        return operation()
+
+    p._offload_call = paused_offload
+
+    async def scenario():
+        reconcile = asyncio.create_task(
+            p._reconcile_charge_limit(generation, "test")
+        )
+        await read_started.wait()
+        await p.set_charge_limit(False, 80)
+        release_read.set()
+        await reconcile
+
+    asyncio.run(scenario())
+
+    assert p._charge_limit_generation > generation
+    assert backend.set_requests == []
+    assert backend.value == 100
+
+
+def test_shutdown_invalidates_reconcile_before_stale_write(tmp_path, monkeypatch):
+    backend = _RecordingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    generation = p._charge_limit_generation
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+
+    p._prepare_shutdown()
+    asyncio.run(p._reconcile_charge_limit(generation, "test"))
+
+    assert p._charge_limit_generation > generation
+    assert p._charge_limit_reconcile_task is None
+    assert backend.set_requests == []
+
+
+def test_reconcile_replaces_lost_backend_with_same_class(tmp_path, monkeypatch):
+    lost = _ReplaceableChargeLimit(lost=True)
+    replacement = _ReplaceableChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=lost)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: replacement)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    assert p._charge_limit is replacement
+    assert lost.set_requests == []
+    assert replacement.set_requests == [80]
+    assert replacement.value == 80
+
+
+def test_reconcile_rejects_different_replacement_class(tmp_path, monkeypatch):
+    lost = _ReplaceableChargeLimit(lost=True)
+    different = _RecordingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=lost)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: different)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    assert p._charge_limit is lost
+    assert lost.set_requests == []
+    assert different.set_requests == []
+
+
+@pytest.mark.parametrize(
+    ("device_key", "kind", "backend_class"),
+    [
+        ("rog_xbox_ally_x", "sysfs", SysfsChargeLimit),
+        ("steam_deck_oled", "deck", SteamDeckChargeLimit),
+    ],
+)
+def test_exact_profile_can_gain_supported_backend_late(
+    tmp_path, monkeypatch, device_key, kind, backend_class
+):
+    replacement = _late_probe_backend(tmp_path, kind)
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key=device_key)
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: replacement)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    assert isinstance(p._charge_limit, backend_class)
+    assert p._charge_limit.get() == 80
+
+
+@pytest.mark.parametrize(
+    "device_key",
+    ["msi_claw_8_ai_plus", "generic", "rog_future"],
+)
+def test_late_probe_does_not_expand_null_backend_support(
+    tmp_path, monkeypatch, device_key
+):
+    replacement = _late_probe_backend(tmp_path, "sysfs")
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key=device_key)
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: replacement)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    assert isinstance(p._charge_limit, NullChargeLimit)
+    assert replacement.get() == 100
+
+
+def test_set_charge_limit_offloads_apply_and_schedules_reconcile(
+    tmp_path, monkeypatch
+):
+    backend = _BlockingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+
+    async def scenario():
+        asyncio.get_running_loop().call_later(0.01, backend.release.set)
+        result = await p.set_charge_limit(True, 80)
+        task = p._charge_limit_reconcile_task
+        assert task is not None
+        assert not task.done()
+        task.cancel()
+        return result
+
+    result = asyncio.run(scenario())
+
+    assert result["applied_percent"] == 80
+    assert result["reconciliation"]["trigger"] == "set_charge_limit"
+
+
+def test_reapply_offloads_charge_limit_before_scheduling_reconcile(
+    tmp_path, monkeypatch
+):
+    backend = _RecordingChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    events = []
+
+    for name in (
+        "_cancel_color_revert",
+        "_apply_cpu",
+        "_apply_gpu_clock",
+        "_schedule_tdp_apply",
+        "_reapply_fans",
+        "_reapply_hdr",
+        "_reapply_color",
+        "_reapply_audio",
+        "_reapply_controller",
+        "_schedule_hud_apply",
+    ):
+        monkeypatch.setattr(p, name, lambda *args: None)
+    monkeypatch.setattr(p, "_tdp_control_on", lambda: True)
+
+    def immediate_offload(operation, done=None):
+        events.append("offload")
+        operation()
+        events.append("apply")
+        if done is not None:
+            done()
+
+    monkeypatch.setattr(p, "_offload", immediate_offload)
+    original_schedule = p._schedule_charge_limit_reconcile
+
+    def record_schedule(trigger):
+        events.append("schedule")
+        original_schedule(trigger)
+
+    monkeypatch.setattr(p, "_schedule_charge_limit_reconcile", record_schedule)
+
+    async def scenario():
+        p._reapply_all()
+        assert p._charge_limit_reconcile_task is not None
+        p._charge_limit_reconcile_task.cancel()
+
+    asyncio.run(scenario())
+
+    assert events[:3] == ["offload", "apply", "schedule"]
+    assert backend.set_requests == [80]
+
+
+def test_reconcile_does_not_invent_readback_for_fixed_backend(
+    tmp_path, monkeypatch
+):
+    backend = _FixedChargeLimit()
+    replacement = _FixedChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: replacement)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    assert backend.set_requests == []
+    assert replacement.set_requests == []
+    assert p._charge_limit_reconciliation["status"] == "unverifiable"
+    assert p._charge_limit_reconciliation["readback"] is None
+    assert p._charge_limit_reconciliation["writes"] == 0
+
+
+def test_reconcile_history_keeps_only_eight_allowlisted_events(
+    tmp_path, monkeypatch
+):
+    backend = _FakeChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+
+    async def scenario():
+        for index in range(10):
+            p._charge_limit_generation += 1
+            await p._reconcile_charge_limit(
+                p._charge_limit_generation, f"test-{index}"
+            )
+
+    asyncio.run(scenario())
+
+    history = p._charge_limit_reconciliation["history"]
+    assert len(history) == 8
+    assert history[0]["trigger"] == "test-2"
+    assert set(history[-1]) == {
+        "trigger",
+        "check",
+        "requested",
+        "readback",
+        "action",
+        "ok",
+        "backend",
+    }
+
+
+def test_new_schedule_cancels_previous_reconcile_task(tmp_path, monkeypatch):
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=_FakeChargeLimit())
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (3600.0,))
+
+    async def scenario():
+        p._schedule_charge_limit_reconcile("first")
+        first = p._charge_limit_reconcile_task
+        p._schedule_charge_limit_reconcile("second")
+        second = p._charge_limit_reconcile_task
+        await asyncio.sleep(0)
+        assert first.cancelled()
+        assert second is not first
+        assert not second.done()
+        second.cancel()
+
+    asyncio.run(scenario())

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -161,6 +161,28 @@ class _BlockingChargeLimit(_FakeChargeLimit):
         return super().set(percent)
 
 
+class _BlockingFailedWriteChargeLimit(_FakeChargeLimit):
+    def __init__(self):
+        super().__init__()
+        self.write_started = threading.Event()
+        self.release_write = threading.Event()
+        self.writes = []
+        self._first_write = True
+
+    def set(self, percent):
+        self.writes.append(int(percent))
+        if self._first_write:
+            self._first_write = False
+            self.write_started.set()
+            self.release_write.wait(timeout=1)
+            return False
+        return super().set(percent)
+
+    def disable(self):
+        self.writes.append("off")
+        return super().disable()
+
+
 class _FixedChargeLimit(_RecordingChargeLimit):
     adjustable = False
     name = "lenovo-conservation"
@@ -329,9 +351,36 @@ def test_reconcile_restores_saved_limit_after_external_reset(tmp_path, monkeypat
                 "action": "write",
                 "ok": True,
                 "backend": "fake",
+                "reason": "mismatch_corrected",
             }
         ],
     }
+
+
+def test_later_match_replaces_failed_reconcile_summary(tmp_path, monkeypatch):
+    backend = _FakeChargeLimit()
+    reads = iter((100, 100, 80))
+    monkeypatch.setattr(backend, "get", lambda: next(reads, 80))
+    monkeypatch.setattr(backend, "set", lambda percent: False)
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0, 0.0))
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    summary = p._charge_limit_reconciliation
+    assert summary["status"] == "confirmed"
+    assert summary["reason"] == "matched"
+    assert summary["readback"] == 80
+    assert summary["checks"] == 2
+    assert summary["writes"] == 1
+    assert summary["history"][-2]["ok"] is False
+    assert summary["history"][-1]["ok"] is True
 
 
 def test_newer_disable_invalidates_reconcile_before_stale_write(tmp_path, monkeypatch):
@@ -523,6 +572,84 @@ def test_exact_profile_rejects_unwritable_late_probe_candidate(
     assert set_requests == [80]
 
 
+@pytest.mark.parametrize(
+    (
+        "case",
+        "expected_reason",
+        "expected_backend",
+        "expected_readback",
+        "expected_action",
+        "expected_writes",
+    ),
+    [
+        ("no_candidate", "no_candidate", "unsupported", None, "unavailable", 0),
+        ("wrong_class", "wrong_class", "fake", None, "unavailable", 0),
+        ("unreadable", "unreadable", "sysfs-threshold", None, "unavailable", 0),
+        ("write_rejected", "write_rejected", "sysfs-threshold", 100, "write", 1),
+        (
+            "confirmation_failed",
+            "confirmation_failed",
+            "sysfs-threshold",
+            100,
+            "write",
+            1,
+        ),
+    ],
+)
+def test_late_probe_reports_allowlisted_failure_reason(
+    tmp_path,
+    monkeypatch,
+    case,
+    expected_reason,
+    expected_backend,
+    expected_readback,
+    expected_action,
+    expected_writes,
+):
+    if case == "no_candidate":
+        candidate = NullChargeLimit()
+    elif case == "wrong_class":
+        candidate = _RecordingChargeLimit()
+    else:
+        candidate = _late_probe_backend(tmp_path, "sysfs")
+        if case == "unreadable":
+            monkeypatch.setattr(candidate, "get", lambda: None)
+        elif case == "write_rejected":
+            monkeypatch.setattr(candidate, "set", lambda percent: False)
+        else:
+            monkeypatch.setattr(candidate, "set", lambda percent: True)
+
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: candidate)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    summary = p._charge_limit_reconciliation
+    assert summary["status"] == "failed"
+    assert summary["reason"] == expected_reason
+    assert summary["readback"] == expected_readback
+    assert summary["writes"] == expected_writes
+    assert summary["history"][-1] == {
+        "trigger": "test",
+        "check": 1,
+        "requested": 80,
+        "readback": expected_readback,
+        "action": expected_action,
+        "ok": False,
+        "backend": expected_backend,
+        "reason": expected_reason,
+    }
+    assert isinstance(p._charge_limit, NullChargeLimit)
+
+
 def test_failed_private_candidate_is_consumed_once(tmp_path, monkeypatch):
     candidate = _FailingChargeLimit()
     p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
@@ -684,6 +811,66 @@ def test_latest_of_two_queued_intents_applies_private_candidate(
     assert candidate.get() == 60
     assert p._charge_limit_candidate is None
     assert isinstance(p._charge_limit, NullChargeLimit)
+
+
+def test_selected_backend_skips_retry_after_newer_intent(
+    tmp_path, monkeypatch
+):
+    backend = _BlockingFailedWriteChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = executor
+
+    async def scenario():
+        old = asyncio.create_task(p.set_charge_limit(True, 80))
+        while not backend.write_started.is_set():
+            await asyncio.sleep(0)
+        latest = asyncio.create_task(p.set_charge_limit(False, 80))
+        while p._settings["charge_limit_enabled"]:
+            await asyncio.sleep(0)
+        backend.release_write.set()
+        await asyncio.gather(old, latest)
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        backend.release_write.set()
+        executor.shutdown(wait=True)
+
+    assert backend.writes == [80, "off"]
+    assert backend.value == 100
+
+
+def test_private_candidate_skips_retry_after_newer_intent(
+    tmp_path, monkeypatch
+):
+    candidate = _BlockingFailedWriteChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._charge_limit_candidate = candidate
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    p._apply_executor = executor
+
+    async def scenario():
+        old = asyncio.create_task(p.set_charge_limit(True, 80))
+        while not candidate.write_started.is_set():
+            await asyncio.sleep(0)
+        latest = asyncio.create_task(p.set_charge_limit(False, 80))
+        while p._settings["charge_limit_enabled"]:
+            await asyncio.sleep(0)
+        candidate.release_write.set()
+        await asyncio.gather(old, latest)
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        candidate.release_write.set()
+        executor.shutdown(wait=True)
+
+    assert candidate.writes == [80, "off"]
+    assert candidate.value == 100
+    assert p._charge_limit_candidate is None
 
 
 def test_cancelled_queued_intent_still_applies_private_candidate(
@@ -1031,6 +1218,7 @@ def test_reconcile_history_keeps_only_eight_allowlisted_events(
         "action",
         "ok",
         "backend",
+        "reason",
     }
 
 

--- a/tests/test_battery_rpc.py
+++ b/tests/test_battery_rpc.py
@@ -454,6 +454,72 @@ def test_exact_profile_can_gain_supported_backend_late(
 
     assert isinstance(p._charge_limit, backend_class)
     assert p._charge_limit.get() == 80
+    assert p._charge_limit_reconciliation["status"] == "recovered"
+    assert p._charge_limit_reconciliation["history"][-1]["action"] == "write"
+
+
+def test_exact_profile_rejects_unreadable_late_probe_candidate(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    set_requests = []
+    monkeypatch.setattr(candidate, "get", lambda: None)
+    monkeypatch.setattr(
+        candidate,
+        "set",
+        lambda percent: (set_requests.append(percent), False)[1],
+    )
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: candidate)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    state = p._charge_limit_state()
+    assert isinstance(p._charge_limit, NullChargeLimit)
+    assert state["supported"] is False
+    assert state["backend"] == "unsupported"
+    assert set_requests == []
+    assert p._charge_limit_reconciliation["status"] == "failed"
+    assert p._charge_limit_reconciliation["checks"] == 1
+    assert p._charge_limit_reconciliation["history"][-1]["action"] == "unavailable"
+
+
+def test_exact_profile_rejects_unwritable_late_probe_candidate(
+    tmp_path, monkeypatch
+):
+    candidate = _late_probe_backend(tmp_path, "sysfs")
+    set_requests = []
+    monkeypatch.setattr(
+        candidate,
+        "set",
+        lambda percent: (set_requests.append(percent), False)[1],
+    )
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=NullChargeLimit())
+    p._init()
+    p._device = types.SimpleNamespace(key="rog_xbox_ally_x")
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    p._charge_limit_generation += 1
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
+    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: candidate)
+
+    asyncio.run(
+        p._reconcile_charge_limit(p._charge_limit_generation, "test")
+    )
+
+    state = p._charge_limit_state()
+    assert isinstance(p._charge_limit, NullChargeLimit)
+    assert state["supported"] is False
+    assert state["backend"] == "unsupported"
+    assert set_requests == [80]
 
 
 @pytest.mark.parametrize(
@@ -554,26 +620,19 @@ def test_reapply_offloads_charge_limit_before_scheduling_reconcile(
     assert backend.set_requests == [80]
 
 
-def test_reconcile_does_not_invent_readback_for_fixed_backend(
-    tmp_path, monkeypatch
-):
+def test_scheduler_reports_fixed_backend_as_unverifiable(tmp_path, monkeypatch):
     backend = _FixedChargeLimit()
-    replacement = _FixedChargeLimit()
     p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
     p._init()
     p._settings["charge_limit_enabled"] = True
     p._settings["charge_limit_percent"] = 80
-    p._charge_limit_generation += 1
-    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0,))
-    monkeypatch.setattr(sys.modules["main"], "select_charge_limit", lambda _: replacement)
 
-    asyncio.run(
-        p._reconcile_charge_limit(p._charge_limit_generation, "test")
-    )
+    p._schedule_charge_limit_reconcile("test")
 
     assert backend.set_requests == []
-    assert replacement.set_requests == []
+    assert p._charge_limit_reconcile_task is None
     assert p._charge_limit_reconciliation["status"] == "unverifiable"
+    assert p._charge_limit_reconciliation["reason"] == "fixed_threshold"
     assert p._charge_limit_reconciliation["readback"] is None
     assert p._charge_limit_reconciliation["writes"] == 0
 
@@ -609,6 +668,35 @@ def test_reconcile_history_keeps_only_eight_allowlisted_events(
         "ok",
         "backend",
     }
+
+
+def test_reconcile_publishes_each_check_before_next_delay(tmp_path, monkeypatch):
+    backend = _FakeChargeLimit()
+    p = _make_plugin(tmp_path, monkeypatch, charge_limit=backend)
+    p._init()
+    p._settings["charge_limit_enabled"] = True
+    p._settings["charge_limit_percent"] = 80
+    monkeypatch.setattr(p, "_charge_limit_verify_delays", (0.0, 3600.0))
+
+    async def scenario():
+        p._schedule_charge_limit_reconcile("test")
+
+        async def first_check_finished():
+            while not p._charge_limit_history:
+                await asyncio.sleep(0.001)
+
+        await asyncio.wait_for(first_check_finished(), timeout=1.0)
+        snapshot = dict(p._charge_limit_reconciliation)
+        p._charge_limit_reconcile_task.cancel()
+        return snapshot
+
+    snapshot = asyncio.run(scenario())
+
+    assert snapshot["status"] == "recovered"
+    assert snapshot["checks"] == 1
+    assert snapshot["writes"] == 1
+    assert snapshot["readback"] == 80
+    assert len(snapshot["history"]) == 1
 
 
 def test_new_schedule_cancels_previous_reconcile_task(tmp_path, monkeypatch):

--- a/tests/test_charge_limit.py
+++ b/tests/test_charge_limit.py
@@ -139,9 +139,20 @@ def test_lenovo_conservation_is_boolean_toggle(tmp_path):
     assert cl.supported is True
     assert cl.adjustable is False
     assert cl.get() is None  # no known percent read from sysfs
-    assert cl.fixed_percent == 80  # firmware conservation level, surfaced to the UI
+    assert not hasattr(cl, "fixed_percent")
     assert cl.set(80) is True  # percent ignored -> writes 1 (on)
     assert cl.disable() is True
+
+
+def test_charge_limit_backend_names_are_stable(tmp_path):
+    _mk_bat(str(tmp_path), value="80")
+    _mk_deck_hwmon(str(tmp_path), value="0")
+    _mk_conservation(str(tmp_path), value="0")
+
+    assert NullChargeLimit().name == "unsupported"
+    assert SysfsChargeLimit(root=str(tmp_path)).name == "sysfs-threshold"
+    assert SteamDeckChargeLimit(root=str(tmp_path)).name == "steamdeck-hwmon"
+    assert LenovoConservationMode(root=str(tmp_path)).name == "lenovo-conservation"
 
 
 def test_lenovo_conservation_unsupported_without_file(tmp_path):

--- a/tests/test_modules_gating.py
+++ b/tests/test_modules_gating.py
@@ -75,6 +75,32 @@ def test_charge_limit_applied_when_system_enabled():
     assert ("set", 80) in p._charge_limit.calls
 
 
+def test_disabling_system_invalidates_old_charge_limit_reconcile():
+    import asyncio
+
+    p = _plugin_cl()
+    p._init = lambda: None
+    p._save = lambda: None
+    p._sync_sampler = lambda: None
+    p._release_gpu_clock = lambda *_: asyncio.sleep(0)
+    p._reapply_all = p._apply_charge_limit
+    p._charge_limit_generation = 1
+    p._charge_limit_reconcile_task = None
+    p._charge_limit_history = []
+    p._charge_limit_reconciliation = {}
+    p._charge_limit_verify_delays = (0.0,)
+    old_generation = p._charge_limit_generation
+
+    async def scenario():
+        await p.set_ui_module("system", True)
+        await p._reconcile_charge_limit(old_generation, "test")
+
+    asyncio.run(scenario())
+
+    assert p._charge_limit_generation > old_generation
+    assert p._charge_limit.calls == [("disable",)]
+
+
 class _FakeToggle:
     def __init__(self, supported=True, max_cores=8):
         self.supported = supported


### PR DESCRIPTION
## Qué cambia / What changes / Cosa cambia

### Español

Panel de Control mantiene separado el límite solicitado del valor leído y comprueba el resultado a los 2, 8 y 20 segundos después del arranque, la reanudación o un cambio de contexto. Si el firmware o el sistema restablecen el umbral, lo recupera sin mantener un bucle permanente.

La detección desde un estado inicialmente no compatible queda limitada a perfiles ROG y Steam Deck confirmados. Las rutas previamente compatibles solo pueden recuperarse con el mismo tipo de backend. Lenovo mantiene su modo booleano y MSI y los equipos genéricos no ganan soporte. Los nuevos reportes distinguen por qué falló la detección o confirmación sin incluir rutas ni salida cruda.

### English

Panel de Control keeps the requested limit separate from hardware readback and verifies it at 2, 8, and 20 seconds after startup, resume, or a context change. If firmware or the operating system resets the threshold, it restores it without running a permanent polling loop.

Acquisition from an initially unsupported state is limited to confirmed ROG and Steam Deck profiles. Previously supported paths can only recover the same backend type. Lenovo keeps its boolean conservation mode, while MSI and generic devices gain no new support. New reports distinguish detection and confirmation failures without paths or raw output.

### Italiano

Panel de Control mantiene separato il limite richiesto dal valore letto e lo verifica dopo 2, 8 e 20 secondi dall'avvio, dalla riattivazione o da un cambio di contesto. Se il firmware o il sistema reimpostano la soglia, la ripristina senza mantenere un ciclo permanente.

L'acquisizione da uno stato inizialmente non supportato è limitata ai profili ROG e Steam Deck confermati. I percorsi già supportati possono recuperare solo lo stesso tipo di backend. Lenovo mantiene la modalità di conservazione booleana, mentre MSI e i dispositivi generici non ottengono nuovo supporto. I nuovi report distinguono gli errori di rilevamento e conferma senza percorsi né output grezzo.

## Cómo se probó / How it was tested / Come è stato verificato

- ROG Xbox Ally X RC73XA, SteamOS 6.16.12: un cambio externo de 75% a 100% volvió a 75% antes de la lectura a los 3 segundos y permaneció estable hasta superar los 20 segundos.
- Legion Go S 83N6, SteamOS 6.16.12: conservación booleana permaneció en 0; no se trató como porcentaje.
- MSI Claw 8 AI+ A2VM, SteamOS 6.16.12: permaneció sin interfaz compatible y sin soporte nuevo.
- Steam Deck LCD/OLED y ROG Ally Bazzite no estuvieron accesibles; estas rutas tienen cobertura sintética, no validación física.
- Python: 2107 passed, 1 skipped, 55 subtests.
- Frontend: 79 archivos y 658 pruebas.
- Ruff, TypeScript, build y diff-check correctos.

Si el problema continúa después de actualizar, abre un reporte nuevo desde el plugin justo después del fallo. El nuevo diagnóstico permitirá distinguir si el backend no apareció, no pudo leerse, rechazó la escritura o no confirmó el valor.

En #408 este cambio cubre la parte de batería. Si los problemas de color o HUD continúan después de actualizar, deben enviarse como un reporte nuevo para no reutilizar el diagnóstico de la versión 0.34.0.

## Checklist

- [x] Conventional Commits
- [x] `pnpm typecheck`, `pnpm test:fe` y `pnpm build`
- [x] Ruff y suite Python completa
- [x] Sin secretos, datos personales ni dependencias nuevas

Closes #64
Closes #103
Closes #178
Closes #352
Closes #408
Closes #441
