### PR TITLE
fix(tdp): confirm delayed firmware readback

### DIFF
--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -47,4 +47,5 @@ def legion_go_s_83n6_firmware_attr_quirks(device, root: str = "/") -> dict:
     return {
         "ignored_live_maxes": {"pl1": 15, "pl2": 15, "pl3": 20},
         "cap_boost_to_active": True,
+        "readback_settle_delays": (0.05, 0.10, 0.20, 0.40),
     }

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -90,10 +90,15 @@ class FirmwareAttrBackend(TDPBackend):
         self._pp_dir = self._find_profile_dir()  # static, resolved once
         self._pp_choices = None                  # parsed lazily, then cached
         self._legacy = self._find_legacy_nodes(driver_prefix)  # ASUS dual-interface
-        self._rails = tuple(
+        self._primary_rails = tuple(
             rail
             for rail, attr in _RAIL_ATTRS
-            if os.path.exists(self._attr(attr)) or rail in self._legacy
+            if os.path.exists(self._attr(attr))
+        )
+        self._rails = tuple(
+            rail
+            for rail, _attr in _RAIL_ATTRS
+            if rail in self._primary_rails or rail in self._legacy
         )
         self.supports_levels = any(rail != "pl1" for rail in self._rails)
 
@@ -365,12 +370,19 @@ class FirmwareAttrBackend(TDPBackend):
             "reported_live_bounds": reported,
         }
 
-    @staticmethod
-    def _observation_mismatches(observation, targets):
+    def _observation_mismatches(self, observation, targets):
         bad = []
-        for surface, rails in observation.surfaces.items():
-            for rail, reading in rails.items():
-                target = targets.get(rail)
-                if target is not None and reading.applied_w != target:
+        for surface, rails in (
+            (self.name, self._primary_rails),
+            ("asus-nb-wmi", self._legacy),
+        ):
+            observed = observation.surfaces.get(surface, {})
+            for rail in rails:
+                if rail not in targets:
+                    continue
+                reading = observed.get(rail)
+                if reading is None or reading.applied_w is None:
+                    bad.append(f"{surface}/{rail}=unavailable")
+                elif reading.applied_w != targets[rail]:
                     bad.append(f"{surface}/{rail}={reading.applied_w}")
         return bad

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -1,6 +1,8 @@
 import dataclasses
 import os
 
+import pytest
+
 from device_profiles import DEVICE_TABLE, GENERIC
 from tdp import factory
 from tdp.backend import NullBackend
@@ -117,13 +119,15 @@ def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
     assert getattr(nearby, "_rail_floors", None) == {}
 
 
