### PR TITLE
feat: add first-class Anatase support

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ import decky
 import auto_tdp
 import device_registry
 import osinfo
+import pdc_platform as platform_support
 import self_updater
 import theme_activation
 import theme_packages
@@ -327,6 +328,14 @@ class Plugin:
             os.path.join(decky.DECKY_PLUGIN_SETTINGS_DIR, "state.json")
         )
         self._settings = self._store.load(DEFAULTS)
+        self._os_id = osinfo.read_os_id()
+        self._os_name = osinfo.read_os_name()
+        self._platform = platform_support.describe(self._os_id)
+        self._hhd_tdp_client = platform_support.select_hhd_tdp_client(
+            self._os_id,
+            controller_hhd,
+        )
+        self._tdp_external_owner = None if self._os_id == "anatase" else False
         desktop_settings_changed = normalize_desktop_settings(self._settings)
         # Probe hardware/environment HERE, wrapped so it NEVER raises — a raise in
         # init or _main bricks plugin load (UI stuck on spinner forever).
@@ -389,7 +398,10 @@ class Plugin:
             self._tdp_profiles.drop_legacy_gpu_clocks()
             self._settings["_gpu_scope_migrated"] = True
             self._store.save(self._settings)
-        self._tdp_backend = tdp_factory.select_backend(self._device)
+        self._tdp_backend = tdp_factory.select_backend(
+            self._device,
+            os_id=self._os_id,
+        )
         self._steamdeck_ppt_history = deque(maxlen=32)
         self._steamdeck_ppt_last_failure = None
         self._steamdeck_ppt_recovery_blocked = False
@@ -598,7 +610,6 @@ class Plugin:
         # Real silicon name (static) shown in the DeviceHeader instead of the hardcoded
         # table chip; read once here like _cpu_info. None on generic or when unreadable.
         self._chip = read_cpu_model() if not self._device.is_generic else None
-        self._os_name = osinfo.read_os_name()
         self._current_appid = None
         self._current_game_name = None  # display name of the running game (for the HUD)
         # HUD (MangoHud) plugin-state metrics: the presets.conf path + the shown pdc
@@ -1259,13 +1270,18 @@ class Plugin:
         backend = getattr(self, "_controller_backend", None)
         if getattr(backend, "manager", None) != controller_detect.HHD:
             return True
+        hhd_client = getattr(self, "_hhd_tdp_client", controller_hhd)
         try:
-            current = controller_hhd.current_tdp_enable()
+            current = hhd_client.current_tdp_enable()
         except Exception:  # noqa: BLE001
             return False
         if current is False:
+            if getattr(self, "_os_id", None) == "anatase":
+                self._tdp_external_owner = False
             return True
         if current is not True:
+            if getattr(self, "_os_id", None) == "anatase":
+                self._tdp_external_owner = True
             return False
         previous = self._settings.get("hhd_tdp_prev")
         if previous is None:
@@ -1276,8 +1292,13 @@ class Plugin:
                 self._settings["hhd_tdp_prev"] = None
                 return False
         try:
-            return controller_hhd.set_tdp_enable(False) is False
+            released = hhd_client.set_tdp_enable(False) is False
+            if getattr(self, "_os_id", None) == "anatase":
+                self._tdp_external_owner = not released
+            return released
         except Exception:  # noqa: BLE001
+            if getattr(self, "_os_id", None) == "anatase":
+                self._tdp_external_owner = True
             return False
 
     def _suspend_handheld_tdp_for_desktop(self) -> None:
@@ -1717,6 +1738,7 @@ class Plugin:
             "product_family": read_str("/sys/class/dmi/id/product_family"),
             "board_name": read_str("/sys/class/dmi/id/board_name"),
             "os": os_name,
+            "platform": dict(self._platform),
             "kernel": kernel,
         }
 
@@ -1936,7 +1958,7 @@ class Plugin:
         self._init()
         hhd_present = self._controller_backend.manager == controller_detect.HHD
         # Only read HHD state when HHD is the active manager (its API is local).
-        state = controller_hhd.read_state() if hhd_present else None
+        state = self._hhd_tdp_client.read_state() if hhd_present else None
         out = controller_conflict.assess(state, self._tdp_supported())
         out["hhd_present"] = hhd_present
         return out
@@ -2043,13 +2065,23 @@ class Plugin:
                 return failure.get("reason", "restore_failed")
         return None
 
-    def _restore_power_handoff(self, preserve_ownership=False) -> bool:
-        ppt_released = (
+    def _release_tdp_hardware(self, preserve_ownership=False) -> bool:
+        backend = getattr(self, "_tdp_backend", None)
+        release = getattr(backend, "release", None)
+        try:
+            backend_released = bool(release()) if callable(release) else True
+        except Exception:  # noqa: BLE001
+            backend_released = False
+        if not backend_released:
+            return False
+        return (
             self._restore_steamdeck_ppt(preserve_ownership=True)
             if preserve_ownership
             else self._restore_steamdeck_ppt()
         )
-        if not ppt_released:
+
+    def _restore_power_handoff(self, preserve_ownership=False) -> bool:
+        if not self._release_tdp_hardware(preserve_ownership):
             return False
         return (
             self._restore_hhd_tdp(preserve_ownership=True)
@@ -2058,12 +2090,69 @@ class Plugin:
         )
 
     # ---- TDP conflict + master switch --------------------------------------
+    def _tdp_write_authorized(self) -> bool:
+        return (
+            getattr(self, "_os_id", None) != "anatase"
+            or self._tdp_external_owner is False
+        )
+
+    async def _prime_tdp_ownership(self) -> bool | None:
+        if self._os_id != "anatase":
+            return False
+        hhd_present = self._controller_backend.manager == controller_detect.HHD
+        if not hhd_present:
+            self._tdp_external_owner = False
+            return False
+        managing = await self._offload_call(
+            self._hhd_tdp_client.current_tdp_enable
+        )
+        self._tdp_external_owner = managing is not False
+        return managing
+
+    async def _recover_tdp_startup_state(self) -> bool:
+        managing = await self._prime_tdp_ownership()
+        if self._os_id != "anatase" or managing is False:
+            return await self._offload_call(self._recover_tdp_runtime_transaction)
+        if not getattr(self._tdp_backend, "safety_locked", False):
+            return True
+        if managing is True:
+            relinquish = getattr(self._tdp_backend, "relinquish_ownership", None)
+            if callable(relinquish):
+                try:
+                    result = await self._offload_call(relinquish)
+                except Exception as error:  # noqa: BLE001
+                    decky.logger.warning(
+                        "Interrupted TDP ownership relinquish failed: %s",
+                        type(error).__name__,
+                    )
+                else:
+                    ok = bool(isinstance(result, dict) and result.get("ok"))
+                    detail = (
+                        result.get("detail")
+                        if isinstance(result, dict)
+                        else "invalid response"
+                    )
+                    log = decky.logger.info if ok else decky.logger.warning
+                    log("Interrupted TDP ownership relinquish: %s", detail)
+                    if ok and not getattr(
+                        self._tdp_backend,
+                        "safety_locked",
+                        False,
+                    ):
+                        return True
+        reason = "external owner" if managing is True else "ownership unconfirmed"
+        decky.logger.warning(
+            "Interrupted TDP transaction recovery deferred: %s",
+            reason,
+        )
+        return False
+
     async def get_tdp_conflict(self) -> dict:
         """Which external managers can currently write the power rails."""
         self._init()
         hhd_present = self._controller_backend.manager == controller_detect.HHD
         hhd_call = (
-            self._offload_call(controller_hhd.current_tdp_enable)
+            self._offload_call(self._hhd_tdp_client.current_tdp_enable)
             if hhd_present
             else asyncio.sleep(0, result=False)
         )
@@ -2071,6 +2160,10 @@ class Plugin:
             hhd_call,
             self._offload_call(self._powerstation_detector.tdp_active),
         )
+        if self._os_id == "anatase":
+            self._tdp_external_owner = (
+                managing is not False if hhd_present else False
+            )
         return {
             "hhd_present": hhd_present,
             "hhd_managing": bool(managing),
@@ -2084,7 +2177,7 @@ class Plugin:
         await self._ensure_recognised_desktop_migration()
         if getattr(self, "_desktop_recognition_migration_pending", False):
             managing = await self._offload_call(
-                controller_hhd.current_tdp_enable
+                self._hhd_tdp_client.current_tdp_enable
             )
             return {
                 "ok": False,
@@ -2092,15 +2185,19 @@ class Plugin:
                 "detail": "desktop migration pending",
             }
         if not await self._probe_tdp_backend(force=True):
-            prev = await self._offload_call(controller_hhd.current_tdp_enable)
+            prev = await self._offload_call(
+                self._hhd_tdp_client.current_tdp_enable
+            )
             return {
                 "ok": False,
                 "hhd_managing": bool(prev),
                 "detail": "tdp backend readback unavailable",
             }
         # HHD's REST client is blocking urllib — keep it off the loop.
-        prev = await self._offload_call(controller_hhd.current_tdp_enable)
+        prev = await self._offload_call(self._hhd_tdp_client.current_tdp_enable)
         if prev is None:
+            if self._os_id == "anatase":
+                self._tdp_external_owner = True
             return {"ok": False, "hhd_managing": False}
         if prev and self._settings.get("hhd_tdp_prev") is None:
             self._settings["hhd_tdp_prev"] = True
@@ -2109,11 +2206,26 @@ class Plugin:
             except Exception:  # noqa: BLE001
                 self._settings["hhd_tdp_prev"] = None
                 return {"ok": False, "hhd_managing": True}
-        applied = await self._offload_call(lambda: controller_hhd.set_tdp_enable(False))
+        applied = await self._offload_call(
+            lambda: self._hhd_tdp_client.set_tdp_enable(False)
+        )
         if applied is not False:
+            if self._os_id == "anatase":
+                self._tdp_external_owner = True
             return {"ok": False, "hhd_managing": bool(applied)}
+        if self._os_id == "anatase":
+            self._tdp_external_owner = False
         result = await self._apply_tdp_now("take-control")
         if not result.ok:
+            hardware_released = await self._offload_call(
+                self._release_tdp_hardware
+            )
+            if not hardware_released:
+                return {
+                    "ok": False,
+                    "hhd_managing": False,
+                    "detail": f"{result.detail}; hardware restore pending",
+                }
             restore = await self._offload_call(self._restore_hhd_tdp_status)
             managing = restore.get("hhd_managing")
             if managing is None:
@@ -2143,14 +2255,19 @@ class Plugin:
                 "marker_cleared": True,
             }
         try:
-            echoed = controller_hhd.set_tdp_enable(bool(prev))
+            hhd_client = getattr(self, "_hhd_tdp_client", controller_hhd)
+            echoed = hhd_client.set_tdp_enable(bool(prev))
             if echoed != bool(prev):
+                if getattr(self, "_os_id", None) == "anatase":
+                    self._tdp_external_owner = True
                 return {
                     "ok": False,
                     "hardware_ok": False,
                     "hhd_managing": echoed if isinstance(echoed, bool) else None,
                     "marker_cleared": False,
                 }
+            if getattr(self, "_os_id", None) == "anatase":
+                self._tdp_external_owner = bool(prev)
             if preserve_ownership:
                 return {
                     "ok": True,
@@ -3732,6 +3849,25 @@ class Plugin:
                 True,
                 "tdp-control-disabled",
             )
+        if not self._tdp_write_authorized():
+            self._tdp_status = "unverifiable"
+            self._tdp_reason = "external_owner"
+            self._tdp_targets = None
+            self._remember_tdp_observation(self._observe_tdp_sync())
+            result = TdpResult(
+                logical_watts,
+                self._tdp_backend.read_applied(),
+                False,
+                "tdp-ownership-unconfirmed",
+            )
+            self._record_tdp_transition(
+                command.reason,
+                action="blocked",
+                result=result,
+                on_ac=command.on_ac,
+                requested=command.requested,
+            )
+            return result
         mode = self._firmware_mode()
         if mode != _CUSTOM_MODE:
             if not self._tdp_backend.set_profile(mode):
