### PR TITLE
fix(tdp): defensively reassert Xbox Ally X game limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -2842,6 +2842,15 @@ class Plugin:
         command = self._capture_tdp_command(reason, on_ac)
         self._offload(lambda: self._execute_tdp_command(command))
 
+    def _tdp_authoritative_reassert_s(self):
+        if self._current_appid is None:
+            return None
+        return getattr(
+            self._tdp_backend,
+            "authoritative_reassert_s",
+            None,
+        )
+
     def _tdp_guard_tick(self, now=None):
         now = time.monotonic() if now is None else float(now)
         if self._tdp_shutdown:
@@ -2885,8 +2894,14 @@ class Plugin:
                 "heartbeat_s",
                 None,
             ),
+            authoritative_reassert_s=self._tdp_authoritative_reassert_s(),
         )
-        action = outcome.action
+        action = (
+            "reassert"
+            if outcome.action == "apply"
+            and outcome.reason == "periodic_reassert"
+            else outcome.action
+        )
         result = None
         if command.generation != self._tdp_generation:
             return
@@ -2947,6 +2962,9 @@ class Plugin:
             due.append(ready_at)
         if memory.next_retry_at > now:
             due.append(memory.next_retry_at)
+        reassert_s = self._tdp_authoritative_reassert_s()
+        if reassert_s is not None and memory.last_write_at is not None:
+            due.append(memory.last_write_at + float(reassert_s))
         if not due:
             return interval
         return max(0.05, min(interval, min(due) - now))
@@ -6192,6 +6210,11 @@ class Plugin:
                 getattr(self._tdp_backend, "guard_interval_s", 0.0)
             ),
             "heartbeat_s": getattr(self._tdp_backend, "heartbeat_s", None),
+            "authoritative_reassert_s": getattr(
+                self._tdp_backend,
+                "authoritative_reassert_s",
+                None,
+            ),
             "read_tolerance_w": int(
                 getattr(self._tdp_backend, "read_tolerance_w", 0)
             ),

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -17,6 +17,18 @@ def is_gpd_win_mini_2025(device, root: str = "/") -> bool:
     )
 
 
