### PR TITLE
fix: corrige el acceso a Panel de Control desde el QAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Español
 
-* **QAM:** Panel de Control permanece siempre accesible desde la entrada estándar de Decky aunque no se pueda registrar el icono directo. El icono opcional vuelve a mostrar el panel directamente y el contenido completo solo se monta en la entrada visible, sin depender de una redirección ni mantener dos paneles activos. Ajustes solicita reiniciar Decky si no puede limpiar un registro obsoleto. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
+* **QAM:** Corrige el acceso directo que podía quedar obsoleto al actualizar desde 0.37.5 a 0.37.6 con Decky 3.2.6 y abrir la lista de Decky en lugar de Panel de Control. La entrada estándar permanece siempre disponible, el icono vuelve a mostrar el panel directamente y el contenido completo solo se monta en la entrada visible. Ajustes solicita reiniciar Decky si no puede limpiar un registro obsoleto. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
 
 ### English
 
-* **QAM:** Panel de Control always remains accessible from the standard Decky entry even when the direct icon cannot be registered. The optional icon displays the panel directly again, while the full content mounts only in the visible entry, without relying on a redirect or keeping two panels active. Settings asks to restart Decky when a stale registration cannot be cleared. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
+* **QAM:** Fixes the direct shortcut becoming stale when upgrading from 0.37.5 to 0.37.6 on Decky 3.2.6 and opening Decky's plugin list instead of Panel de Control. The standard entry always remains available, the icon displays the panel directly again, and full content mounts only in the visible entry. Settings asks to restart Decky when a stale registration cannot be cleared. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
 
 ### Italiano
 
-* **QAM:** Pannello di controllo resta sempre accessibile dalla voce standard di Decky anche quando non è possibile registrare l'icona diretta. L'icona opzionale mostra di nuovo il pannello direttamente e il contenuto completo viene montato solo nella voce visibile, senza dipendere da un reindirizzamento né mantenere attivi due pannelli. Impostazioni richiede il riavvio di Decky se non riesce a rimuovere una registrazione obsoleta. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
+* **QAM:** Corregge il collegamento diretto che poteva restare obsoleto aggiornando dalla 0.37.5 alla 0.37.6 con Decky 3.2.6 e aprire l'elenco dei plugin Decky invece di Panel de Control. La voce standard resta sempre disponibile, l'icona mostra nuovamente il pannello direttamente e il contenuto completo viene montato solo nella voce visibile. Impostazioni richiede il riavvio di Decky se non riesce a rimuovere una registrazione obsoleta. ([#478](https://github.com/Hooandee/panel-de-control/issues/478)) ([#480](https://github.com/Hooandee/panel-de-control/issues/480))
 
 ## [0.37.7](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.37.6...panel-de-control-v0.37.7) (2026-08-17)
 


### PR DESCRIPTION
## Español

Seguimiento de #484. El arreglo ya está en `main`; esta PR corrige el changelog para describir la regresión introducida en `0.37.6` y aporta el commit convencional `fix:` que `release-please` necesita.

## English

Follow-up to #484. The fix is already in `main`; this PR corrects the changelog to describe the regression introduced in `0.37.6` and provides the conventional `fix:` commit required by `release-please`.

## Italiano

Seguito della #484. La correzione è già in `main`; questa PR corregge il changelog per descrivere la regressione introdotta nella `0.37.6` e fornisce il commit convenzionale `fix:` richiesto da `release-please`.