@@ -3901,6 +4037,13 @@ class Plugin:
             self._tdp_status = "unverifiable"
             self._tdp_reason = "control_disabled"
             self._tdp_reconcile_memory = ReconcileMemory()
+            return
+        if not self._tdp_write_authorized():
+            self._tdp_status = "unverifiable"
+            self._tdp_reason = "external_owner"
+            self._tdp_targets = None
+            self._tdp_reconcile_memory = ReconcileMemory()
+            self._remember_tdp_observation(self._observe_tdp_sync())
             return
         if self._firmware_mode() != _CUSTOM_MODE:
             self._tdp_status = "unverifiable"
@@ -7200,6 +7343,8 @@ class Plugin:
             "surfaces": observation.as_dict()["surfaces"],
             "conflict_persistent": self._tdp_conflict_persistent,
             "failures": self._tdp_reconcile_memory.failures,
+            "handoff_required": self._os_id == "anatase",
+            "external_owner": self._tdp_external_owner,
         }
 
     def _tdp_diagnostics(self):
@@ -8103,7 +8248,7 @@ class Plugin:
         # Created here (not _init) so unit tests that never call _main run inline.
         self._ensure_apply_executor()
         await self._offload_call(self._recover_recognised_desktop_migration)
-        await self._offload_call(self._recover_tdp_runtime_transaction)
+        await self._recover_tdp_startup_state()
         await self._probe_tdp_backend(force=True)
         self._theme_executor = ThreadPoolExecutor(max_workers=1)
         self._theme_accepting_work = True
@@ -8130,6 +8275,7 @@ class Plugin:
             decky.logger.info("Legion fan sensor exposed (lenovo_wmi_other)")
         await self._recover_gpd_fan()
         await self._offload_call(self._recover_fremont_fan_handoff)
+        await self._prime_tdp_ownership()
         try:
             if self._settings.get("steamdeck_ppt_previous") is not None:
                 await self._offload_call(self._restore_steamdeck_ppt)

--- a/py_modules/pdc_platform/__init__.py
+++ b/py_modules/pdc_platform/__init__.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+from osinfo import read_os_id
+
+
+_FIRST_CLASS = frozenset({"anatase", "bazzite", "cachyos", "steamos"})
+
+
+def plugin_root_from_platform_file(path: str) -> str:
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(path))))
+
+
+def activate_import_paths(
+    os_id: str | None,
+    plugin_root: str,
+    paths: list[str],
+) -> None:
+    if os_id != "anatase":
+        return
+    local_modules = os.path.join(plugin_root, "py_modules")
+    if not os.path.isdir(local_modules):
+        return
+    paths[:] = [path for path in paths if path != local_modules]
+    paths.insert(0, local_modules)
+
+
+activate_import_paths(
+    read_os_id(),
+    plugin_root_from_platform_file(__file__),
+    sys.path,
+)
+
+from . import anatase_hhd  # noqa: E402
+
+
+def describe(os_id: str | None) -> dict:
+    return {
+        "id": os_id,
+        "support_tier": "first-class" if os_id in _FIRST_CLASS else "capability",
+    }
+
+
+def select_hhd_tdp_client(os_id: str | None, default_client):
+    return anatase_hhd if os_id == "anatase" else default_client

