### PR TITLE
fix(updater): show all notes since installed version

### DIFF
--- a/main.py
+++ b/main.py
@@ -761,11 +761,11 @@ class Plugin:
 
     async def check_update(self, force: bool = False) -> dict:
         self._init()
-        return self_updater.check(force)
+        return await asyncio.to_thread(self_updater.check, force)
 
     async def install_update(self) -> dict:
         self._init()
-        return self_updater.install()
+        return await asyncio.to_thread(self_updater.install)
 
     async def restart_loader(self) -> None:
         # Fire-and-forget: restarts Decky to load the just-installed files.

--- a/py_modules/self_updater.py
+++ b/py_modules/self_updater.py
@@ -16,6 +16,7 @@ import os
 import re
 import shutil
 import tempfile
+import threading
 import urllib.error
 import urllib.request
 import zipfile
@@ -31,6 +32,7 @@ _UA = "decky-self-updater"
 
 # Session cache: only hit GitHub once per Steam session (force=True bypasses it).
 _cache: dict | None = None
+_operation_lock = threading.RLock()
 
 
 def _plugin_dir() -> Path:
@@ -106,36 +108,82 @@ def _shape(data: dict, current: str) -> dict:
     }
 
 
+def _release_notes(data: list[dict], current: str, latest: str) -> str:
+    releases: dict[str, dict] = {}
+    for release in data:
+        if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+            continue
+        version = _extract_semver(str(release.get("tag_name", "")))
+        if (
+            version
+            and _is_newer(version, current)
+            and not _is_newer(version, latest)
+        ):
+            releases.setdefault(version, release)
+
+    notes: list[str] = []
+    for version in sorted(releases, key=_norm, reverse=True):
+        release = releases[version]
+        body = str(release.get("body", "") or "").strip()
+        notes.append(f"## v{version}" + (f"\n\n{body}" if body else ""))
+    return "\n\n".join(notes)
+
+
+def _fetch_releases(slug: str) -> list[dict]:
+    releases: list[dict] = []
+    page = 1
+    while True:
+        api = (
+            f"https://api.github.com/repos/{_GITHUB_OWNER}/{slug}/releases"
+            f"?per_page=100&page={page}"
+        )
+        batch = json.loads(_http_get(api, "application/vnd.github+json"))
+        if not isinstance(batch, list):
+            raise ValueError("unexpected releases response")
+        releases.extend(batch)
+        if len(batch) < 100:
+            return releases
+        page += 1
+
+
 def check(force: bool = False) -> dict:
     global _cache
-    if _cache is not None and not force:
-        return _cache
-    current = read_version()
-    result = {
-        "current": current,
-        "latest": current,
-        "has_update": False,
-        "notes": "",
-        "download_url": "",
-        "error": "",
-    }
-    try:
-        slug = _repo_slug()
-        api = f"https://api.github.com/repos/{_GITHUB_OWNER}/{slug}/releases/latest"
-        data = json.loads(_http_get(api, "application/vnd.github+json"))
-        result = _shape(data, current)
-    except urllib.error.HTTPError as e:
-        # 404 = no published release yet → benign "up to date", not an error.
-        if e.code == 404:
-            decky.logger.info("[updater] no published release yet")
-        else:
+    with _operation_lock:
+        if _cache is not None and not force:
+            return _cache
+        current = read_version()
+        empty = {
+            "current": current,
+            "latest": current,
+            "has_update": False,
+            "notes": "",
+            "download_url": "",
+            "error": "",
+        }
+        result = empty
+        latest_loaded = False
+        try:
+            slug = _repo_slug()
+            latest_api = f"https://api.github.com/repos/{_GITHUB_OWNER}/{slug}/releases/latest"
+            latest_data = json.loads(_http_get(latest_api, "application/vnd.github+json"))
+            latest_loaded = True
+            result = _shape(latest_data, current)
+            if result["has_update"]:
+                releases = [latest_data, *_fetch_releases(slug)]
+                result["notes"] = _release_notes(
+                    releases, current, result["latest"]
+                )
+        except urllib.error.HTTPError as e:
+            if e.code == 404 and not latest_loaded:
+                decky.logger.info("[updater] no published release yet")
+            else:
+                decky.logger.warning(f"[updater] check failed: {e}")
+                result = {**empty, "error": "network"}
+        except Exception as e:  # noqa: BLE001 — must never propagate to the UI
             decky.logger.warning(f"[updater] check failed: {e}")