-def test_exact_legion_go_s_83l3_waits_for_async_firmware_readback(
+@pytest.mark.parametrize("product_name", ("83L3", "83N6"))
+def test_exact_legion_go_s_waits_for_async_firmware_readback(
     tmp_path,
     monkeypatch,
+    product_name,
 ):
     root = str(tmp_path)
     _mk_fw(root, "lenovo-wmi-other-0")
-    _mk_dmi(root, "LENOVO", "83L3")
+    _mk_dmi(root, "LENOVO", product_name)
     backend = select_backend(
         _p("legion_go_s"),
         root=root,
@@ -131,18 +135,20 @@ def test_exact_legion_go_s_83l3_waits_for_async_firmware_readback(
     )
     stale = _observation(backend, 15, 15, 15)
     original_observe = backend.observe
-    observations = iter((stale,))
+    observations = iter((stale, stale, stale))
 
     def observe_after_firmware_settles():
         return next(observations, None) or original_observe()
 
+    sleeps = []
     monkeypatch.setattr(backend, "observe", observe_after_firmware_settles)
-    monkeypatch.setattr("tdp.firmware_attr.time.sleep", lambda _delay: None)
+    monkeypatch.setattr("tdp.firmware_attr.time.sleep", sleeps.append)
 
     result = backend.set_levels(20, 20, 20, ac=True)
 
     assert result.ok is True
     assert result.applied_w == 20
+    assert sleeps == [0.05, 0.10, 0.20]
     assert backend.diagnostics()["readback_settle_ms"] == 750
 
 
@@ -224,7 +230,7 @@ def test_exact_legion_go_s_83n6_diagnostics_keep_reported_sentinel_max(tmp_path)
     assert backend.diagnostics() == {
         "boost_capped_to_active": True,
         "ignored_live_maxes": {"pl1": 15, "pl2": 15, "pl3": 20},
-        "readback_settle_ms": 0,
+        "readback_settle_ms": 750,
         "reported_live_bounds": {
             "pl1": {"min": 5, "max": 15},
             "pl2": {"min": 5, "max": 15},

--- a/tests/test_tdp_firmware_attr.py
+++ b/tests/test_tdp_firmware_attr.py
@@ -149,6 +149,37 @@ def test_set_levels_keeps_failure_when_async_readback_never_converges(
     assert f"{b.name}/pl1=35" in result.detail
 
 
+def test_set_levels_never_succeeds_when_primary_readback_disappears(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    b = _settling_backend(root, 0)
+    unavailable = TdpObservation(readable=False)
+    monkeypatch.setattr(b, "observe", lambda: unavailable)
+
+    result = b.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w is None
+    assert f"{b.name}/pl1=unavailable" in result.detail
+
+
+def test_set_levels_never_succeeds_when_primary_sysfs_disappears_after_probe(
+    tmp_path,
+):
+    root = str(tmp_path)
+    b = _settling_backend(root, 0)
+    for attr in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
+        os.remove(b._attr(attr))
+
+    result = b.set_levels(20, 20, 20, ac=True)
+
+    assert result.ok is False
+    assert result.applied_w is None
+    assert f"{b.name}/pl1=unavailable" in result.detail
+
+
 def test_set_levels_does_not_wait_after_a_write_error(tmp_path, monkeypatch):
     root = str(tmp_path)
     b = _settling_backend(root, 0)
@@ -286,6 +317,41 @@ def test_legacy_interface_absent_is_a_clean_noop(tmp_path):
     b = FirmwareAttrBackend("asus-armoury", fb, root=root)
     res = b.set_levels(20, 24, 28, ac=True)
     assert res.ok is True and res.applied_w == 20
+
+
+def test_legacy_only_boost_rails_do_not_require_primary_readback(tmp_path):
+    root = str(tmp_path)
+    _mk_attr(root, "asus-armoury", "ppt_pl1_spl", 20, 7, 35)
+    _mk_legacy(root, pl1="20", pl2="24", fppt="28")
+    fb = TdpLimits(min_w=7, default_w=17, max_w=25, max_ac_w=35)
+    b = FirmwareAttrBackend("asus-armoury", fb, root=root)
+
+    result = b.set_levels(20, 24, 28, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 20
+
+
+def test_set_levels_fails_if_legacy_readback_disappears_after_write(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_full(root, "asus-armoury")
+    _mk_legacy(root)
+    b = FirmwareAttrBackend("asus-armoury", FALLBACK, root=root)
+    original_observe = b.observe
+
+    def observe_after_legacy_disappears():
+        os.remove(b._legacy["pl2"])
+        return original_observe()
+
+    monkeypatch.setattr(b, "observe", observe_after_legacy_disappears)
+
+    result = b.set_levels(20, 24, 28, ac=True)
+
+    assert result.ok is False
+    assert "asus-nb-wmi/pl2=unavailable" in result.detail
 
 
 def test_observe_reads_every_primary_rail_and_live_bound(tmp_path):


### PR DESCRIPTION
## What does this change?

- Wait for delayed firmware-attribute readback on the exact Lenovo Legion Go S `83N6` before reporting a manual TDP write as rejected.
- Keep the configured firmware and ASUS legacy rail topology stable after probing, so missing readback is reported as unavailable instead of being promoted to success.
- Preserve mixed ASUS systems where boost rails are available only through `asus-nb-wmi`.

## How was it tested?

- Added regressions for three consecutive stale reads, exact `50/100/200 ms` retry cadence, persistent mismatch, unavailable primary readback, sysfs disappearance after probing, and disappearing ASUS legacy readback.
- Lenovo Legion Go S `83N6`: applied and confirmed `5 → 6 → 5 W` through the real Decky RPC; all three rails converged and the original profile was restored.
- ROG Xbox Ally X: reapplied `25/26/45 W` and confirmed matching readback on both `asus-armoury` and `asus-nb-wmi`; the original profile was preserved.
- MSI Claw 8 AI+: confirmed the selected Intel RAPL path remains unaffected with a successful 22 W readback.
- `ruff check py_modules main.py tests`
- `python -m pytest`: 2112 passed, 1 skipped, 55 subtests passed
- `pnpm typecheck`
- `pnpm test:fe`: 706 passed
- `pnpm build`

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.