--- a/py_modules/pdc_platform/anatase_hhd.py
+++ b/py_modules/pdc_platform/anatase_hhd.py
@@ -1,0 +1,86 @@
+"""Anatase-owned adapter for cooperative TDP handoff with HHD."""
+
+import json
+import os
+import urllib.request
+
+from controllers import conflict
+
+
+_TOKEN_REL = "etc/hhd/.token"
+_BASE = "http://127.0.0.1:5335/api/v1"
+
+
+def _token(root: str = "/"):
+    try:
+        with open(os.path.join(root, _TOKEN_REL)) as handle:
+            token = handle.read().strip()
+        return token or None
+    except OSError:
+        return None
+
+
+def _get(path: str, token: str, timeout: int = 5):
+    request = urllib.request.Request(
+        _BASE + path,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def _post(path: str, token: str, payload: dict, timeout: int = 5):
+    request = urllib.request.Request(
+        _BASE + path,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def read_state(root: str = "/"):
+    token = _token(root)
+    if not token:
+        return None
+    try:
+        return _get("/state", token)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def post_state(payload: dict, root: str = "/"):
+    token = _token(root)
+    if not token:
+        return None
+    try:
+        return _post("/state", token, payload)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _tdp_enable(state):
+    try:
+        value = state["hhd"]["settings"]["tdp_enable"]
+    except (KeyError, TypeError):
+        return None
+    return value if isinstance(value, bool) else None
+
+
+def current_tdp_enable(root: str = "/"):
+    state = read_state(root)
+    if _tdp_enable(state) is None:
+        return None
+    return conflict.hhd_managing_power(state)
+
+
+def set_tdp_enable(enabled: bool, root: str = "/"):
+    post_state(
+        {"hhd": {"settings": {"tdp_enable": bool(enabled)}}},
+        root,
+    )
+    return _tdp_enable(read_state(root))

--- a/py_modules/tdp/amd_dptc.py
+++ b/py_modules/tdp/amd_dptc.py
@@ -1,0 +1,57 @@
+import glob
+import os
+
+from sysfs import read_str
+from tdp.firmware_attr import FirmwareAttrBackend
+
+
+class AmdDptcBackend(FirmwareAttrBackend):
+    """Anatase's amd-dptc firmware ABI with cooperative state restoration."""
+
+    def __init__(
+        self,
+        fallback,
+        root="/",
+        write_max=None,
+        safety_lock_path=None,
+        ownership_lock_path=None,
+    ):
+        try:
+            requested_max = int(write_max) if write_max is not None else 0
+        except (TypeError, ValueError):
+            requested_max = 0
+        self._write_max = max(fallback.max_ac_w, requested_max)
+        super().__init__(
+            "amd-dptc",
+            fallback,
+            root=root,
+            profile_name="amd-dptc",
+            is_generic=True,
+            cap_boost_to_active=True,
+            safety_lock_path=safety_lock_path,
+            restore_on_release=True,
+            ownership_lock_path=ownership_lock_path,
+        )
+        self.name = "amd-dptc"
+        self.supported = (
+            self.supported
+            and self._pp_dir is not None
+            and "custom" in self.profile_choices()
+        )
+
+    def _find_profile_dir(self):
+        if not self._profile_name:
+            return None
+        base = os.path.join(self._root, "sys/class/platform-profile")
+        for candidate in sorted(glob.glob(os.path.join(base, "*"))):
+            name = read_str(os.path.join(candidate, "name"))
+            if name and name.startswith(self._profile_name):
+                return candidate
+        return None
+
+    def _profile_rail_max(self, attr):
+        if attr == "ppt_pl2_sppt":
+            return round(self._write_max * 1.2)
+        if attr == "ppt_pl3_fppt":
+            return round(self._write_max * 1.4)
+        return self._write_max

--- a/py_modules/tdp/asus_nb_wmi.py
+++ b/py_modules/tdp/asus_nb_wmi.py
@@ -1,0 +1,250 @@
+import os
+
+from tdp.backend import TDPBackend
+from tdp.runtime_lock import RuntimeSafetyLock
+from tdp.types import RailReading, TdpLimits, TdpObservation, TdpResult
+
+
+_BASE = "sys/devices/platform/asus-nb-wmi"
+_NODES = (
+    ("pl1", "ppt_pl1_spl"),
+    ("pl2", "ppt_pl2_sppt"),
+    ("pl3", "ppt_fppt"),
+)
+
+
+class AsusNbWmiBackend(TDPBackend):
+    """Standalone legacy ASUS TDP ABI used when asus-armoury is absent."""
+
+    name = "asus-nb-wmi"
+
+    def __init__(
+        self,
+        fallback: TdpLimits,
+        root: str = "/",
+        ownership_lock_path: str | None = None,
+    ) -> None:
+        self._fallback = fallback
+        base = os.path.join(root, _BASE)
+        self._paths = {
+            rail: os.path.join(base, node)
+            for rail, node in _NODES
+            if os.path.isfile(os.path.join(base, node))
+        }
+        self._rails = tuple(rail for rail, _node in _NODES if rail in self._paths)
+        self.supported = "pl1" in self._paths
+        self.supports_levels = len(self._rails) > 1
+        self._ownership_lock = RuntimeSafetyLock(ownership_lock_path)
+        payload = self._ownership_lock.load_payload()
+        saved = payload.get("snapshot") if isinstance(payload, dict) else None
+        self._owned_snapshot = (
+            {rail: int(value) for rail, value in saved.items()}
+            if isinstance(saved, dict)
+            and set(saved) == set(self._rails)
+            and all(isinstance(value, int) for value in saved.values())
+            else None
+        )
+        self._ownership_recovery_pending = payload is not None
+        self._recovery_blocked = False
+
+    @property
+    def safety_locked(self) -> bool:
+        return self._recovery_blocked or self._ownership_recovery_pending
+
+    def get_limits(self) -> TdpLimits:
+        return self._fallback
+
+    def level_limits(self) -> dict:
+        return {
+            rail: {
+                "min": self._fallback.min_w,
+                "max": self._rail_max(rail),
+            }
+            for rail in self._rails
+        }
+
+    def set_tdp(self, watts: int, ac: bool) -> TdpResult:
+        if not self.supported:
+            return TdpResult(watts, None, False, "asus-nb-wmi TDP path not present")
+        target = self._fallback.clamp(watts, ac)
+        return self.set_levels(target, target, target, ac)
+
+    def set_levels(self, pl1: int, pl2: int, pl3: int, ac: bool) -> TdpResult:
+        if not self.supported:
+            return TdpResult(pl1, None, False, "asus-nb-wmi TDP path not present")
+        if self.safety_locked:
+            return TdpResult(pl1, self.read_applied(), False, "TDP recovery pending")
+        requested = {"pl1": pl1, "pl2": pl2, "pl3": pl3}
+        targets = {
+            rail: max(
+                self._fallback.min_w,
+                min(int(requested[rail]), self._rail_max(rail)),
+            )
+            for rail in self._rails
+        }
+        before = self._read_snapshot()
+        if before is None:
+            return TdpResult(pl1, self.read_applied(), False, "TDP snapshot unavailable")
+        first_claim = self._owned_snapshot is None
+        if first_claim:
+            payload = {
+                "state": "ownership_pending",
+                "snapshot": before,
+            }
+            if not self._ownership_lock.persist_payload(payload):
+                return TdpResult(
+                    pl1,
+                    self.read_applied(),
+                    False,
+                    "ownership safety lock unavailable; no writes performed",
+                )
+            self._owned_snapshot = before
+
+        failure = self._write_and_verify(targets)
+        if failure is not None:
+            restored = self._restore(before)
+            if restored and first_claim:
+                if not self._ownership_lock.clear():
+                    self._recovery_blocked = True
+                    return TdpResult(
+                        pl1,
+                        self.read_applied(),
+                        False,
+                        f"write not confirmed: {failure}, recovery marker clear failed",
+                    )
+                self._owned_snapshot = None
+            self._recovery_blocked = not restored
+            detail = f"write not confirmed: {failure}"
+            detail += ", rolled back" if restored else ", rollback failed"
+            return TdpResult(pl1, self.read_applied(), False, detail)
+
+        return TdpResult(pl1, targets["pl1"], True, "")
+
+    def read_applied(self) -> int | None:
+        return self._read_int(self._paths.get("pl1"))
+
+    def observe(self) -> TdpObservation:
+        surfaces = (
+            {
+                self.name: {
+                    rail: RailReading(
+                        self._read_int(path),
+                        self._fallback.min_w,
+                        self._rail_max(rail),
+                    )
+                    for rail, path in self._paths.items()
+                }
+            }
+            if self.supported
+            else {}
+        )
+        return TdpObservation(readable=self.supported, surfaces=surfaces)
+
+    def reconciliation_levels(self, levels: dict) -> dict[str, int]:
+        return {
+            rail: int(levels[rail])
+            for rail in self._rails
+            if rail in levels
+        }
+
+    def release(self) -> bool:
+        if self._owned_snapshot is None:
+            return not self.safety_locked
+        restored = self._restore(self._owned_snapshot)
+        self._recovery_blocked = not restored
+        if restored:
+            if not self._ownership_lock.clear():
+                self._recovery_blocked = True
+                return False
+            self._owned_snapshot = None
+            self._ownership_recovery_pending = False
+        return restored
+
+    def recover_runtime_transaction(self) -> dict:
+        if not self._ownership_recovery_pending:
+            return {"ok": True, "detail": "no ASUS legacy recovery pending"}
+        if self._owned_snapshot is None:
+            return {"ok": False, "detail": "ASUS legacy recovery snapshot invalid"}
+        ok = self.release()
+        return {
+            "ok": ok,
+            "detail": (
+                "ASUS legacy ownership recovered"
+                if ok
+                else "ASUS legacy ownership recovery failed"
+            ),
+        }
+
+    def relinquish_ownership(self) -> dict:
+        if self._recovery_blocked:
+            return {"ok": False, "detail": "ASUS legacy recovery blocked"}
+        if not self._ownership_recovery_pending:
+            return {"ok": True, "detail": "no ASUS legacy ownership pending"}
+        if self._owned_snapshot is None:
+            return {"ok": False, "detail": "ASUS legacy recovery snapshot invalid"}
+        if not self._ownership_lock.clear():
+            return {"ok": False, "detail": "ASUS legacy ownership marker clear failed"}
+        self._owned_snapshot = None
+        self._ownership_recovery_pending = False
+        return {"ok": True, "detail": "ASUS legacy ownership relinquished"}
+
+    def diagnostics(self) -> dict:
+        return {
+            "rails": list(self._rails),
+            "transactional": True,
+            "owns_state": self._owned_snapshot is not None,
+            "recovery_blocked": self.safety_locked,
+        }
+
+    def _rail_max(self, rail: str) -> int:
+        if rail == "pl2":
+            return round(self._fallback.max_ac_w * 1.2)
+        if rail == "pl3":
+            return round(self._fallback.max_ac_w * 1.4)
+        return self._fallback.max_ac_w
+
+    def _read_snapshot(self) -> dict[str, int] | None:
+        values = {rail: self._read_int(path) for rail, path in self._paths.items()}
+        if any(value is None for value in values.values()):
+            return None
+        return {rail: int(value) for rail, value in values.items()}
+
+    def _write_and_verify(self, values: dict[str, int]) -> str | None:
+        for rail in reversed(self._rails):
+            if not self._write(self._paths[rail], values[rail]):
+                return f"{self.name}/{rail} write failed"
+        for rail in self._rails:
+            observed = self._read_int(self._paths[rail])
+            if observed != values[rail]:
+                shown = "unavailable" if observed is None else observed
+                return f"{self.name}/{rail}={shown}"
+        return None
+
+    def _restore(self, values: dict[str, int]) -> bool:
+        writes = [
+            self._write(self._paths[rail], values[rail])
+            for rail in reversed(self._rails)
+        ]
+        return all(writes) and all(
+            self._read_int(self._paths[rail]) == values[rail]
+            for rail in self._rails
+        )
+
+    @staticmethod
+    def _read_int(path: str | None) -> int | None:
+        if not path:
+            return None
+        try:
+            with open(path) as handle:
+                return int(handle.read().strip())
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _write(path: str, value: int) -> bool:
+        try:
+            with open(path, "w") as handle:
+                handle.write(f"{value}\n")
+            return True
+        except OSError:
+            return False

--- a/py_modules/tdp/backend.py
+++ b/py_modules/tdp/backend.py
@@ -68,6 +68,10 @@ class TDPBackend(ABC):
     def set_profile(self, mode: str) -> bool:
         return False
 
+    def release(self) -> bool:
+        """Return hardware owned by this backend to its pre-control state."""
+        return True
+
 
 class NullBackend(TDPBackend):
     supported = False

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -8,9 +8,12 @@ from device_quirks import (
     legion_go_s_83n6_rail_floors,
 )
 from tdp.alib import AlibBackend
+from tdp.amd_dptc import AmdDptcBackend
+from tdp.asus_nb_wmi import AsusNbWmiBackend
 from tdp.backend import NullBackend, TDPBackend
 from tdp.firmware_attr import FirmwareAttrBackend
 from tdp.intel_rapl import IntelRaplBackend
+from tdp.msi_claw_a8 import MsiClawA8FirmwareBackend
 from tdp.ryzenadj import RyzenadjBackend
 from tdp.steamdeck_hwmon import SteamDeckHwmonBackend
 from tdp.types import TdpLimits
@@ -30,7 +33,7 @@ def _runtime_lock_path(root, name):
     return os.path.join(root, "run/panel-de-control", name)
 
 
-def _candidates(device, fallback, root, ryzenadj):
+def _candidates(device, fallback, root, ryzenadj, os_id=None):
     """Ordered probe chain of backend factories (constructed lazily by the caller,
     so an early match costs no extra sysfs work). The detected family puts its
     known-good backend first, then falls through to every other known path by
@@ -55,6 +58,11 @@ def _candidates(device, fallback, root, ryzenadj):
             safety_lock_path=_runtime_lock_path(
                 root,
                 "firmware-asus-armoury.lock",
+            ),
+            restore_on_release=os_id == "anatase",
+            ownership_lock_path=_runtime_lock_path(
+                root,
+                "ownership-asus-armoury.lock",
             ),
         )
 
@@ -92,6 +100,33 @@ def _candidates(device, fallback, root, ryzenadj):
     def deck():
         return SteamDeckHwmonBackend(fallback, device.key, root=root)
 
+    def asus_nb_wmi():
+        return AsusNbWmiBackend(
+            fallback,
+            root=root,
+            ownership_lock_path=_runtime_lock_path(
+                root,
+                "ownership-asus-nb-wmi.lock",
+            ),
+        )
+
+    def dptc():
+        return AmdDptcBackend(
+            fallback,
+            root=root,
+            write_max=device.cooler_max,
+            safety_lock_path=_runtime_lock_path(root, "firmware-amd-dptc.lock"),
+            ownership_lock_path=_runtime_lock_path(root, "ownership-amd-dptc.lock"),
+        )
+
+    def msi_a8():
+        return MsiClawA8FirmwareBackend(
+            fallback,
+            root=root,
+            safety_lock_path=_runtime_lock_path(root, "firmware-msi-claw-a8.lock"),
+            ownership_lock_path=_runtime_lock_path(root, "ownership-msi-claw-a8.lock"),
+        )
+
     def alib():
         return AlibBackend(fallback, root=root, write_max=device.cooler_max)
 
@@ -110,23 +145,36 @@ def _candidates(device, fallback, root, ryzenadj):
         return [asus, lenovo, msi]
     if key.startswith("steam_deck"):
         return [deck]
-    if key == "msi_claw_a8":
-        return [ryzenadj]
-    if key == "onexplayer_apex":
-        return [alib, ryzenadj]
-    if key in _STRICT_RYZENADJ_KEYS:
-        return [asus, lenovo, msi, ryzenadj]
-    if key.startswith("rog_"):
+    if os_id != "anatase":
+        if key == "msi_claw_a8":
+            return [ryzenadj]
+        if key == "onexplayer_apex":
+            return [alib, ryzenadj]
+        if key in _STRICT_RYZENADJ_KEYS:
+            return [asus, lenovo, msi, ryzenadj]
+        if key.startswith("rog_"):
+            return [asus, lenovo, msi, *amd_tail]
+        if key.startswith("legion_"):
+            return [lenovo, asus, msi, *amd_tail]
         return [asus, lenovo, msi, *amd_tail]
+
+    if key == "msi_claw_a8":
+        return [msi_a8, ryzenadj]
+    if key == "onexplayer_apex":
+        return [dptc, alib, ryzenadj]
+    if key in _STRICT_RYZENADJ_KEYS:
+        return [dptc, asus, lenovo, msi, ryzenadj]
+    if key.startswith("rog_"):
+        return [asus, asus_nb_wmi, *amd_tail]
     if key.startswith("legion_"):
         return [lenovo, asus, msi, *amd_tail]
     # generic / other AMD. intel-rapl excluded (AMD RAPL can confirm a write without
     # changing real TDP); deck excluded (steamdeck-hwmon matches any power*_cap chip,
     # incl. amdgpu's GPU cap — wrong rail).
-    return [asus, lenovo, msi, *amd_tail]
+    return [dptc, asus, lenovo, msi, *amd_tail]
 
 
-def select_backend(device, root="/", ryzenadj_resolve=None) -> TDPBackend:
+def select_backend(device, root="/", ryzenadj_resolve=None, os_id=None) -> TDPBackend:
     """Pick the first supported TDP strategy for the detected device; else NullBackend."""
     fallback = TdpLimits.from_profile(device)
 
@@ -146,7 +194,7 @@ def select_backend(device, root="/", ryzenadj_resolve=None) -> TDPBackend:
         )
 
     trace = []
-    for make in _candidates(device, fallback, root, ryzenadj):
+    for make in _candidates(device, fallback, root, ryzenadj, os_id):
         candidate = make.__name__
         try:
             backend = make()

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -77,6 +77,8 @@ class FirmwareAttrBackend(TDPBackend):
         authoritative_reassert_s=None,
         trust_live_bounds=False,
         safety_lock_path=None,
+        restore_on_release=False,
+        ownership_lock_path=None,
     ):
         self.name = f"firmware-attr:{driver_prefix}"
         self._fallback = fallback
@@ -85,6 +87,8 @@ class FirmwareAttrBackend(TDPBackend):
         self._is_generic = is_generic
         self._trust_live_bounds = bool(trust_live_bounds)
         self._safety_lock = RuntimeSafetyLock(safety_lock_path)
+        self._restore_on_release = bool(restore_on_release)
+        self._ownership_lock = RuntimeSafetyLock(ownership_lock_path)
         self._rail_floors = _normalise_rail_floors(rail_floors)
         self._ignored_live_maxes = _normalise_rail_values(ignored_live_maxes)
         self.cap_boost_to_active = bool(cap_boost_to_active)
@@ -114,6 +118,13 @@ class FirmwareAttrBackend(TDPBackend):
             if self._runtime_lock_payload
             else None
         )
+        self._owned_payload = (
+            self._ownership_lock.load_payload()
+            if self._restore_on_release
+            else None
+        )
+        self._owns_state = False
+        self._ownership_recovery_pending = self._owned_payload is not None
         complete_primary = all(rail in self._primary_rails for rail, _attr in _RAIL_ATTRS)
         complete_legacy = all(rail in self._legacy for rail, _attr in _RAIL_ATTRS)
         try:
@@ -246,40 +257,87 @@ class FirmwareAttrBackend(TDPBackend):
             mismatches = self._snapshot_mismatches(surfaces, snapshot, profile)
         return not mismatches, write_failures + mismatches
 
-    def recover_runtime_transaction(self):
+    def _restore_payload(self, purpose):
         payload = self._runtime_lock_payload
+        if purpose == "ownership":
+            payload = self._owned_payload
         saved = payload.get("snapshot") if isinstance(payload, dict) else None
         if not isinstance(saved, dict) or not saved:
-            return {"ok": False, "detail": "firmware recovery snapshot unavailable"}
+            return {"ok": False, "detail": f"firmware {purpose} snapshot unavailable"}
         surfaces = self._transaction_surfaces({rail: 0 for rail in self._rails})
         current = {
             self._surface_label(surface, rail): path
             for surface, rail, path in surfaces
         }
         if set(saved) != set(current):
-            return {"ok": False, "detail": "firmware recovery surfaces changed"}
+            return {"ok": False, "detail": f"firmware {purpose} surfaces changed"}
         try:
             snapshot = {current[label]: int(value) for label, value in saved.items()}
         except (TypeError, ValueError):
-            return {"ok": False, "detail": "firmware recovery snapshot invalid"}
+            return {"ok": False, "detail": f"firmware {purpose} snapshot invalid"}
         profile = payload.get("profile")
         if self._pp_dir and not isinstance(profile, str):
-            return {"ok": False, "detail": "firmware recovery profile unavailable"}
+            return {"ok": False, "detail": f"firmware {purpose} profile unavailable"}
         recovered, problems = self._rollback_transaction(surfaces, snapshot, profile)
         if not recovered:
-            detail = "firmware recovery failed: " + ", ".join(problems)
+            detail = f"firmware {purpose} recovery failed: " + ", ".join(problems)
             payload = {**payload, "state": "rollback_failed", "detail": detail}
-            self._runtime_lock_payload = payload
             self._write_circuit_open = detail
-            self._safety_lock.persist_payload(payload)
+            if purpose == "transaction":
+                self._runtime_lock_payload = payload
+                self._safety_lock.persist_payload(payload)
+            else:
+                self._owned_payload = payload
+                self._ownership_recovery_pending = True
+                self._ownership_lock.persist_payload(payload)
             return {"ok": False, "detail": detail}
-        if not self._safety_lock.clear():
-            detail = "firmware recovery confirmed; runtime lock clear failed"
+        lock = self._safety_lock if purpose == "transaction" else self._ownership_lock
+        if not lock.clear():
+            detail = f"firmware {purpose} recovery confirmed; runtime lock clear failed"
             self._write_circuit_open = detail
             return {"ok": False, "detail": detail}
-        self._runtime_lock_payload = None
+        if purpose == "transaction":
+            self._runtime_lock_payload = None
+        else:
+            self._owned_payload = None
+            self._owns_state = False
+            self._ownership_recovery_pending = False
         self._write_circuit_open = None
-        return {"ok": True, "detail": "firmware transaction recovered"}
+        return {"ok": True, "detail": f"firmware {purpose} recovered"}
+
+    def recover_runtime_transaction(self):
+        if self._runtime_lock_payload is not None:
+            recovered = self._restore_payload(
+                "transaction",
+            )
+            if not recovered["ok"]:
+                return recovered
+        if self._ownership_recovery_pending:
+            return self._restore_payload("ownership")
+        return {"ok": True, "detail": "no firmware recovery pending"}
+
+    def relinquish_ownership(self):
+        if self._runtime_lock_payload is not None:
+            return {
+                "ok": False,
+                "detail": "firmware transaction recovery pending",
+            }
+        if not self._ownership_recovery_pending:
+            return {"ok": True, "detail": "no firmware ownership pending"}
+        if self._owned_payload is None:
+            return {
+                "ok": False,
+                "detail": "firmware ownership snapshot unavailable",
+            }
+        if not self._ownership_lock.clear():
+            return {
+                "ok": False,
+                "detail": "firmware ownership marker clear failed",
+            }
+        self._owned_payload = None
+        self._owns_state = False
+        self._ownership_recovery_pending = False
+        return {"ok": True, "detail": "firmware ownership relinquished"}
 
     def reconciliation_levels(self, levels):
         return {
@@ -343,7 +401,11 @@ class FirmwareAttrBackend(TDPBackend):
         )
 
     def ready(self):
-        if not self.supported or self._write_circuit_open is not None:
+        if (
+            not self.supported
+            or self._write_circuit_open is not None
+            or self._ownership_recovery_pending
+        ):
             return False
         if not self._trust_live_bounds:
             return True
@@ -355,7 +417,10 @@ class FirmwareAttrBackend(TDPBackend):
 
     @property
     def safety_locked(self):
-        return self._write_circuit_open is not None
+        return (
+            self._write_circuit_open is not None
+            or self._ownership_recovery_pending
+        )
 
     def probe(self):
         return self.ready()
@@ -468,6 +533,13 @@ class FirmwareAttrBackend(TDPBackend):
                 False,
                 f"firmware write circuit open: {self._write_circuit_open}",
             )
+        if self._ownership_recovery_pending:
+            return TdpResult(
+                pl1,
+                self.read_applied(),
+                False,
+                "firmware ownership recovery pending",
+            )
         if self._trust_live_bounds and any(
             self._validated_live_bounds(attr) is None
             for rail, attr in _RAIL_ATTRS
@@ -491,6 +563,25 @@ class FirmwareAttrBackend(TDPBackend):
                 + ", ".join(missing)
                 + "; no writes performed",
             )
+        first_claim = self._restore_on_release and self._owned_payload is None
+        if first_claim:
+            owned_payload = {
+                "state": "ownership_pending",
+                "detail": "firmware ownership snapshot pending",
+                "snapshot": {
+                    self._surface_label(surface, rail): snapshot[path]
+                    for surface, rail, path in surfaces
+                },
+                "profile": previous_profile,
+            }
+            if not self._ownership_lock.persist_payload(owned_payload):
+                return TdpResult(
+                    pl1,
+                    self.read_applied(),
+                    False,
+                    "ownership safety lock unavailable; no writes performed",
+                )
+            self._owned_payload = owned_payload
         lock_payload = {
             "state": "transaction_pending",
             "detail": "firmware transaction pending",
@@ -501,6 +592,12 @@ class FirmwareAttrBackend(TDPBackend):
             "profile": previous_profile,
         }
         if not self._safety_lock.persist_payload(lock_payload):
+            if first_claim:
+                if self._ownership_lock.clear():
+                    self._owned_payload = None
+                else:
+                    self._ownership_recovery_pending = True
+                    self._write_circuit_open = "ownership marker clear failed"
             return TdpResult(
                 pl1,
                 self.read_applied(),
@@ -565,6 +662,13 @@ class FirmwareAttrBackend(TDPBackend):
                 self._write_circuit_open = rollback_detail
             else:
                 self._runtime_lock_payload = None
+                if first_claim:
+                    if self._ownership_lock.clear():
+                        self._owned_payload = None
+                    else:
+                        self._ownership_recovery_pending = True
+                        self._write_circuit_open = "ownership marker clear failed"
+                        rollback_detail += "; ownership marker clear failed"
             restored_applied_w = (
                 self._read_int(self._attr("ppt_pl1_spl"))
                 if applied_w is not None
@@ -588,6 +692,8 @@ class FirmwareAttrBackend(TDPBackend):
                 self._write_circuit_open,
             )
         self._runtime_lock_payload = None
+        if self._restore_on_release:
+            self._owns_state = True
         return TdpResult(
             pl1,
             applied_w,
@@ -647,6 +753,11 @@ class FirmwareAttrBackend(TDPBackend):
             ),
             "reported_live_bounds": reported,
         }
+        if self._restore_on_release:
+            diagnostics["owns_state"] = self._owns_state
+            diagnostics["ownership_recovery_pending"] = (
+                self._ownership_recovery_pending
+            )
         if self._write_circuit_open is not None:
             diagnostics["write_circuit_open"] = self._write_circuit_open
         if self._trust_live_bounds:
@@ -656,6 +767,18 @@ class FirmwareAttrBackend(TDPBackend):
                 if rail in self._rails
             }
         return diagnostics
+
+    def release(self):
+        if not self._restore_on_release:
+            return True
+        if self._runtime_lock_payload is not None:
+            recovered = self._restore_payload("transaction")
+            if not recovered["ok"]:
+                return False
+        if self._owned_payload is None:
+            return not self._ownership_recovery_pending
+        restored = self._restore_payload("ownership")
+        return bool(restored["ok"])
 
     def _observation_mismatches(self, observation, targets):
         bad = []

--- a/py_modules/tdp/msi_claw_a8.py
+++ b/py_modules/tdp/msi_claw_a8.py
@@ -1,0 +1,42 @@
+import os
+
+from sysfs import read_str
+from tdp.firmware_attr import FirmwareAttrBackend
+
+
+class MsiClawA8FirmwareBackend(FirmwareAttrBackend):
+    """MSI Claw A8 firmware ABI, gated to its exact board identifier."""
+
+    def __init__(
+        self,
+        fallback,
+        root="/",
+        safety_lock_path=None,
+        ownership_lock_path=None,
+    ):
+        super().__init__(
+            "msi-wmi-platform",
+            fallback,
+            root=root,
+            is_generic=True,
+            safety_lock_path=safety_lock_path,
+            restore_on_release=True,
+            ownership_lock_path=ownership_lock_path,
+        )
+        self.name = "msi-claw-a8-firmware"
+        self.supported = (
+            read_str(os.path.join(root, "sys/class/dmi/id/board_name")) == "MS-1T8K"
+            and self._dir is not None
+            and len(self._primary_rails) == 3
+        )
+        self.supports_levels = self.supported
+
+    def get_limits(self):
+        return self._fallback
+
+    def _profile_rail_max(self, attr):
+        if attr == "ppt_pl2_sppt":
+            return 37
+        if attr == "ppt_pl3_fppt":
+            return 55
+        return self._fallback.max_ac_w

--- a/tests/test_anatase_platform.py
+++ b/tests/test_anatase_platform.py
@@ -1,0 +1,140 @@
+import json
+import os
+
+import pytest
+
+from controllers import hhd as default_hhd
+from pdc_platform import anatase_hhd
+from pdc_platform import (
+    activate_import_paths,
+    describe,
+    plugin_root_from_platform_file,
+    select_hhd_tdp_client,
+)
+
+
+def _write(path, value):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as handle:
+        handle.write(str(value))
+
+
+def test_anatase_is_explicitly_first_class():
+    assert describe("anatase") == {
+        "id": "anatase",
+        "support_tier": "first-class",
+    }
+
+
+def test_existing_first_class_platforms_keep_the_default_hhd_client():
+    for os_id in ("steamos", "bazzite", "cachyos", None, "unknown"):
+        assert select_hhd_tdp_client(os_id, default_hhd) is default_hhd
+
+
+def test_only_anatase_selects_its_isolated_hhd_client():
+    assert select_hhd_tdp_client("anatase", default_hhd) is anatase_hhd
+    assert anatase_hhd is not default_hhd
+
+
+def test_anatase_prioritises_plugin_modules_over_fedora_site_packages(tmp_path):
+    plugin_root = str(tmp_path / "plugin")
+    local_modules = os.path.join(plugin_root, "py_modules")
+    os.makedirs(local_modules)
+    paths = ["/usr/lib64/python3.14/site-packages", local_modules]
+
+    activate_import_paths("anatase", plugin_root, paths)
+
+    assert paths[0] == local_modules
+
+
+def test_platform_package_resolves_the_real_plugin_root(tmp_path):
+    plugin_root = str(tmp_path / "Panel de Control")
+    package_file = os.path.join(
+        plugin_root,
+        "py_modules/pdc_platform/__init__.py",
+    )
+
+    assert plugin_root_from_platform_file(package_file) == plugin_root
+
+
+def test_other_platforms_keep_their_existing_import_order(tmp_path):
+    plugin_root = str(tmp_path / "plugin")
+    local_modules = os.path.join(plugin_root, "py_modules")
+    os.makedirs(local_modules)
+    original = ["/usr/lib/python3/site-packages", local_modules]
+    paths = list(original)
+
+    for os_id in ("steamos", "bazzite", "cachyos", None):
+        activate_import_paths(os_id, plugin_root, paths)
+        assert paths == original
+
+
+def test_anatase_hhd_client_reads_and_confirms_tdp_state(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _write(os.path.join(root, "etc/hhd/.token"), "local-token")
+    gets = []
+    posts = []
+    states = iter(
+        (
+            {"hhd": {"settings": {"tdp_enable": True}}},
+            {"hhd": {"settings": {"tdp_enable": False}}},
+        )
+    )
+
+    def fake_get(path, token, timeout=5):
+        gets.append((path, token, timeout))
+        return next(states)
+
+    def fake_post(path, token, payload, timeout=5):
+        posts.append((path, token, json.loads(json.dumps(payload)), timeout))
+        return {"accepted": True}
+
+    monkeypatch.setattr(anatase_hhd, "_get", fake_get)
+    monkeypatch.setattr(anatase_hhd, "_post", fake_post)
+
+    assert anatase_hhd.current_tdp_enable(root=root) is True
+    assert anatase_hhd.set_tdp_enable(False, root=root) is False
+    assert gets == [
+        ("/state", "local-token", 5),
+        ("/state", "local-token", 5),
+    ]
+    assert posts == [
+        (
+            "/state",
+            "local-token",
+            {"hhd": {"settings": {"tdp_enable": False}}},
+            5,
+        )
+    ]
+
+
+def test_anatase_hhd_client_fails_closed_without_token(tmp_path):
+    root = str(tmp_path)
+
+    assert anatase_hhd.read_state(root=root) is None
+    assert anatase_hhd.current_tdp_enable(root=root) is None
+    assert anatase_hhd.set_tdp_enable(False, root=root) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {},
+        {"hhd": {}},
+        {"hhd": {"settings": {}}},
+        {"hhd": {"settings": {"tdp_enable": 0}}},
+        {"hhd": {"settings": {"tdp_enable": "false"}}},
+    ),
+)
+def test_anatase_hhd_client_fails_closed_on_unconfirmed_payload(
+    tmp_path,
+    monkeypatch,
+    payload,
+):
+    root = str(tmp_path)
+    _write(os.path.join(root, "etc/hhd/.token"), "local-token")
+    monkeypatch.setattr(anatase_hhd, "_get", lambda *args, **kwargs: payload)
+    monkeypatch.setattr(anatase_hhd, "_post", lambda *args, **kwargs: payload)
+
+    assert anatase_hhd.current_tdp_enable(root=root) is None
+    assert anatase_hhd.set_tdp_enable(False, root=root) is None

--- a/tests/test_tdp_anatase_backends.py
+++ b/tests/test_tdp_anatase_backends.py
@@ -1,0 +1,760 @@
+import os
+
+from tdp.amd_dptc import AmdDptcBackend
+from tdp.asus_nb_wmi import AsusNbWmiBackend
+from tdp.backend import NullBackend
+from tdp.firmware_attr import FirmwareAttrBackend
+from tdp.msi_claw_a8 import MsiClawA8FirmwareBackend
+from tdp.types import TdpLimits
+
+
+LIMITS = TdpLimits(min_w=7, default_w=15, max_w=25, max_ac_w=30)
+RAILS = {
+    "pl1": "ppt_pl1_spl",
+    "pl2": "ppt_pl2_sppt",
+    "pl3": "ppt_pl3_fppt",
+}
+
+
+def _write(path, value):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as handle:
+        handle.write(str(value))
+
+
+def _read(path):
+    with open(path) as handle:
+        return handle.read().strip()
+
+
+def _legacy_path(root, rail):
+    leaf = "ppt_fppt" if rail == "pl3" else RAILS[rail]
+    return os.path.join(root, "sys/devices/platform/asus-nb-wmi", leaf)
+
+
+def _mk_asus_legacy(root, values=None):
+    values = values or {"pl1": 15, "pl2": 20, "pl3": 25}
+    for rail, value in values.items():
+        _write(_legacy_path(root, rail), value)
+
+
+def _fw_path(root, provider, rail, leaf="current_value"):
+    return os.path.join(
+        root,
+        "sys/class/firmware-attributes",
+        provider,
+        "attributes",
+        RAILS[rail],
+        leaf,
+    )
+
+
+def _mk_firmware(root, provider, values=None):
+    values = values or {"pl1": 15, "pl2": 20, "pl3": 25}
+    maximums = {"pl1": 35, "pl2": 45, "pl3": 55}
+    for rail, value in values.items():
+        _write(_fw_path(root, provider, rail), value)
+        _write(_fw_path(root, provider, rail, "min_value"), 5)
+        _write(_fw_path(root, provider, rail, "max_value"), maximums[rail])
+
+
+def _mk_profile(root, provider="amd-dptc", profile="balanced", include_custom=True):
+    base = os.path.join(root, "sys/class/platform-profile/platform-profile-0")
+    _write(os.path.join(base, "name"), provider)
+    _write(os.path.join(base, "profile"), profile)
+    choices = "low-power balanced performance"
+    if include_custom:
+        choices += " custom"
+    _write(os.path.join(base, "choices"), choices)
+    return os.path.join(base, "profile")
+
+
+def _mk_dmi(root, board_name):
+    _write(os.path.join(root, "sys/class/dmi/id/board_name"), board_name)
+
+
+def test_backend_contract_has_safe_default_release():
+    assert NullBackend("absent").release() is True
+
+
+def _anatase_asus_backend(root):
+    return FirmwareAttrBackend(
+        "asus-armoury",
+        LIMITS,
+        root=root,
+        safety_lock_path=os.path.join(root, "run/pdc/asus-transaction.lock"),
+        restore_on_release=True,
+        ownership_lock_path=os.path.join(root, "run/pdc/asus-ownership.lock"),
+    )
+
+
+def test_anatase_asus_armoury_releases_both_surfaces_exactly(tmp_path):
+    root = str(tmp_path)
+    primary = {"pl1": 15, "pl2": 20, "pl3": 25}
+    legacy = {"pl1": 5, "pl2": 5, "pl3": 5}
+    _mk_firmware(root, "asus-armoury", primary)
+    _mk_asus_legacy(root, legacy)
+    backend = _anatase_asus_backend(root)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is True
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_fw_path(root, "asus-armoury", rail)))
+        for rail in RAILS
+    } == primary
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == legacy
+
+
+def test_anatase_asus_armoury_recovers_owned_surfaces_after_restart(tmp_path):
+    root = str(tmp_path)
+    primary = {"pl1": 15, "pl2": 20, "pl3": 25}
+    legacy = {"pl1": 5, "pl2": 5, "pl3": 5}
+    _mk_firmware(root, "asus-armoury", primary)
+    _mk_asus_legacy(root, legacy)
+
+    first = _anatase_asus_backend(root)
+    assert first.set_levels(10, 12, 14, ac=True).ok is True
+
+    restarted = _anatase_asus_backend(root)
+    assert restarted.safety_locked is True
+    blocked = restarted.set_levels(11, 13, 15, ac=True)
+    assert blocked.ok is False
+    assert blocked.detail == "firmware ownership recovery pending"
+    assert restarted.recover_runtime_transaction()["ok"] is True
+    assert {
+        rail: int(_read(_fw_path(root, "asus-armoury", rail)))
+        for rail in RAILS
+    } == primary
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == legacy
+
+
+def test_anatase_asus_relinquishes_stale_ownership_without_sysfs_writes(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_firmware(root, "asus-armoury")
+    _mk_asus_legacy(root)
+    first = _anatase_asus_backend(root)
+    assert first.set_levels(10, 15, 15, ac=True).ok is True
+    hhd_values = {"pl1": 18, "pl2": 23, "pl3": 29}
+    for rail, value in hhd_values.items():
+        _write(_fw_path(root, "asus-armoury", rail), value)
+        _write(_legacy_path(root, rail), value)
+
+    restarted = _anatase_asus_backend(root)
+    monkeypatch.setattr(
+        restarted,
+        "_write",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected write")),
+    )
+
+    assert restarted.relinquish_ownership()["ok"] is True
+    assert restarted.safety_locked is False
+    assert {
+        rail: int(_read(_fw_path(root, "asus-armoury", rail)))
+        for rail in RAILS
+    } == hhd_values
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == hhd_values
+
+
+def test_anatase_asus_does_not_relinquish_ownership_during_partial_transaction(
+    tmp_path,
+):
+    root = str(tmp_path)
+    _mk_firmware(root, "asus-armoury")
+    _mk_asus_legacy(root)
+    first = _anatase_asus_backend(root)
+    assert first.set_levels(10, 15, 15, ac=True).ok is True
+    first._runtime_lock_payload = {"state": "write_pending"}
+    first._write_circuit_open = "write_pending"
+
+    result = first.relinquish_ownership()
+
+    assert result == {
+        "ok": False,
+        "detail": "firmware transaction recovery pending",
+    }
+    assert first.safety_locked is True
+
+
+def test_anatase_asus_release_drains_transaction_before_ownership(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    primary = {"pl1": 15, "pl2": 20, "pl3": 25}
+    legacy = {"pl1": 5, "pl2": 5, "pl3": 5}
+    _mk_firmware(root, "asus-armoury", primary)
+    _mk_asus_legacy(root, legacy)
+    backend = _anatase_asus_backend(root)
+    transaction_path = os.path.join(root, "run/pdc/asus-transaction.lock")
+    ownership_path = os.path.join(root, "run/pdc/asus-ownership.lock")
+    clear = backend._safety_lock.clear
+    monkeypatch.setattr(backend._safety_lock, "clear", lambda: False)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert os.path.exists(transaction_path)
+    assert os.path.exists(ownership_path)
+    monkeypatch.setattr(backend._safety_lock, "clear", clear)
+    assert backend.release() is True
+    assert not os.path.exists(transaction_path)
+    assert not os.path.exists(ownership_path)
+    assert {
+        rail: int(_read(_fw_path(root, "asus-armoury", rail)))
+        for rail in RAILS
+    } == primary
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == legacy
+
+
+def test_asus_legacy_requires_pl1_and_uses_only_present_rails(tmp_path):
+    root = str(tmp_path)
+    backend = AsusNbWmiBackend(LIMITS, root=root)
+    assert backend.supported is False
+
+    _write(_legacy_path(root, "pl1"), 15)
+    backend = AsusNbWmiBackend(LIMITS, root=root)
+
+    assert backend.supported is True
+    assert backend.supports_levels is False
+    assert backend.observe().as_dict()["surfaces"] == {
+        "asus-nb-wmi": {
+            "pl1": {"applied": 15, "min": 7, "max": 30},
+        }
+    }
+
+
+def test_asus_legacy_writes_highest_rail_first_and_releases_snapshot(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_asus_legacy(root, original)
+    backend = AsusNbWmiBackend(LIMITS, root=root)
+    writes = []
+    real_write = backend._write
+
+    def record(path, value):
+        writes.append((os.path.basename(path), value))
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_write", record)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is True
+    assert [name for name, _value in writes] == [
+        "ppt_fppt",
+        "ppt_pl2_sppt",
+        "ppt_pl1_spl",
+    ]
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_asus_legacy_recovers_owned_rails_after_restart(tmp_path):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_asus_legacy(root, original)
+    lock_path = os.path.join(root, "run/pdc/asus-legacy-ownership.lock")
+    first = AsusNbWmiBackend(LIMITS, root=root, ownership_lock_path=lock_path)
+
+    assert first.set_levels(10, 12, 14, ac=True).ok is True
+
+    restarted = AsusNbWmiBackend(
+        LIMITS,
+        root=root,
+        ownership_lock_path=lock_path,
+    )
+    assert restarted.safety_locked is True
+    assert restarted.recover_runtime_transaction()["ok"] is True
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_asus_legacy_relinquishes_stale_ownership_without_sysfs_writes(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_asus_legacy(root)
+    lock_path = os.path.join(root, "run/pdc/asus-legacy-ownership.lock")
+    first = AsusNbWmiBackend(LIMITS, root=root, ownership_lock_path=lock_path)
+    assert first.set_levels(10, 15, 15, ac=True).ok is True
+    hhd_values = {"pl1": 18, "pl2": 23, "pl3": 29}
+    for rail, value in hhd_values.items():
+        _write(_legacy_path(root, rail), value)
+
+    restarted = AsusNbWmiBackend(
+        LIMITS,
+        root=root,
+        ownership_lock_path=lock_path,
+    )
+    monkeypatch.setattr(
+        restarted,
+        "_write",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected write")),
+    )
+
+    assert restarted.relinquish_ownership()["ok"] is True
+    assert restarted.safety_locked is False
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == hhd_values
+
+
+def test_asus_legacy_rolls_back_every_rail_after_partial_failure(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_asus_legacy(root, original)
+    backend = AsusNbWmiBackend(LIMITS, root=root)
+    real_write = backend._write
+    failed = False
+
+    def fail_once(path, value):
+        nonlocal failed
+        if path == _legacy_path(root, "pl2") and not failed:
+            failed = True
+            return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_write", fail_once)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rolled back" in result.detail
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_asus_legacy_attempts_all_restores_when_one_rollback_write_fails(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_asus_legacy(root, original)
+    backend = AsusNbWmiBackend(LIMITS, root=root)
+    real_read = backend._read_int
+    real_write = backend._write
+    pl1_reads = 0
+
+    def mismatch_after_write(path):
+        nonlocal pl1_reads
+        if path == _legacy_path(root, "pl1"):
+            pl1_reads += 1
+            if pl1_reads == 2:
+                return 9
+        return real_read(path)
+
+    def fail_pl2_restore(path, value):
+        if path == _legacy_path(root, "pl2") and value == original["pl2"]:
+            return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_read_int", mismatch_after_write)
+    monkeypatch.setattr(backend, "_write", fail_pl2_restore)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rollback failed" in result.detail
+    assert _read(_legacy_path(root, "pl1")) == "15"
+    assert _read(_legacy_path(root, "pl3")) == "25"
+    writes = []
+    monkeypatch.setattr(
+        backend,
+        "_write",
+        lambda path, value: writes.append((path, value)) or real_write(path, value),
+    )
+
+    blocked = backend.set_levels(11, 13, 15, ac=True)
+
+    assert blocked.ok is False
+    assert blocked.detail == "TDP recovery pending"
+    assert writes == []
+    monkeypatch.setattr(backend, "_write", real_write)
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_legacy_path(root, rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_amd_dptc_requires_matching_profile_custom_and_pl1(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "amd-dptc")
+    without_profile = AmdDptcBackend(LIMITS, root=root)
+    assert without_profile.supported is False
+
+    _mk_profile(root, provider="amd-pmf")
+    wrong_profile = AmdDptcBackend(LIMITS, root=root)
+    assert wrong_profile.supported is False
+
+    _mk_profile(root, include_custom=False)
+    without_custom = AmdDptcBackend(LIMITS, root=root)
+    assert without_custom.supported is False
+
+    _mk_profile(root)
+    backend = AmdDptcBackend(LIMITS, root=root)
+
+    assert backend.supported is True
+    assert backend.profile_choices() == [
+        "low-power",
+        "balanced",
+        "performance",
+        "custom",
+    ]
+
+
+def test_amd_dptc_does_not_resolve_relative_attributes_without_provider(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path / "root")
+    _mk_profile(root)
+    for rail in RAILS:
+        _write(os.path.join(tmp_path, "attributes", RAILS[rail], "current_value"), 15)
+    monkeypatch.chdir(tmp_path)
+
+    backend = AmdDptcBackend(LIMITS, root=root)
+
+    assert backend.supported is False
+
+
+def test_amd_dptc_uses_live_bounds_and_restores_profile_and_rails(tmp_path):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "amd-dptc-0", original)
+    profile_path = _mk_profile(root)
+    backend = AmdDptcBackend(LIMITS, root=root)
+
+    assert backend.get_limits() == TdpLimits(7, 15, 25, 30)
+    assert backend.level_limits() == {
+        "pl1": {"min": 7, "max": 30},
+        "pl2": {"min": 7, "max": 36},
+        "pl3": {"min": 7, "max": 42},
+    }
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is True
+    assert _read(profile_path) == "custom"
+    assert backend.release() is True
+    assert _read(profile_path) == "balanced"
+    assert {
+        rail: int(_read(_fw_path(root, "amd-dptc-0", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_amd_dptc_recovers_owned_profile_and_rails_after_restart(tmp_path):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "amd-dptc", original)
+    profile_path = _mk_profile(root)
+    transaction = os.path.join(root, "run/pdc/dptc-transaction.lock")
+    ownership = os.path.join(root, "run/pdc/dptc-ownership.lock")
+    first = AmdDptcBackend(
+        LIMITS,
+        root=root,
+        safety_lock_path=transaction,
+        ownership_lock_path=ownership,
+    )
+
+    assert first.set_levels(10, 12, 14, ac=True).ok is True
+
+    restarted = AmdDptcBackend(
+        LIMITS,
+        root=root,
+        safety_lock_path=transaction,
+        ownership_lock_path=ownership,
+    )
+    assert restarted.safety_locked is True
+    assert restarted.recover_runtime_transaction()["ok"] is True
+    assert _read(profile_path) == "balanced"
+    assert {
+        rail: int(_read(_fw_path(root, "amd-dptc", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_amd_dptc_rolls_back_profile_and_rails_on_readback_mismatch(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "amd-dptc", original)
+    profile_path = _mk_profile(root)
+    backend = AmdDptcBackend(LIMITS, root=root)
+    real_read = backend._read_int
+    pl1_reads = 0
+
+    def lie_once(path):
+        nonlocal pl1_reads
+        if path == _fw_path(root, "amd-dptc", "pl1"):
+            pl1_reads += 1
+            if pl1_reads == 2:
+                return 9
+        return real_read(path)
+
+    monkeypatch.setattr(backend, "_read_int", lie_once)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rollback confirmed" in result.detail
+    assert _read(profile_path) == "balanced"
+    assert {
+        rail: int(_read(_fw_path(root, "amd-dptc", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_amd_dptc_attempts_all_restores_when_one_rollback_write_fails(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "amd-dptc", original)
+    profile_path = _mk_profile(root)
+    backend = AmdDptcBackend(LIMITS, root=root)
+    real_read = backend._read_int
+    real_write = backend._write
+    pl1_reads = 0
+
+    def mismatch_after_write(path):
+        nonlocal pl1_reads
+        if path == _fw_path(root, "amd-dptc", "pl1"):
+            pl1_reads += 1
+            if pl1_reads == 2:
+                return 9
+        return real_read(path)
+
+    def fail_pl2_restore(path, value):
+        if path == _fw_path(root, "amd-dptc", "pl2") and value == original["pl2"]:
+            return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_read_int", mismatch_after_write)
+    monkeypatch.setattr(backend, "_write", fail_pl2_restore)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rollback failed" in result.detail
+    assert _read(_fw_path(root, "amd-dptc", "pl1")) == "15"
+    assert _read(_fw_path(root, "amd-dptc", "pl3")) == "25"
+    assert _read(profile_path) == "balanced"
+    writes = []
+    monkeypatch.setattr(
+        backend,
+        "_write",
+        lambda path, value: writes.append((path, value)) or real_write(path, value),
+    )
+
+    blocked = backend.set_levels(11, 13, 15, ac=True)
+
+    assert blocked.ok is False
+    assert blocked.detail.startswith("firmware write circuit open:")
+    assert writes == []
+    monkeypatch.setattr(backend, "_write", real_write)
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_fw_path(root, "amd-dptc", rail)))
+        for rail in RAILS
+    } == original
+    assert _read(profile_path) == "balanced"
+
+
+def test_msi_a8_requires_exact_board_and_complete_native_abi(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "msi-wmi-platform")
+    _mk_dmi(root, "MS-1T42")
+    nearby = MsiClawA8FirmwareBackend(LIMITS, root=root)
+    assert nearby.supported is False
+
+    _mk_dmi(root, "MS-1T8K")
+    os.remove(_fw_path(root, "msi-wmi-platform", "pl3"))
+    partial = MsiClawA8FirmwareBackend(LIMITS, root=root)
+    assert partial.supported is False
+
+    _write(_fw_path(root, "msi-wmi-platform", "pl3"), 25)
+    exact = MsiClawA8FirmwareBackend(LIMITS, root=root)
+    assert exact.supported is True
+    assert exact.name == "msi-claw-a8-firmware"
+
+
+def test_msi_a8_transaction_releases_snapshot(tmp_path):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "msi-wmi-platform", original)
+    _mk_dmi(root, "MS-1T8K")
+    backend = MsiClawA8FirmwareBackend(LIMITS, root=root)
+
+    assert backend.set_levels(10, 12, 14, ac=True).ok is True
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_fw_path(root, "msi-wmi-platform", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_msi_a8_recovers_owned_rails_after_restart(tmp_path):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "msi-wmi-platform", original)
+    _mk_dmi(root, "MS-1T8K")
+    transaction = os.path.join(root, "run/pdc/msi-a8-transaction.lock")
+    ownership = os.path.join(root, "run/pdc/msi-a8-ownership.lock")
+    first = MsiClawA8FirmwareBackend(
+        LIMITS,
+        root=root,
+        safety_lock_path=transaction,
+        ownership_lock_path=ownership,
+    )
+
+    assert first.set_levels(10, 12, 14, ac=True).ok is True
+
+    restarted = MsiClawA8FirmwareBackend(
+        LIMITS,
+        root=root,
+        safety_lock_path=transaction,
+        ownership_lock_path=ownership,
+    )
+    assert restarted.safety_locked is True
+    assert restarted.recover_runtime_transaction()["ok"] is True
+    assert {
+        rail: int(_read(_fw_path(root, "msi-wmi-platform", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_msi_a8_uses_native_per_rail_ceilings(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "msi-wmi-platform")
+    _mk_dmi(root, "MS-1T8K")
+    backend = MsiClawA8FirmwareBackend(
+        TdpLimits(min_w=6, default_w=17, max_w=35, max_ac_w=35),
+        root=root,
+    )
+
+    assert backend.level_limits() == {
+        "pl1": {"min": 6, "max": 35},
+        "pl2": {"min": 6, "max": 37},
+        "pl3": {"min": 6, "max": 55},
+    }
+
+
+def test_msi_a8_rolls_back_after_partial_failure(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "msi-wmi-platform", original)
+    _mk_dmi(root, "MS-1T8K")
+    backend = MsiClawA8FirmwareBackend(LIMITS, root=root)
+    real_write = backend._write
+    failed = False
+
+    def fail_once(path, value):
+        nonlocal failed
+        if path == _fw_path(root, "msi-wmi-platform", "pl2") and not failed:
+            failed = True
+            return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_write", fail_once)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rollback confirmed" in result.detail
+    assert {
+        rail: int(_read(_fw_path(root, "msi-wmi-platform", rail)))
+        for rail in RAILS
+    } == original
+
+
+def test_msi_a8_attempts_all_restores_when_one_rollback_write_fails(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    original = {"pl1": 15, "pl2": 20, "pl3": 25}
+    _mk_firmware(root, "msi-wmi-platform", original)
+    _mk_dmi(root, "MS-1T8K")
+    backend = MsiClawA8FirmwareBackend(LIMITS, root=root)
+    real_read = backend._read_int
+    real_write = backend._write
+    pl1_reads = 0
+
+    def mismatch_after_write(path):
+        nonlocal pl1_reads
+        if path == _fw_path(root, "msi-wmi-platform", "pl1"):
+            pl1_reads += 1
+            if pl1_reads == 2:
+                return 9
+        return real_read(path)
+
+    def fail_pl2_restore(path, value):
+        if path == _fw_path(root, "msi-wmi-platform", "pl2") and value == original["pl2"]:
+            return False
+        return real_write(path, value)
+
+    monkeypatch.setattr(backend, "_read_int", mismatch_after_write)
+    monkeypatch.setattr(backend, "_write", fail_pl2_restore)
+
+    result = backend.set_levels(10, 12, 14, ac=True)
+
+    assert result.ok is False
+    assert "rollback failed" in result.detail
+    assert _read(_fw_path(root, "msi-wmi-platform", "pl1")) == "15"
+    assert _read(_fw_path(root, "msi-wmi-platform", "pl3")) == "25"
+    writes = []
+    monkeypatch.setattr(
+        backend,
+        "_write",
+        lambda path, value: writes.append((path, value)) or real_write(path, value),
+    )
+
+    blocked = backend.set_levels(11, 13, 15, ac=True)
+
+    assert blocked.ok is False
+    assert blocked.detail.startswith("firmware write circuit open:")
+    assert writes == []
+    monkeypatch.setattr(backend, "_write", real_write)
+    assert backend.release() is True
+    assert {
+        rail: int(_read(_fw_path(root, "msi-wmi-platform", rail)))
+        for rail in RAILS
+    } == original

--- a/tests/test_tdp_control_rpc.py
+++ b/tests/test_tdp_control_rpc.py
@@ -21,6 +21,8 @@ class FakeBackend:
 
     def __init__(self):
         self.set_levels_calls = 0
+        self.release_calls = 0
+        self.release_ok = True
         self._applied = None
 
     def get_limits(self):
@@ -36,6 +38,10 @@ class FakeBackend:
 
     def read_applied(self):
         return self._applied
+
+    def release(self):
+        self.release_calls += 1
+        return self.release_ok
 
 
 class FakeFan:
@@ -142,6 +148,187 @@ def test_conflict_reports_hhd_managing(Plugin, fake_hhd):
     }
 
 
+def _anatase_plugin(Plugin, monkeypatch):
+    import main as main_mod
+
+    monkeypatch.setattr(main_mod.osinfo, "read_os_id", lambda: "anatase")
+    monkeypatch.setattr(main_mod.osinfo, "read_os_name", lambda: "Anatase")
+    plugin = Plugin()
+    plugin._init()
+    return plugin, main_mod
+
+
+def test_anatase_selects_isolated_hhd_power_client_and_reports_platform(
+    Plugin,
+    monkeypatch,
+):
+    from pdc_platform import anatase_hhd
+
+    plugin, _main_mod = _anatase_plugin(Plugin, monkeypatch)
+
+    assert plugin._hhd_tdp_client is anatase_hhd
+    assert plugin._report_environment()["platform"] == {
+        "id": "anatase",
+        "support_tier": "first-class",
+    }
+
+
+def test_anatase_blocks_tdp_until_hhd_ownership_is_known(Plugin, monkeypatch):
+    plugin, _main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._tdp_backend.set_levels_calls = 0
+
+    result = plugin._reapply_tdp()
+
+    assert result.ok is False
+    assert result.detail == "tdp-ownership-unconfirmed"
+    assert plugin._tdp_backend.set_levels_calls == 0
+
+
+def test_anatase_hhd_owner_blocks_tdp_writes(Plugin, monkeypatch):
+    plugin, main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._controller_backend.manager = main_mod.controller_detect.HHD
+    plugin._hhd_tdp_client = FakeHHD(True)
+
+    asyncio.run(plugin._prime_tdp_ownership())
+    plugin._tdp_backend.set_levels_calls = 0
+    result = plugin._reapply_tdp()
+
+    assert plugin._tdp_external_owner is True
+    assert result.detail == "tdp-ownership-unconfirmed"
+    assert plugin._tdp_backend.set_levels_calls == 0
+
+
+def test_anatase_without_hhd_allows_direct_backend(Plugin, monkeypatch):
+    plugin, _main_mod = _anatase_plugin(Plugin, monkeypatch)
+
+    asyncio.run(plugin._prime_tdp_ownership())
+    plugin._tdp_backend.set_levels_calls = 0
+    result = plugin._reapply_tdp()
+
+    assert plugin._tdp_external_owner is False
+    assert result.ok is True
+    assert plugin._tdp_backend.set_levels_calls == 1
+
+
+def test_anatase_startup_relinquishes_stale_ownership_without_recovery_write(
+    Plugin,
+    monkeypatch,
+):
+    plugin, main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._controller_backend.manager = main_mod.controller_detect.HHD
+    plugin._hhd_tdp_client = FakeHHD(True)
+    events = []
+    backend = types.SimpleNamespace(
+        safety_locked=True,
+        recover_runtime_transaction=lambda: events.append("recover")
+        or {"ok": True, "detail": "recovered"},
+    )
+
+    def relinquish():
+        events.append("relinquish")
+        backend.safety_locked = False
+        return {"ok": True, "detail": "stale ownership relinquished"}
+
+    backend.relinquish_ownership = relinquish
+    plugin._tdp_backend = backend
+
+    async def direct(fn):
+        return fn()
+
+    plugin._offload_call = direct
+
+    assert asyncio.run(plugin._recover_tdp_startup_state()) is True
+    assert plugin._tdp_external_owner is True
+    assert events == ["relinquish"]
+
+
+def test_anatase_startup_keeps_recovery_locked_when_hhd_is_unreadable(
+    Plugin,
+    monkeypatch,
+):
+    plugin, main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._controller_backend.manager = main_mod.controller_detect.HHD
+    plugin._hhd_tdp_client = FakeHHD(None)
+    events = []
+    plugin._tdp_backend = types.SimpleNamespace(
+        safety_locked=True,
+        relinquish_ownership=lambda: events.append("relinquish"),
+        recover_runtime_transaction=lambda: events.append("recover"),
+    )
+
+    async def direct(fn):
+        return fn()
+
+    plugin._offload_call = direct
+
+    assert asyncio.run(plugin._recover_tdp_startup_state()) is False
+    assert plugin._tdp_external_owner is True
+    assert events == []
+
+
+def test_anatase_startup_recovers_when_hhd_confirms_disabled(
+    Plugin,
+    monkeypatch,
+):
+    plugin, main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._controller_backend.manager = main_mod.controller_detect.HHD
+    plugin._hhd_tdp_client = FakeHHD(False)
+    events = []
+    plugin._tdp_backend = types.SimpleNamespace(
+        safety_locked=True,
+        recover_runtime_transaction=lambda: events.append("recover")
+        or {"ok": True, "detail": "recovered"},
+    )
+
+    async def direct(fn):
+        return fn()
+
+    plugin._offload_call = direct
+
+    assert asyncio.run(plugin._recover_tdp_startup_state()) is True
+    assert plugin._tdp_external_owner is False
+    assert events == ["recover"]
+
+
+def test_non_anatase_startup_preserves_runtime_recovery(Plugin):
+    plugin = Plugin()
+    plugin._init()
+    plugin._os_id = "bazzite"
+    events = []
+    plugin._tdp_backend = types.SimpleNamespace(
+        safety_locked=True,
+        recover_runtime_transaction=lambda: events.append("recover")
+        or {"ok": True, "detail": "recovered"},
+    )
+
+    async def direct(fn):
+        return fn()
+
+    plugin._offload_call = direct
+
+    assert asyncio.run(plugin._recover_tdp_startup_state()) is True
+    assert events == ["recover"]
+
+
+def test_anatase_takeover_unlocks_tdp_only_after_hhd_confirms(
+    Plugin,
+    monkeypatch,
+):
+    plugin, main_mod = _anatase_plugin(Plugin, monkeypatch)
+    plugin._controller_backend.manager = main_mod.controller_detect.HHD
+    hhd = FakeHHD(True)
+    plugin._hhd_tdp_client = hhd
+    asyncio.run(plugin._prime_tdp_ownership())
+    plugin._tdp_backend.set_levels_calls = 0
+
+    result = asyncio.run(plugin.take_tdp_control())
+
+    assert result == {"ok": True, "hhd_managing": False}
+    assert plugin._tdp_external_owner is False
+    assert hhd.value is False
+    assert plugin._tdp_backend.set_levels_calls == 1
+
+
 def test_conflict_no_hhd_present(Plugin, fake_hhd):
     p = Plugin()
     p._init()
@@ -210,6 +397,27 @@ def test_take_restores_hhd_immediately_when_first_panel_apply_fails(Plugin, fake
     assert out["hhd_managing"] is True
     assert fake_hhd.value is True
     assert p._settings["hhd_tdp_prev"] is None
+
+
+def test_failed_take_keeps_hhd_off_until_backend_release_succeeds(Plugin, fake_hhd):
+    p = Plugin()
+    p._init()
+    p._tdp_backend.release_ok = False
+    fake_hhd.set(True)
+
+    async def failed_apply(_reason):
+        return TdpResult(20, None, False, "firmware transaction pending")
+
+    p._apply_tdp_now = failed_apply
+
+    out = asyncio.run(p.take_tdp_control())
+
+    assert out["ok"] is False
+    assert out["hhd_managing"] is False
+    assert "hardware restore pending" in out["detail"]
+    assert fake_hhd.value is False
+    assert p._settings["hhd_tdp_prev"] is True
+    assert p._tdp_backend.release_calls == 1
 
 
 def test_failed_apply_reports_hhd_restored_from_an_existing_marker(Plugin, fake_hhd):
@@ -387,6 +595,39 @@ def test_restore_noop_when_never_taken(Plugin, fake_hhd):
     p._restore_hhd_tdp()
     assert fake_hhd.value is True          # untouched — nothing to restore
     assert p._settings["hhd_tdp_prev"] is None
+
+
+def test_power_handoff_releases_backend_before_external_owners(Plugin):
+    plugin = Plugin()
+    plugin._init()
+    events = []
+    plugin._tdp_backend.release = lambda: events.append("backend") or True
+    plugin._restore_steamdeck_ppt = lambda preserve_ownership=False: (
+        events.append("steamdeck") or True
+    )
+    plugin._restore_hhd_tdp = lambda preserve_ownership=False: (
+        events.append("hhd") or True
+    )
+
+    assert plugin._restore_power_handoff() is True
+    assert events == ["backend", "steamdeck", "hhd"]
+
+
+def test_power_handoff_stops_before_hhd_if_backend_restore_fails(Plugin):
+    plugin = Plugin()
+    plugin._init()
+    external = []
+    plugin._tdp_backend.release_ok = False
+    plugin._restore_steamdeck_ppt = lambda preserve_ownership=False: (
+        external.append("steamdeck") or True
+    )
+    plugin._restore_hhd_tdp = lambda preserve_ownership=False: (
+        external.append("hhd") or True
+    )
+
+    assert plugin._restore_power_handoff() is False
+    assert plugin._tdp_backend.release_calls == 1
+    assert external == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tdp_factory_matrix.py
+++ b/tests/test_tdp_factory_matrix.py
@@ -1,0 +1,267 @@
+import os
+
+from device_profiles import DEVICE_TABLE, GENERIC
+from tdp.factory import select_backend
+
+
+def _profile(key):
+    return next(profile for profile in DEVICE_TABLE if profile.key == key)
+
+
+def _write(path, value):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as handle:
+        handle.write(str(value))
+
+
+def _mk_legacy_asus(root):
+    base = os.path.join(root, "sys/devices/platform/asus-nb-wmi")
+    for leaf, value in (
+        ("ppt_pl1_spl", 15),
+        ("ppt_pl2_sppt", 20),
+        ("ppt_fppt", 25),
+    ):
+        _write(os.path.join(base, leaf), value)
+
+
+def _mk_firmware(root, provider):
+    base = os.path.join(root, "sys/class/firmware-attributes", provider, "attributes")
+    for attr, maximum in (
+        ("ppt_pl1_spl", 35),
+        ("ppt_pl2_sppt", 45),
+        ("ppt_pl3_fppt", 55),
+    ):
+        path = os.path.join(base, attr)
+        _write(os.path.join(path, "current_value"), 15)
+        _write(os.path.join(path, "min_value"), 5)
+        _write(os.path.join(path, "max_value"), maximum)
+
+
+def _mk_dptc(root):
+    _mk_firmware(root, "amd-dptc")
+    base = os.path.join(root, "sys/class/platform-profile/platform-profile-0")
+    _write(os.path.join(base, "name"), "amd-dptc")
+    _write(os.path.join(base, "profile"), "balanced")
+    _write(
+        os.path.join(base, "choices"),
+        "low-power balanced performance custom",
+    )
+
+
+def _mk_board(root, board_name):
+    _write(os.path.join(root, "sys/class/dmi/id/board_name"), board_name)
+
+
+def _no_ryzenadj():
+    return None
+
+
+def test_rog_ally_selects_standalone_legacy_backend(tmp_path):
+    root = str(tmp_path)
+    _mk_legacy_asus(root)
+
+    backend = select_backend(
+        _profile("rog_ally"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="anatase",
+    )
+
+    assert backend.name == "asus-nb-wmi"
+    assert [item["candidate"] for item in backend.probe_trace] == [
+        "asus",
+        "asus_nb_wmi",
+    ]
+
+
+def test_rog_with_armoury_and_legacy_keeps_coordinated_backend(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "asus-armoury")
+    _mk_legacy_asus(root)
+
+    backend = select_backend(
+        _profile("rog_ally"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="anatase",
+    )
+
+    assert backend.name == "firmware-attr:asus-armoury"
+    assert [item["candidate"] for item in backend.probe_trace] == ["asus"]
+
+
+def test_known_rog_does_not_probe_dptc_or_other_vendor_firmware(tmp_path):
+    root = str(tmp_path)
+    _mk_dptc(root)
+    _mk_firmware(root, "lenovo-wmi-other")
+    _mk_firmware(root, "msi-wmi-platform")
+
+    backend = select_backend(
+        _profile("rog_ally"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="anatase",
+    )
+
+    assert backend.supported is False
+    assert [item["candidate"] for item in backend.probe_trace] == [
+        "asus",
+        "asus_nb_wmi",
+        "ryzenadj",
+        "alib",
+    ]
+
+
+def test_amd_dptc_is_first_for_supported_non_vendor_specific_families(tmp_path):
+    keys = (
+        "onexplayer_apex",
+        "aokzoe_a1x",
+        "gpd_win_mini_2025",
+        "onexplayer_f1pro",
+        "gpd_win5",
+        "gpd_win_max_2",
+    )
+    for key in keys:
+        root = str(tmp_path / key)
+        _mk_dptc(root)
+
+        backend = select_backend(
+            _profile(key),
+            root=root,
+            ryzenadj_resolve=_no_ryzenadj,
+            os_id="anatase",
+        )
+
+        assert backend.name == "amd-dptc"
+        assert [item["candidate"] for item in backend.probe_trace] == ["dptc"]
+
+
+def test_dptc_does_not_change_steam_deck_legion_msi_or_rog(tmp_path):
+    keys = (
+        "steam_deck_lcd",
+        "steam_deck_oled",
+        "rog_ally",
+        "legion_go",
+        "msi_claw_8_ai_plus",
+        "msi_claw_a8",
+    )
+    for key in keys:
+        root = str(tmp_path / key)
+        _mk_dptc(root)
+
+        backend = select_backend(
+            _profile(key),
+            root=root,
+            ryzenadj_resolve=_no_ryzenadj,
+            os_id="anatase",
+        )
+
+        assert backend.name != "amd-dptc"
+
+
+def test_msi_a8_exact_board_prefers_its_native_backend(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "msi-wmi-platform")
+    _mk_board(root, "MS-1T8K")
+
+    backend = select_backend(
+        _profile("msi_claw_a8"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="anatase",
+    )
+
+    assert backend.name == "msi-claw-a8-firmware"
+    assert [item["candidate"] for item in backend.probe_trace] == ["msi_a8"]
+
+
+def test_msi_a8_nearby_board_falls_back_without_touching_intel_chain(tmp_path):
+    root = str(tmp_path)
+    _mk_firmware(root, "msi-wmi-platform")
+    _mk_board(root, "MS-1T42")
+
+    amd_backend = select_backend(
+        _profile("msi_claw_a8"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+        os_id="anatase",
+    )
+    intel_backend = select_backend(
+        _profile("msi_claw_8_ai_plus"),
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+        os_id="anatase",
+    )
+
+    assert amd_backend.name == "ryzenadj"
+    assert [item["candidate"] for item in amd_backend.probe_trace] == [
+        "msi_a8",
+        "ryzenadj",
+    ]
+    assert intel_backend.name == "firmware-attr:msi-wmi-platform"
+    assert [item["candidate"] for item in intel_backend.probe_trace] == ["msi"]
+
+
+def test_generic_amd_prefers_complete_dptc_with_conservative_profile(tmp_path):
+    root = str(tmp_path)
+    _mk_dptc(root)
+
+    backend = select_backend(
+        GENERIC,
+        root=root,
+        ryzenadj_resolve=lambda: "/usr/bin/ryzenadj",
+        os_id="anatase",
+    )
+
+    assert backend.name == "amd-dptc"
+    assert backend.get_limits().max_ac_w == GENERIC.tdp_max_charger
+
+
+def test_non_anatase_keeps_historical_rog_fallback_chain(tmp_path):
+    root = str(tmp_path)
+    _mk_legacy_asus(root)
+    _mk_dptc(root)
+
+    backend = select_backend(
+        _profile("rog_ally"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="bazzite",
+    )
+
+    assert backend.supported is False
+    assert [item["candidate"] for item in backend.probe_trace] == [
+        "asus",
+        "lenovo",
+        "msi",
+        "ryzenadj",
+        "alib",
+    ]
+
+
+def test_gpd_win5_dptc_keeps_safe_ceiling_and_exposes_cooler_headroom(tmp_path):
+    root = str(tmp_path)
+    _mk_dptc(root)
+    base = os.path.join(
+        root,
+        "sys/class/firmware-attributes/amd-dptc/attributes",
+    )
+    _write(os.path.join(base, "ppt_pl1_spl/max_value"), 80)
+    _write(os.path.join(base, "ppt_pl2_sppt/max_value"), 90)
+    _write(os.path.join(base, "ppt_pl3_fppt/max_value"), 100)
+
+    backend = select_backend(
+        _profile("gpd_win5"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="anatase",
+    )
+
+    assert backend.get_limits().max_w == 55
+    assert backend.get_limits().max_ac_w == 55
+    assert backend.level_limits() == {
+        "pl1": {"min": 5, "max": 75},
+        "pl2": {"min": 5, "max": 90},
+        "pl3": {"min": 5, "max": 100},
+    }
+    assert backend.cap_boost_to_active is True

--- a/tests/test_tdp_guard_rpc.py
+++ b/tests/test_tdp_guard_rpc.py
@@ -171,6 +171,21 @@ def test_stale_generation_never_writes(plugin):
     assert result.detail == "stale-generation"
 
 
+def test_anatase_external_owner_blocks_guard_correction(plugin):
+    plugin._os_id = "anatase"
+    plugin._tdp_external_owner = True
+    plugin._tdp_profiles.set_pl1("global", 25)
+    plugin._tdp_backend.set_levels_calls = 0
+
+    plugin._tdp_guard_tick(now=10.0)
+    plugin._tdp_guard_tick(now=10.75)
+
+    assert plugin._tdp_backend.set_levels_calls == 0
+    assert plugin._tdp_targets is None
+    assert plugin._tdp_status == "unverifiable"
+    assert plugin._tdp_reason == "external_owner"
+
+
 def test_command_preserves_requested_but_applies_live_target(plugin):
     plugin._tdp_profiles.set_pl1("global", 25)
     plugin._tdp_backend.live_max = 15

--- a/tests/test_tdp_rpc.py
+++ b/tests/test_tdp_rpc.py
@@ -501,11 +501,29 @@ def test_cooler_boost_raises_ceiling_on_win5(Plugin):
     p = Plugin()
     p._init()
     p._device = detect(product_name="G1618-05")  # gpd_win5, cooler_max=75
-    assert p._limits().max_w == 20 and p._limits().max_ac_w == 60  # cooler off
+    p._tdp_backend.get_limits = lambda: TdpLimits(5, 25, 55, 55)
+    p._tdp_backend.level_limits = lambda: {
+        "pl1": {"min": 5, "max": 75},
+        "pl2": {"min": 5, "max": 75},
+        "pl3": {"min": 5, "max": 75},
+    }
+    p._tdp_backend.cap_boost_to_active = True
+
+    assert p._limits().max_w == 55 and p._limits().max_ac_w == 55
+    assert asyncio.run(p.get_tdp_state())["level_limits"] == {
+        "pl1": {"min": 5, "max": 55},
+        "pl2": {"min": 5, "max": 55},
+        "pl3": {"min": 5, "max": 55},
+    }
     asyncio.run(p.set_cooler_boost(True))
     assert p._limits().max_w == 75 and p._limits().max_ac_w == 75  # cooler on
+    assert asyncio.run(p.get_tdp_state())["level_limits"] == {
+        "pl1": {"min": 5, "max": 75},
+        "pl2": {"min": 5, "max": 75},
+        "pl3": {"min": 5, "max": 75},
+    }
     asyncio.run(p.set_cooler_boost(False))
-    assert p._limits().max_w == 20
+    assert p._limits().max_w == 55
 
 
 def test_cooler_boost_ignored_when_device_has_no_cooler(Plugin):


### PR DESCRIPTION
## What does this change?

- Treats Anatase as a first-class platform with an isolated HHD handoff adapter.
- Adds Anatase-only backend selection for ASUS firmware attributes/legacy WMI, AMD DPTC and MSI Claw A8 while preserving the existing SteamOS, Bazzite and CachyOS routes.
- Makes TDP ownership transactional and restart-safe: Panel de Control never writes while HHD owns the rails, restores both ASUS surfaces exactly on release, and fails closed when ownership cannot be confirmed.
- Adds backend, routing, handoff, guard and restart-recovery regression coverage.

AMD DPTC and MSI Claw A8 routing are capability-tested but not yet hardware-verified.

## How was it tested?

- ROG Ally RC71L, Anatase, kernel 7.0.12:
  - exercised the upgrade path from the installed Panel de Control 0.38.0 build and reloaded the final candidate;
  - completed HHD → Panel de Control → 10 W → HHD from the Decky QAM;
  - confirmed PL1/PL2/PL3 on both `asus-armoury` and `asus-nb-wmi`;
  - confirmed exact restoration, loader restart and stale-ownership recovery without sysfs writes.
- `python -m pytest`: 2695 passed, 1 skipped.
- `pnpm test:fe`: 1016 passed.
- `ruff check .`, `pnpm typecheck`, `pnpm build` and `git diff --check` pass.

## Checklist

- [x] The commit messages follow Conventional Commits.
- [x] Frontend and Python checks pass.
- [x] No secrets, tokens or personal data are included.
- [x] No new third-party dependencies were added.