-            result["error"] = "network"
-    except Exception as e:  # noqa: BLE001 — must never propagate to the UI
-        decky.logger.warning(f"[updater] check failed: {e}")
-        result["error"] = "network"
-    _cache = result
-    return result
+            result = {**empty, "error": "network"}
+        _cache = result
+        return result
 
 
 def _extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
@@ -156,41 +204,43 @@ def install() -> dict:
 
     Returns {ok, needs_restart, message}. Never raises.
     """
-    info = check()
-    url = str(info.get("download_url") or "")
-    if not url:
-        return {"ok": False, "needs_restart": False, "message": "no_asset"}
-    try:
-        plugin_dir = _plugin_dir()
-        name = _plugin_name()
-        blob = _http_get(url, "application/octet-stream")
-        with tempfile.TemporaryDirectory() as tmp:
-            tmpd = Path(tmp)
-            zpath = tmpd / "update.zip"
-            zpath.write_bytes(blob)
-            extract = tmpd / "x"
-            with zipfile.ZipFile(zpath) as zf:
-                _extract_zip(zf, extract)
-            src = extract / name  # top folder == plugin.json name
-            if not src.is_dir():
-                subdirs = [p for p in extract.iterdir() if p.is_dir()]
-                if len(subdirs) == 1:
-                    src = subdirs[0]
-            if not src.is_dir():
-                return {"ok": False, "needs_restart": False, "message": "bad_zip"}
-            # Copy over the installed plugin dir. User settings live in
-            # DECKY_PLUGIN_SETTINGS_DIR (outside this dir) and are untouched.
-            for item in src.iterdir():
-                dest = plugin_dir / item.name
-                if item.is_dir():
-                    shutil.copytree(item, dest, dirs_exist_ok=True)
-                else:
-                    shutil.copy2(item, dest)
-        _mark_installed()
-        return {"ok": True, "needs_restart": True, "message": "installed"}
-    except Exception as e:  # noqa: BLE001
-        decky.logger.error(f"[updater] install failed: {e}")
-        return {"ok": False, "needs_restart": False, "message": "install_failed"}
+    with _operation_lock:
+        info = check()
+        url = str(info.get("download_url") or "")
+        if not info.get("has_update") or not url:
+            return {"ok": False, "needs_restart": False, "message": "no_asset"}
+        try:
+            plugin_dir = _plugin_dir()
+            name = _plugin_name()
+            blob = _http_get(url, "application/octet-stream")
+            with tempfile.TemporaryDirectory() as tmp:
+                tmpd = Path(tmp)
+                zpath = tmpd / "update.zip"
+                zpath.write_bytes(blob)
+                extract = tmpd / "x"
+                with zipfile.ZipFile(zpath) as zf:
+                    _extract_zip(zf, extract)
+                src = extract / name  # top folder == plugin.json name
+                if not src.is_dir():
+                    subdirs = [p for p in extract.iterdir() if p.is_dir()]
+                    if len(subdirs) == 1:
+                        src = subdirs[0]
+                if not src.is_dir():
+                    return {"ok": False, "needs_restart": False, "message": "bad_zip"}
+                # Copy over the installed plugin dir. User settings live in
+                # DECKY_PLUGIN_SETTINGS_DIR (outside this dir) and are untouched.
+                for item in src.iterdir():
+                    dest = plugin_dir / item.name
+                    if item.is_dir():
+                        shutil.copytree(item, dest, dirs_exist_ok=True)
+                    else:
+                        shutil.copy2(item, dest)
+            read_version.cache_clear()
+            _mark_installed()
+            return {"ok": True, "needs_restart": True, "message": "installed"}
+        except Exception as e:  # noqa: BLE001
+            decky.logger.error(f"[updater] install failed: {e}")
+            return {"ok": False, "needs_restart": False, "message": "install_failed"}
 
 
 def restart_loader() -> None:

--- a/src/updater/UpdateModal.tsx
+++ b/src/updater/UpdateModal.tsx
@@ -1,10 +1,18 @@
-import { DialogButton, ModalRoot } from "@decky/ui";
+import {
+  DialogButton,
+  Focusable,
+  GamepadButton,
+  getFocusNavController,
+  ModalRoot,
+  type GamepadEvent,
+} from "@decky/ui";
 import { FocusRoot } from "../components/FocusRoot";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import type { InstallResult } from "../api";
 import { useUpdate } from "./useUpdate";
 import type { Lang } from "../i18n";
 import { getUpdaterStrings } from "./strings";
+import { releaseNotesForLanguage } from "./releaseNotes";
 
 const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace";
 
@@ -48,6 +56,8 @@ function renderMarkdown(md: string): ReactNode[] {
       out.push(
         <div
           key={i}
+          role="heading"
+          aria-level={heading[1].length}
           style={{ fontSize: heading[1].length <= 2 ? 16 : 13, fontWeight: 700, margin: "12px 0 4px" }}
         >
           {renderInline(heading[2])}
@@ -88,8 +98,33 @@ export function UpdateModal({
   const t = getUpdaterStrings(lang).modal;
   const { install, restart, status } = useUpdate(lang);
   const [result, setResult] = useState<InstallResult | null>(null);
+  const notesRef = useRef<HTMLDivElement>(null);
+  const actionRef = useRef<HTMLDivElement>(null);
   const installing = status === "installing";
   const done = status === "done";
+  const visibleNotes = releaseNotesForLanguage(notes, lang);
+
+  const scrollNotes = (event: GamepadEvent) => {
+    const viewport = notesRef.current;
+    if (!viewport) return;
+    const direction = event.detail.button === GamepadButton.DIR_DOWN
+      ? 1
+      : event.detail.button === GamepadButton.DIR_UP
+        ? -1
+        : 0;
+    const atEdge = direction < 0
+      ? viewport.scrollTop <= 0
+      : viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - 1;
+    if (!direction) return;
+    if (direction > 0 && atEdge) {
+      getFocusNavController()?.FocusElement(actionRef.current);
+      return;
+    }
+    if (atEdge) return;
+    event.preventDefault();
+    event.stopPropagation();
+    viewport.scrollBy({ top: direction * viewport.clientHeight * 0.8 });
+  };
 
   return (
     <ModalRoot onCancel={closeModal} onEscKeypress={closeModal}>
@@ -97,18 +132,32 @@ export function UpdateModal({
         <div style={{ fontSize: 20, fontWeight: 700 }}>
           {t.title} v{latest}
         </div>
-        <div style={{ maxHeight: 340, overflowY: "auto", paddingRight: 8 }}>
-          {notes ? renderMarkdown(notes) : <div style={{ opacity: 0.7 }}>{t.noNotes}</div>}
-        </div>
+        {visibleNotes ? (
+          <Focusable onActivate={() => {}} onGamepadDirection={scrollNotes} noFocusRing>
+            <div
+              ref={notesRef}
+              data-testid="notes-scroll"
+              style={{ maxHeight: 340, overflowY: "auto", paddingRight: 8 }}
+            >
+              {renderMarkdown(visibleNotes)}
+            </div>
+          </Focusable>
+        ) : (
+          <div style={{ opacity: 0.7 }}>{t.noNotes}</div>
+        )}
         {done ? (
           <>
             <div style={{ fontSize: 13 }}>
               {t.installed} {t.restartNote}
             </div>
-            <DialogButton onClick={() => restart()}>{t.restart}</DialogButton>
+            <DialogButton ref={actionRef} onClick={() => restart()}>{t.restart}</DialogButton>
           </>
         ) : (
-          <DialogButton disabled={installing} onClick={() => void install().then(setResult)}>
+          <DialogButton
+            ref={actionRef}
+            disabled={installing}
+            onClick={() => void install().then(setResult)}
+          >
             {installing ? t.installing : t.install}
           </DialogButton>
         )}

--- a/src/updater/UpdatePanel.test.tsx
+++ b/src/updater/UpdatePanel.test.tsx
@@ -1,9 +1,30 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@decky/ui", () => ({
-  DialogButton: ({ children, ...props }: any) => <button type="button" {...props}>{children}</button>,
+  DialogButton: ({ children, ref, ...props }: any) => (
+    <button ref={ref} type="button" {...props}>{children}</button>
+  ),
+  GamepadButton: { DIR_UP: 9, DIR_DOWN: 10 },
+  getFocusNavController: () => ({ FocusElement: (element: HTMLElement) => element.focus() }),
+  Focusable: ({ children, onActivate: _onActivate, noFocusRing: _noFocusRing, onGamepadDirection, ...props }: any) => (
+    <div
+      data-testid="notes-focus"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+        onGamepadDirection?.({
+          detail: { button: event.key === "ArrowUp" ? 9 : 10 },
+          preventDefault: () => event.preventDefault(),
+          stopPropagation: () => event.stopPropagation(),
+        });
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
   ModalRoot: ({ children }: any) => <section>{children}</section>,
   showModal: vi.fn(),
 }));
@@ -44,5 +65,96 @@ describe("Italian updater", () => {
     expect(screen.getByText("Novità v0.35.0")).toBeTruthy();
     expect(screen.getByText("Nessuna nota per questa versione.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Installa l'aggiornamento" })).toBeTruthy();
+  });
+
+  it("scrolls long release notes with one gamepad target", () => {
+    render(
+      <UpdateModal
+        lang="es"
+        latest="0.37.10"
+        notes={[
+          "## v0.37.10",
+          "### Novedades",
+          "- Cambio más reciente",
+          "### What's new",
+          "- Latest change",
+          "### Novità",
+          "- Ultima modifica",
+          "## v0.37.9",
+          "### Novedades",
+          "- Cambio anterior",
+        ].join("\n\n")}
+      />,
+    );
+
+    expect(screen.getAllByTestId("notes-focus")).toHaveLength(1);
+    expect(screen.getByRole("heading", { name: "v0.37.10", level: 2 })).toBeTruthy();
+    expect(screen.getByText("Cambio más reciente")).toBeTruthy();
+    expect(screen.queryByText("Latest change")).toBeNull();
+    expect(screen.queryByText("Ultima modifica")).toBeNull();
+    expect(screen.queryByRole("heading", { level: 3 })).toBeNull();
+
+    const target = screen.getByTestId("notes-focus");
+    const viewport = screen.getByTestId("notes-scroll");
+    Object.defineProperties(viewport, {
+      clientHeight: { value: 340 },
+      scrollHeight: { value: 1000 },
+      scrollBy: {
+        value: ({ top }: { top: number }) => {
+          viewport.scrollTop += top;
+        },
+      },
+    });
+
+    expect(fireEvent.keyDown(target, { key: "ArrowDown" })).toBe(false);
+    expect(viewport.scrollTop).toBe(272);
+
+    viewport.scrollTop = 660;
+    expect(fireEvent.keyDown(target, { key: "ArrowDown" })).toBe(true);
+    expect(viewport.scrollTop).toBe(660);
+
+    const install = screen.getByRole("button", { name: "Instalar actualización" });
+    expect(document.activeElement).toBe(install);
+    expect(
+      target.compareDocumentPosition(install)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it.each([
+    ["en", "Latest change", "Cambio más reciente", "Ultima modifica"],
+    ["it", "Ultima modifica", "Cambio más reciente", "Latest change"],
+  ] as const)("shows only %s release notes", (lang, visible, hiddenA, hiddenB) => {
+    render(
+      <UpdateModal
+        lang={lang}
+        latest="0.37.10"
+        notes={[
+          "## v0.37.10",
+          "### Novedades",
+          "- Cambio más reciente",
+          "### What's new",
+          "- Latest change",
+          "### Novità",
+          "- Ultima modifica",
+        ].join("\n\n")}
+      />,
+    );
+
+    expect(screen.getByText(visible)).toBeTruthy();
+    expect(screen.queryByText(hiddenA)).toBeNull();
+    expect(screen.queryByText(hiddenB)).toBeNull();
+  });
+
+  it("keeps unsectioned notes from older releases", () => {
+    render(
+      <UpdateModal
+        lang="it"
+        latest="0.36.0"
+        notes={"## v0.36.0\n\nLegacy release notes"}
+      />,
+    );
+
+    expect(screen.getByText("Legacy release notes")).toBeTruthy();
   });
 });

--- a/src/updater/releaseNotes.test.ts
+++ b/src/updater/releaseNotes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { releaseNotesForLanguage } from "./releaseNotes";
+
+describe("releaseNotesForLanguage", () => {
+  it("filters each release independently when translations use a different order", () => {
+    const notes = [
+      "## v0.37.1",
+      "### Novità",
+      "- Prima modifica",
+      "### What's new",
+      "- First change",
+      "## v0.37.0",
+      "### What's new",
+      "- Previous change",
+      "### Novità",
+      "- Modifica precedente",
+    ].join("\n");
+
+    expect(releaseNotesForLanguage(notes, "it")).toBe([
+      "## v0.37.1",
+      "- Prima modifica",
+      "",
+      "## v0.37.0",
+      "- Modifica precedente",
+    ].join("\n"));
+  });
+
+  it("falls back to English when the selected translation is missing", () => {
+    const notes = [
+      "## v0.36.0",
+      "### Novedades",
+      "- Cambio en español",
+      "### What's new",
+      "- English change",
+    ].join("\r\n");
+
+    expect(releaseNotesForLanguage(notes, "it")).toBe(
+      "## v0.36.0\n- English change",
+    );
+  });
+
+  it("stops at the next heading even when its language is unknown", () => {
+    const notes = [
+      "## v0.36.0",
+      "### What's new",
+      "- English change",
+      "### Français",
+      "- Changement français",
+    ].join("\n");
+
+    expect(releaseNotesForLanguage(notes, "en")).toBe(
+      "## v0.36.0\n- English change",
+    );
+  });
+});

--- a/src/updater/releaseNotes.ts
+++ b/src/updater/releaseNotes.ts
@@ -1,0 +1,47 @@
+import type { Lang } from "../i18n";
+
+const LANGUAGE_HEADINGS: Record<string, Lang> = {
+  Novedades: "es",
+  "What's new": "en",
+  Novità: "it",
+};
+
+const VERSION_HEADING = /^##\s+v\d+\.\d+\.\d+\s*$/m;
+const LANGUAGE_HEADING = /^###\s+(.+?)\s*$/;
+
+function localizeRelease(section: string, lang: Lang): string {
+  const lines = section.replace(/\r/g, "").trim().split("\n");
+  const headings = lines.flatMap((line, index) => {
+    const heading = line.match(LANGUAGE_HEADING)?.[1];
+    return heading ? [{ index, lang: LANGUAGE_HEADINGS[heading] }] : [];
+  });
+  const translations = headings.filter(
+    (heading): heading is { index: number; lang: Lang } => Boolean(heading.lang),
+  );
+  if (!translations.length) return lines.join("\n").trim();
+
+  const content = (translation: { index: number }) => {
+    const next = headings.find((heading) => heading.index > translation.index);
+    return lines.slice(translation.index + 1, next?.index).join("\n").trim();
+  };
+  const firstNonEmpty = (candidateLang?: Lang) => translations.find(
+    (translation) => (!candidateLang || translation.lang === candidateLang)
+      && content(translation),
+  );
+  const selected = firstNonEmpty(lang) ?? firstNonEmpty("en") ?? firstNonEmpty();
+
+  return selected ? [lines[0], content(selected)].join("\n") : lines[0];
+}
+
+export function releaseNotesForLanguage(notes: string, lang: Lang): string {
+  const starts = [...notes.matchAll(new RegExp(VERSION_HEADING, "gm"))].map(
+    (match) => match.index ?? 0,
+  );
+  if (!starts.length) return notes.trim();
+
+  return starts
+    .map((start, index) => notes.slice(start, starts[index + 1]).trim())
+    .map((section) => localizeRelease(section, lang))
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/tests/test_event_loop_offload.py
+++ b/tests/test_event_loop_offload.py
@@ -182,6 +182,38 @@ def test_offload_without_serial_executor_does_not_block_a_running_loop(
     assert results == [True]
 
 
+def test_update_check_does_not_block_the_event_loop(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    release = threading.Event()
+    monkeypatch.setattr(
+        sys.modules["main"].self_updater,
+        "check",
+        lambda force: release.wait(0.3),
+    )
+
+    async def _run():
+        asyncio.get_running_loop().call_later(0.02, release.set)
+        return await p.check_update(True)
+
+    assert asyncio.run(_run()) is True
+
+
+def test_update_install_does_not_block_the_event_loop(tmp_path, monkeypatch):
+    p, _ = _make_plugin(tmp_path, monkeypatch)
+    release = threading.Event()
+    monkeypatch.setattr(
+        sys.modules["main"].self_updater,
+        "install",
+        lambda: release.wait(0.3),
+    )
+
+    async def _run():
+        asyncio.get_running_loop().call_later(0.02, release.set)
+        return await p.install_update()
+
+    assert asyncio.run(_run()) is True
+
+
 def test_offload_call_dispatches_through_executor(tmp_path, monkeypatch):
     p, _ = _make_plugin(tmp_path, monkeypatch)
     rec = _RecordingExecutor()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,12 +1,62 @@
+import functools
 import importlib
+import io
 import json
 import pathlib
 import sys
+import threading
+import time
 import types
+import urllib.error
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _release(
+    version,
+    body="",
+    *,
+    asset_url="",
+    draft=False,
+    prerelease=False,
+):
+    assets = []
+    if asset_url:
+        assets.append(
+            {
+                "name": "Panel.de.Control.zip",
+                "browser_download_url": asset_url,
+            }
+        )
+    return {
+        "tag_name": f"v{version}",
+        "body": body,
+        "draft": draft,
+        "prerelease": prerelease,
+        "assets": assets,
+    }
+
+
+def _release_archive(version):
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as release_zip:
+        release_zip.writestr(
+            "Panel de Control/package.json",
+            json.dumps({"version": version}),
+        )
+    return archive.getvalue()
+
+
+def _cached_package_version(package):
+    @functools.lru_cache(maxsize=1)
+    def read():
+        return json.loads(package.read_text(encoding="utf-8"))["version"]
+
+    return read
 
 
 @pytest.fixture
@@ -82,27 +132,299 @@ def test_check_shapes_mocked_release_json(updater, monkeypatch):
     monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
     monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
     monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
-    payload = {
-        "tag_name": "v0.2.0",
-        "body": "New in 0.2.0",
-        "assets": [
-            {
-                "name": "Panel de Control.zip",
-                "browser_download_url": "https://gh/Panel%20de%20Control.zip",
-            }
-        ],
-    }
-    monkeypatch.setattr(updater, "_http_get", lambda url, accept: json.dumps(payload).encode())
+    payload = [_release("0.2.0", "New in 0.2.0", asset_url="https://gh/update.zip")]
+
+    def release_get(url, accept):
+        data = payload[0] if url.endswith("/latest") else payload
+        return json.dumps(data).encode()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
 
     result = updater.check(force=True)
     assert result == {
         "current": "0.1.0",
         "latest": "0.2.0",
-        "notes": "New in 0.2.0",
-        "download_url": "https://gh/Panel%20de%20Control.zip",
+        "notes": "## v0.2.0\n\nNew in 0.2.0",
+        "download_url": "https://gh/update.zip",
         "has_update": True,
         "error": "",
     }
+
+
+def test_check_collects_every_stable_release_after_current(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.2.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    latest = _release("0.4.0", "Latest changes", asset_url="https://gh/update.zip")
+    payload = [
+        _release("0.3.0", "Earlier changes"),
+        _release("0.6.0", "Not the published latest"),
+        _release("0.5.0", "Preview", prerelease=True),
+        _release("0.4.1", "Draft", draft=True),
+        latest,
+        _release("0.3.0", "Duplicate changes"),
+        _release("0.2.0", "Already installed"),
+    ]
+
+    def release_get(url, accept):
+        data = latest if url.endswith("/latest") else payload
+        return json.dumps(data).encode()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+
+    result = updater.check(force=True)
+
+    assert result["latest"] == "0.4.0"
+    assert result["download_url"] == "https://gh/update.zip"
+    assert result["has_update"] is True
+    assert result["notes"] == (
+        "## v0.4.0\n\nLatest changes\n\n"
+        "## v0.3.0\n\nEarlier changes"
+    )
+
+
+def test_check_reads_every_release_page(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    installed = _release("0.1.0", "Installed")
+    latest = _release("0.2.0", "Next page", asset_url="https://gh/update.zip")
+    intermediate = _release("0.1.5", "Only on page two")
+    requested = []
+
+    def paged_get(url, accept):
+        requested.append(url)
+        if url.endswith("/latest"):
+            return json.dumps(latest).encode()
+        payload = [latest, intermediate] if "page=2" in url else [installed] * 100
+        return json.dumps(payload).encode()
+
+    monkeypatch.setattr(updater, "_http_get", paged_get)
+
+    result = updater.check(force=True)
+
+    assert requested == [
+        "https://api.github.com/repos/Hooandee/panel-de-control/releases/latest",
+        "https://api.github.com/repos/Hooandee/panel-de-control/releases?per_page=100&page=1",
+        "https://api.github.com/repos/Hooandee/panel-de-control/releases?per_page=100&page=2",
+    ]
+    assert result["latest"] == "0.2.0"
+    assert result["notes"] == (
+        "## v0.2.0\n\nNext page\n\n"
+        "## v0.1.5\n\nOnly on page two"
+    )
+
+
+def test_check_keeps_latest_notes_when_release_history_is_empty(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    latest = _release("0.2.0", "Latest changes", asset_url="https://gh/update.zip")
+
+    def release_get(url, accept):
+        return json.dumps(latest if url.endswith("/latest") else []).encode()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+
+    result = updater.check(force=True)
+
+    assert result["notes"] == "## v0.2.0\n\nLatest changes"
+
+
+def test_check_discards_partial_update_when_release_history_fails(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    latest = _release("0.2.0", "Latest changes", asset_url="https://gh/update.zip")
+
+    def release_get(url, accept):
+        if url.endswith("/latest"):
+            return json.dumps(latest).encode()
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+
+    result = updater.check(force=True)
+
+    assert result["error"] == "network"
+    assert result["has_update"] is False
+    assert result["download_url"] == ""
+
+
+def test_check_coalesces_concurrent_session_requests(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    calls = 0
+    calls_lock = threading.Lock()
+    start = threading.Barrier(2)
+
+    def release_get(url, accept):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        time.sleep(0.05)
+        return json.dumps(_release("0.1.0")).encode()
+
+    def check():
+        start.wait()
+        return updater.check()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: check(), range(2)))
+
+    assert calls == 1
+    assert results[0] == results[1]
+
+
+def test_install_serializes_forced_checks_and_refreshes_cached_version(
+    updater, monkeypatch, tmp_path
+):
+    plugin_dir = tmp_path / "Panel de Control"
+    plugin_dir.mkdir()
+    package = plugin_dir / "package.json"
+    package.write_text(json.dumps({"version": "0.1.0"}), encoding="utf-8")
+    archive = _release_archive("0.2.0")
+
+    installed_asset = "https://gh/0.2.0.zip"
+    next_release = _release(
+        "0.3.0",
+        "Next release",
+        asset_url="https://gh/0.3.0.zip",
+    )
+    updater._cache = {
+        "current": "0.1.0",
+        "latest": "0.2.0",
+        "notes": "## v0.2.0",
+        "download_url": installed_asset,
+        "has_update": True,
+        "error": "",
+    }
+    download_started = threading.Event()
+    release_download = threading.Event()
+    forced_check_started = threading.Event()
+    asset_downloads = 0
+
+    def release_get(url, accept):
+        nonlocal asset_downloads
+        if url == installed_asset:
+            asset_downloads += 1
+            download_started.set()
+            assert release_download.wait(timeout=1)
+            return archive
+        forced_check_started.set()
+        payload = next_release if url.endswith("/latest") else [next_release]
+        return json.dumps(payload).encode()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+    monkeypatch.setattr(updater, "_plugin_dir", lambda: plugin_dir)
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+
+    cached_version = _cached_package_version(package)
+    assert cached_version() == "0.1.0"
+    monkeypatch.setattr(updater, "read_version", cached_version)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        install_result = pool.submit(updater.install)
+        assert download_started.wait(timeout=1)
+        check_result = pool.submit(updater.check, True)
+        overlapped = forced_check_started.wait(timeout=0.05)
+        release_download.set()
+        installed = install_result.result(timeout=1)
+        checked = check_result.result(timeout=1)
+
+    assert overlapped is False
+    assert forced_check_started.is_set() is True
+    assert installed["ok"] is True
+    assert checked["current"] == "0.2.0"
+    assert checked["latest"] == "0.3.0"
+    assert checked["has_update"] is True
+    assert updater._cache == checked
+    assert cached_version() == "0.2.0"
+    assert asset_downloads == 1
+
+
+def test_concurrent_install_requests_download_once(updater, monkeypatch, tmp_path):
+    plugin_dir = tmp_path / "Panel de Control"
+    plugin_dir.mkdir()
+    package = plugin_dir / "package.json"
+    package.write_text(json.dumps({"version": "0.1.0"}), encoding="utf-8")
+    archive = _release_archive("0.2.0")
+
+    asset_url = "https://gh/0.2.0.zip"
+    updater._cache = {
+        "current": "0.1.0",
+        "latest": "0.2.0",
+        "notes": "## v0.2.0",
+        "download_url": asset_url,
+        "has_update": True,
+        "error": "",
+    }
+    download_started = threading.Event()
+    release_download = threading.Event()
+    downloads = 0
+
+    def release_get(url, accept):
+        nonlocal downloads
+        assert url == asset_url
+        downloads += 1
+        download_started.set()
+        assert release_download.wait(timeout=1)
+        return archive
+
+    cached_version = _cached_package_version(package)
+    assert cached_version() == "0.1.0"
+    monkeypatch.setattr(updater, "_http_get", release_get)
+    monkeypatch.setattr(updater, "_plugin_dir", lambda: plugin_dir)
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    monkeypatch.setattr(updater, "read_version", cached_version)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(updater.install)
+        assert download_started.wait(timeout=1)
+        second = pool.submit(updater.install)
+        time.sleep(0.05)
+        assert downloads == 1
+        release_download.set()
+        first_result = first.result(timeout=1)
+        second_result = second.result(timeout=1)
+
+    assert first_result["ok"] is True
+    assert second_result == {
+        "ok": False,
+        "needs_restart": False,
+        "message": "no_asset",
+    }
+    assert downloads == 1
+
+
+def test_check_does_not_install_an_older_release_when_latest_has_no_asset(updater, monkeypatch):
+    monkeypatch.setattr(updater, "read_version", lambda: "0.1.0")
+    monkeypatch.setattr(updater, "_repo_slug", lambda: "panel-de-control")
+    monkeypatch.setattr(updater, "_plugin_name", lambda: "Panel de Control")
+    latest = _release("0.3.0", "Latest")
+    requested = []
+
+    def release_get(url, accept):
+        requested.append(url)
+        if url.endswith("/latest"):
+            return json.dumps(latest).encode()
+        return json.dumps(
+            [_release("0.2.0", "Older", asset_url="https://gh/older.zip")]
+        ).encode()
+
+    monkeypatch.setattr(updater, "_http_get", release_get)
+
+    result = updater.check(force=True)
+
+    assert requested == [
+        "https://api.github.com/repos/Hooandee/panel-de-control/releases/latest",
+    ]
+    assert result["latest"] == "0.3.0"
+    assert result["download_url"] == ""
+    assert result["has_update"] is False
 
 
 def test_check_network_failure_returns_error_status(updater, monkeypatch):


### PR DESCRIPTION
## What does this change?

- Shows every stable release note newer than the installed version, ordered from newest to oldest.
- Keeps GitHub's latest release endpoint as the only source for the target version and downloadable asset.
- Displays only the selected language for each release, with an English fallback and support for older unsectioned notes.
- Makes long update histories scrollable with the gamepad and moves focus to the install action at the bottom.
- Runs checks and installation outside Decky's event loop and serializes updater operations safely.

Closes #497

## How was it tested?

- `pnpm typecheck`
- `pnpm test:fe` — 743 tests passed
- `pnpm build`
- `ruff check py_modules main.py tests`
- `python -m pytest` — 2,145 tests, 55 subtests passed; 1 skipped
- MSI Claw 8 AI+: loaded the real history from 0.34.0 through 0.37.10 in Spanish, English, and Italian; verified controller scrolling and focus handoff.
- Lenovo Legion Go S: completed a real 0.34.0 to 0.37.10 download, install, Decky restart, and final QAM smoke.
- Lenovo Legion Go 2: loaded the same final bundle and verified QAM, Settings, device detection, and updater state.

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.