+def asus_tdp_authoritative_reassert_s(device, root: str = "/") -> float | None:
+    vendor = _read_dmi(root, "sys_vendor").casefold()
+    product = _read_dmi(root, "product_name").casefold()
+    if (
+        getattr(device, "key", None) == "rog_xbox_ally_x"
+        and vendor == "asustek computer inc."
+        and product == "rog xbox ally x rc73xa_rc73xa"
+    ):
+        return 15.0
+    return None
+
+
 def is_legion_go_s_83n6(device, root: str = "/") -> bool:
     return (
         getattr(device, "key", None) == "legion_go_s"

--- a/py_modules/tdp/backend.py
+++ b/py_modules/tdp/backend.py
@@ -11,6 +11,7 @@ class TDPBackend(ABC):
     readback: bool = True
     guard_interval_s: float = 2.0
     heartbeat_s: float | None = None
+    authoritative_reassert_s: float | None = None
     read_tolerance_w: int = 0
     probe_trace: tuple[dict, ...] = ()
     primary_rail: str = "pl1"

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -1,4 +1,5 @@
 from device_quirks import (
+    asus_tdp_authoritative_reassert_s,
     is_gpd_win_mini_2025,
     legion_go_s_83l3_firmware_attr_quirks,
     legion_go_s_83n6_firmware_attr_quirks,
@@ -25,7 +26,16 @@ def _candidates(device, fallback, root, ryzenadj):
     generic = device.is_generic
 
     def asus():
-        return FirmwareAttrBackend("asus-armoury", fallback, root=root, is_generic=generic)
+        return FirmwareAttrBackend(
+            "asus-armoury",
+            fallback,
+            root=root,
+            is_generic=generic,
+            authoritative_reassert_s=asus_tdp_authoritative_reassert_s(
+                device,
+                root,
+            ),
+        )
 
     def lenovo():
         return FirmwareAttrBackend(

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -73,6 +73,7 @@ class FirmwareAttrBackend(TDPBackend):
         ignored_live_maxes=None,
         cap_boost_to_active=False,
         readback_settle_delays=None,
+        authoritative_reassert_s=None,
     ):
         self.name = f"firmware-attr:{driver_prefix}"
         self._fallback = fallback
@@ -101,6 +102,20 @@ class FirmwareAttrBackend(TDPBackend):
             if rail in self._primary_rails or rail in self._legacy
         )
         self.supports_levels = any(rail != "pl1" for rail in self._rails)
+        complete_primary = all(rail in self._primary_rails for rail, _attr in _RAIL_ATTRS)
+        complete_legacy = all(rail in self._legacy for rail, _attr in _RAIL_ATTRS)
+        try:
+            reassert_s = float(authoritative_reassert_s)
+        except (TypeError, ValueError):
+            reassert_s = 0.0
+        self.authoritative_reassert_s = (
+            reassert_s
+            if driver_prefix == "asus-armoury"
+            and complete_primary
+            and complete_legacy
+            and reassert_s > 0
+            else None
+        )
 
     def _live_bounds(self, attr):
         # Read live, never cache: the firmware ceiling is dynamic.

--- a/py_modules/tdp/reconcile.py
+++ b/py_modules/tdp/reconcile.py
@@ -126,6 +126,14 @@ def _heartbeat_delay(value):
     return delay if delay > 0 else UNVERIFIABLE_HEARTBEAT_S
 
 
+def _optional_delay(value):
+    try:
+        delay = float(value)
+    except (TypeError, ValueError):
+        return None
+    return delay if delay > 0 else None
+
+
 def _recent_memory(memory, now):
     recent = tuple(
         seen for seen in memory.drift_times
@@ -143,6 +151,7 @@ def decide(
     write_only=False,
     force=False,
     heartbeat_s=None,
+    authoritative_reassert_s=None,
 ):
     memory, conflict = _recent_memory(memory, now)
     heartbeat = _heartbeat_delay(heartbeat_s)
@@ -215,6 +224,7 @@ def decide(
         )
     signature = _signature(targets, observation, tolerance)
     if not signature:
+        reassert_s = _optional_delay(authoritative_reassert_s)
         status, reason = _steady_status(targets)
         clean = replace(
             memory,
@@ -223,6 +233,31 @@ def decide(
             failures=0,
             next_retry_at=0.0,
         )
+        if memory.failures and reassert_s is not None:
+            failure_status = (
+                "rejected"
+                if memory.failures > len(RETRY_S)
+                else "settling"
+            )
+            action = "apply" if now >= memory.next_retry_at else "hold"
+            return ReconcileDecision(
+                action,
+                failure_status,
+                "write_rejected",
+                memory,
+                conflict,
+            )
+        if reassert_s is not None and (
+            memory.last_write_at is None
+            or now - memory.last_write_at >= reassert_s
+        ):
+            return ReconcileDecision(
+                "apply",
+                status,
+                "periodic_reassert",
+                clean,
+                conflict,
+            )
         return ReconcileDecision("hold", status, reason, clean, conflict)
     if memory.failures and now < memory.next_retry_at:
         status = (

--- a/tests/test_device_quirks.py
+++ b/tests/test_device_quirks.py
@@ -47,6 +47,44 @@ def test_gpd_quirk_is_false_when_dmi_is_unreadable(tmp_path):
     )
 
 
+def test_xbox_ally_x_tdp_reassert_requires_exact_rc73xa_dmi(tmp_path):
+    _write_dmi(
+        str(tmp_path),
+        "ASUSTeK COMPUTER INC.",
+        "ROG Xbox Ally X RC73XA_RC73XA",
+    )
+
+    assert device_quirks.asus_tdp_authoritative_reassert_s(
+        _profile("rog_xbox_ally_x"),
+        str(tmp_path),
+    ) == 15.0
+
+
+def test_xbox_ally_x_tdp_reassert_rejects_other_identities(tmp_path):
+    cases = (
+        ("ASUSTeK COMPUTER INC.", "ROG Ally X RC72LA", _profile("rog_ally_x")),
+        ("ASUSTeK COMPUTER INC.", "ROG Xbox Ally X", _profile("rog_xbox_ally_x")),
+        (
+            "ASUSTeK COMPUTER INC.",
+            "ROG Xbox Ally X Prototype RC73XA_RC73XA",
+            _profile("rog_xbox_ally_x"),
+        ),
+        (
+            "ASUSTeK COMPUTER INC.",
+            "ROG Xbox Ally X RC73XA_RC73XA-OTHER",
+            _profile("rog_xbox_ally_x"),
+        ),
+        ("OTHER", "ROG Xbox Ally X RC73XA", _profile("rog_xbox_ally_x")),
+    )
+
+    for vendor, product, profile in cases:
+        _write_dmi(str(tmp_path), vendor, product)
+        assert device_quirks.asus_tdp_authoritative_reassert_s(
+            profile,
+            str(tmp_path),
+        ) is None
+
+
 def test_legion_go_s_83n6_uses_measured_boost_rail_floors(tmp_path):
     assert hasattr(device_quirks, "legion_go_s_83n6_rail_floors")
     _write_dmi(str(tmp_path), "LeNoVo", "83n6")

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -48,6 +48,14 @@ def _mk_dmi(root, vendor, product):
             f.write(value)
 
 
+def _mk_asus_legacy(root):
+    base = os.path.join(root, "sys/devices/platform/asus-nb-wmi")
+    os.makedirs(base, exist_ok=True)
+    for name in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_fppt"):
+        with open(os.path.join(base, name), "w") as handle:
+            handle.write("15")
+
+
 def _set_fw_max(root, rail, value):
     path = os.path.join(
         root,
@@ -86,6 +94,71 @@ def test_rog_uses_asus_armoury_firmware_attr(tmp_path):
         "supported": True,
     },)
     assert b.diagnostics()["readback_settle_ms"] == 0
+
+
+def test_only_exact_dual_interface_xbox_ally_x_gets_authoritative_reassert(tmp_path):
+    exact_root = str(tmp_path / "exact")
+    _mk_fw(exact_root, "asus-armoury")
+    _mk_asus_legacy(exact_root)
+    _mk_dmi(
+        exact_root,
+        "ASUSTeK COMPUTER INC.",
+        "ROG Xbox Ally X RC73XA_RC73XA",
+    )
+    exact = select_backend(
+        _p("rog_xbox_ally_x"),
+        root=exact_root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    missing_legacy_root = str(tmp_path / "missing-legacy")
+    _mk_fw(missing_legacy_root, "asus-armoury")
+    _mk_dmi(
+        missing_legacy_root,
+        "ASUSTeK COMPUTER INC.",
+        "ROG Xbox Ally X RC73XA_RC73XA",
+    )
+    missing_legacy = select_backend(
+        _p("rog_xbox_ally_x"),
+        root=missing_legacy_root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    partial_primary_root = str(tmp_path / "partial-primary")
+    _mk_fw(partial_primary_root, "asus-armoury")
+    _mk_asus_legacy(partial_primary_root)
+    _mk_dmi(
+        partial_primary_root,
+        "ASUSTeK COMPUTER INC.",
+        "ROG Xbox Ally X RC73XA_RC73XA",
+    )
+    partial_pl3 = os.path.join(
+        partial_primary_root,
+        "sys/class/firmware-attributes/asus-armoury/attributes/ppt_pl3_fppt",
+    )
+    for name in ("current_value", "min_value", "max_value"):
+        os.remove(os.path.join(partial_pl3, name))
+    os.rmdir(partial_pl3)
+    partial_primary = select_backend(
+        _p("rog_xbox_ally_x"),
+        root=partial_primary_root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    other_root = str(tmp_path / "other")
+    _mk_fw(other_root, "asus-armoury")
+    _mk_asus_legacy(other_root)
+    _mk_dmi(other_root, "ASUSTeK COMPUTER INC.", "ROG Ally X RC72LA")
+    other = select_backend(
+        _p("rog_ally_x"),
+        root=other_root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    assert exact.authoritative_reassert_s == 15.0
+    assert missing_legacy.authoritative_reassert_s is None
+    assert partial_primary.authoritative_reassert_s is None
+    assert other.authoritative_reassert_s is None
 
 
 def test_legion_uses_lenovo_firmware_attr(tmp_path):

--- a/tests/test_tdp_guard_rpc.py
+++ b/tests/test_tdp_guard_rpc.py
@@ -279,6 +279,34 @@ def test_guard_corrects_confirmed_drift_without_mutating_profile(plugin):
     assert plugin._tdp_profiles.effective(None)["pl1"] == 15
 
 
+def test_game_authoritative_reassert_rewrites_matching_persisted_target(plugin):
+    plugin._tdp_backend.authoritative_reassert_s = 15.0
+    plugin._tdp_profiles.set_pl1("global", 13)
+    plugin._current_appid = "42"
+    plugin._execute_tdp_command(plugin._capture_tdp_command("game"))
+    plugin._tdp_backend.set_levels_calls = 0
+    plugin._tdp_reconcile_memory = ReconcileMemory(last_write_at=100.0)
+
+    plugin._tdp_guard_tick(now=114.9)
+    plugin._tdp_guard_tick(now=115.0)
+
+    assert plugin._tdp_backend.set_levels_calls == 1
+    assert plugin._tdp_backend._levels == {"pl1": 13, "pl2": 15, "pl3": 15}
+    assert plugin._tdp_profiles.effective("42")["pl1"] == 13
+    assert plugin._tdp_history[-1]["action"] == "reassert"
+    assert plugin._tdp_history[-1]["write"]["ok"] is True
+
+
+def test_authoritative_reassert_is_idle_without_running_game(plugin):
+    plugin._tdp_backend.authoritative_reassert_s = 15.0
+    plugin._tdp_reconcile_memory = ReconcileMemory(last_write_at=100.0)
+    plugin._tdp_backend.set_levels_calls = 0
+
+    plugin._tdp_guard_tick(now=115.0)
+
+    assert plugin._tdp_backend.set_levels_calls == 0
+
+
 def test_guard_keeps_global_and_game_profiles_independent(plugin):
     plugin._tdp_profiles.set_pl1("global", 18)
     plugin._tdp_profiles.create_game_from_global("42")
@@ -404,6 +432,20 @@ def test_guard_delay_respects_minimum_correction_interval(
         last_write_at=99.0,
     )
     monkeypatch.setattr(main_module.time, "monotonic", lambda: 100.0)
+    assert plugin._tdp_guard_delay() == 1.0
+
+
+def test_guard_delay_wakes_when_game_authoritative_reassert_is_due(
+    plugin,
+    monkeypatch,
+):
+    import main as main_module
+
+    plugin._tdp_backend.authoritative_reassert_s = 15.0
+    plugin._current_appid = "42"
+    plugin._tdp_reconcile_memory = ReconcileMemory(last_write_at=100.0)
+    monkeypatch.setattr(main_module.time, "monotonic", lambda: 114.0)
+
     assert plugin._tdp_guard_delay() == 1.0
 
 
@@ -621,6 +663,7 @@ def test_backend_diagnostics_explain_selection_without_personal_identifiers(plug
     assert descriptor["rails"] == ["pl1", "pl2", "pl3"]
     assert descriptor["guard_interval_s"] == 2.0
     assert descriptor["read_tolerance_w"] == 0
+    assert descriptor["authoritative_reassert_s"] is None
     assert descriptor["limits"]["default"] == 15
     assert descriptor["level_limits"]["pl1"]["max"] == 35
     assert descriptor["probe_trace"][0]["candidate"] == "fake"
@@ -628,6 +671,14 @@ def test_backend_diagnostics_explain_selection_without_personal_identifiers(plug
     encoded = json.dumps(descriptor).lower()
     for forbidden in ("appid", "title", "hostname", "serial", "uuid", "/home/"):
         assert forbidden not in encoded
+
+
+def test_backend_diagnostics_publish_authoritative_reassert_cadence(plugin):
+    plugin._tdp_backend.authoritative_reassert_s = 15.0
+
+    descriptor = plugin._tdp_backend_diagnostics()
+
+    assert descriptor["authoritative_reassert_s"] == 15.0
 
 
 def test_backend_diagnostics_are_logged_once_as_compact_json(plugin):

--- a/tests/test_tdp_reconcile.py
+++ b/tests/test_tdp_reconcile.py
@@ -70,6 +70,74 @@ def test_matching_target_is_in_sync():
     assert (out.action, out.status) == ("hold", "in_sync")
 
 
+def test_authoritative_reassert_applies_matching_target_when_due():
+    targets = build_targets({"pl1": 15}, {"pl1": {"min": 7, "max": 30}}, obs())
+    memory = ReconcileMemory(last_write_at=10.0)
+
+    before = decide(
+        targets,
+        obs(),
+        memory,
+        now=24.9,
+        tolerance=0,
+        authoritative_reassert_s=15.0,
+    )
+    due = decide(
+        targets,
+        obs(),
+        memory,
+        now=25.0,
+        tolerance=0,
+        authoritative_reassert_s=15.0,
+    )
+
+    assert before.action == "hold"
+    assert (due.action, due.status, due.reason) == (
+        "apply",
+        "in_sync",
+        "periodic_reassert",
+    )
+
+
+def test_failed_authoritative_reassert_retries_despite_matching_readback():
+    targets = build_targets({"pl1": 15}, {"pl1": {"min": 7, "max": 30}}, obs())
+    due = decide(
+        targets,
+        obs(),
+        ReconcileMemory(last_write_at=10.0),
+        now=25.0,
+        tolerance=0,
+        authoritative_reassert_s=15.0,
+    )
+    failed = after_apply(
+        targets,
+        obs(),
+        due.memory,
+        now=25.0,
+        wrote_ok=False,
+        tolerance=0,
+    )
+    before_retry = decide(
+        targets,
+        obs(),
+        failed.memory,
+        now=25.4,
+        tolerance=0,
+        authoritative_reassert_s=15.0,
+    )
+    retry = decide(
+        targets,
+        obs(),
+        failed.memory,
+        now=25.5,
+        tolerance=0,
+        authoritative_reassert_s=15.0,
+    )
+
+    assert (before_retry.action, before_retry.reason) == ("hold", "write_rejected")
+    assert (retry.action, retry.reason) == ("apply", "write_rejected")
+
+
 def test_constrained_match_is_not_drift():
     limited = obs(value=15, hi=15)
     targets = build_targets(


### PR DESCRIPTION
## What does this change?

Adds a defensive TDP reassert for the exact ROG Xbox Ally X RC73XA configuration reported in #508.

- Rewrites the persisted effective TDP target every 15 seconds while a game is active.
- Requires the exact validated DMI plus complete `asus-armoury` and legacy `asus-nb-wmi` PL1/PL2/PL3 surfaces.
- Uses the existing TDP executor, live limits, readback, retry/backoff, and context generation.
- Does not mutate the saved profile and remains disabled for other ASUS models and all non-ASUS backends.

This is intentionally a defensive mitigation for the observed last-writer behavior. The original CachyOS symptom was not locally reproducible, so this PR is related to #508 but does not close it automatically.

## How was it tested?

- ROG Xbox Ally X RC73XA: verified a same-value 25/26/45 reassert after 15 seconds with a game context, with matching readback on both ASUS surfaces.
- Legion Go 2 83N0: verified the Lenovo backend keeps the policy disabled, converges through its existing asynchronous settling path, and emits no periodic reassert.
- Legion Go S 83N6: verified the Lenovo backend keeps the policy disabled, preserves its 5/15/20 safe target, and emits no periodic reassert.
- `python -m pytest`: 2,154 passed, 1 skipped, 55 subtests passed.
- `ruff check py_modules main.py tests`: passed.
- `pnpm typecheck`, `pnpm test:fe` (743 tests), and `pnpm build`: passed.

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.
