### PR TITLE
fix: recover from unusable TDP routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
           filters: |
             backend:
               - ".github/workflows/ci.yml"
+              - ".github/workflows/release-please.yml"
               - "main.py"
               - "py_modules/**"
+              - "scripts/*.py"
+              - "scripts/**/*.py"
               - "tests/*.py"
               - "tests/**/*.py"
               - "conftest.py"
@@ -50,10 +53,13 @@ jobs:
               - "CHANGELOG.md"
             frontend:
               - ".github/workflows/ci.yml"
+              - ".github/workflows/prerelease.yml"
               - "src/**"
               - "tests/*.ts"
               - "tests/**/*.ts"
-              - "scripts/**"
+              - "scripts/*.mjs"
+              - "scripts/**/*.mjs"
+              - "scripts/sync-plugin-payload.sh"
               - "shared/**"
               - "package.json"
               - "pnpm-lock.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
 
 # Least privilege: CI only reads the repo. No job here writes anything, and a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      decky: ${{ steps.filter.outputs.decky }}
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -32,14 +33,33 @@ jobs:
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
-          predicate-quantifier: every
           filters: |
-            decky:
-              - "**"
-              - "!opengamepadui/**"
-              - "!.github/workflows/opengamepadui-ci.yml"
-              - "!windows/**"
-              - "!.github/workflows/windows-ci.yml"
+            backend:
+              - ".github/workflows/ci.yml"
+              - "main.py"
+              - "py_modules/**"
+              - "tests/*.py"
+              - "tests/**/*.py"
+              - "conftest.py"
+              - "requirements-dev.txt"
+              - "ruff.toml"
+              - "shared/**"
+              - "plugin.json"
+              - ".release-please-manifest.json"
+              - "release-please-config.json"
+              - "CHANGELOG.md"
+            frontend:
+              - ".github/workflows/ci.yml"
+              - "src/**"
+              - "tests/*.ts"
+              - "tests/**/*.ts"
+              - "scripts/**"
+              - "shared/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "rollup.config.js"
+              - "tsconfig.json"
+              - "vitest.config.ts"
 
   backend-tests:
     needs: changes
@@ -49,28 +69,28 @@ jobs:
       - name: Require successful path classification
         if: >-
           needs.changes.result != 'success' ||
-          (needs.changes.outputs.decky != 'true' &&
-          needs.changes.outputs.decky != 'false')
+          (needs.changes.outputs.backend != 'true' &&
+          needs.changes.outputs.backend != 'false')
         run: |
-          echo "::error::Decky path classification failed or returned an invalid output"
+          echo "::error::Backend path classification failed or returned an invalid output"
           exit 1
-      - name: Decky paths unchanged
-        if: needs.changes.outputs.decky == 'false'
-        run: echo "Decky backend tests not required for these paths"
+      - name: Backend paths unchanged
+        if: needs.changes.outputs.backend == 'false'
+        run: echo "Backend tests not required for these paths"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.backend == 'true'
         with:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.backend == 'true'
         with:
           python-version: "3.11"
-      - if: needs.changes.outputs.decky == 'true'
+      - if: needs.changes.outputs.backend == 'true'
         run: pip install -r requirements-dev.txt
-      - if: needs.changes.outputs.decky == 'true'
+      - if: needs.changes.outputs.backend == 'true'
         run: ruff check py_modules main.py tests
-      - if: needs.changes.outputs.decky == 'true'
-        run: python -m pytest -v
+      - if: needs.changes.outputs.backend == 'true'
+        run: python -m pytest -q
 
   frontend-build:
     needs: changes
@@ -80,41 +100,38 @@ jobs:
       - name: Require successful path classification
         if: >-
           needs.changes.result != 'success' ||
-          (needs.changes.outputs.decky != 'true' &&
-          needs.changes.outputs.decky != 'false')
+          (needs.changes.outputs.frontend != 'true' &&
+          needs.changes.outputs.frontend != 'false')
         run: |
-          echo "::error::Decky path classification failed or returned an invalid output"
+          echo "::error::Frontend path classification failed or returned an invalid output"
           exit 1
-      - name: Decky paths unchanged
-        if: needs.changes.outputs.decky == 'false'
-        run: echo "Decky frontend build not required for these paths"
+      - name: Frontend paths unchanged
+        if: needs.changes.outputs.frontend == 'false'
+        run: echo "Frontend build not required for these paths"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         with:
           version: 10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: 20
           cache: pnpm
-      - if: needs.changes.outputs.decky == 'true'
+      - if: needs.changes.outputs.frontend == 'true'
         run: pnpm install --frozen-lockfile
       - name: Type-check the frontend
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm typecheck
-      - name: Validate translation content and terminology
-        if: needs.changes.outputs.decky == 'true'
-        run: pnpm test:i18n
       - name: Run the frontend test suite
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm test:fe
       - name: Build the frontend
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm build
       - name: Verify build output exists
-        if: needs.changes.outputs.decky == 'true'
+        if: needs.changes.outputs.frontend == 'true'
         run: test -f dist/index.js

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ import theme_transport
 from version import read_version
 from settings_store import SettingsStore
 from tdp import factory as tdp_factory
+from tdp.backend import NullBackend
 from tdp import powerstation as powerstation_conflict
 from tdp import suggest as tdp_suggest
 from tdp.reconcile import (
@@ -145,6 +146,7 @@ _monotonic = time.monotonic
 _HUD_OBSERVATION_MAX_AGE_S = 3.0
 _MIN_HUD_REFRESH_S = 1.0
 _HUD_RELOAD_MAX_ATTEMPTS = 4
+_TDP_BACKEND_REPROBE_S = 30.0
 _CHARGE_LIMIT_VERIFY_DELAYS = (2.0, 8.0, 20.0)
 _ROG_CHARGE_LIMIT_PROFILES = frozenset({
     "rog_ally",
@@ -175,6 +177,7 @@ _THEME_ACTIVATION_RECOVERY_FILE = "theme-activation-recovery.json"
 @dataclass(frozen=True)
 class _TdpCommand:
     generation: int
+    backend: object
     reason: str
     logical_requested: dict
     requested: dict
@@ -649,6 +652,10 @@ class Plugin:
             "settling" if self._tdp_supported() else "unsupported"
         )
         self._tdp_reason = ""
+        self._tdp_reprobe_at = 0.0
+        self._tdp_probe_lock = asyncio.Lock()
+        self._tdp_backend_used = False
+        self._tdp_backend_history = deque(maxlen=8)
         self._tdp_conflict_persistent = False
         self._tdp_history = deque(maxlen=32)
         self._tdp_guard_task = None
@@ -2311,6 +2318,23 @@ class Plugin:
             self._restore_hhd_tdp_status(preserve_ownership).get("ok")
         )
 
+    def _restore_hhd_after_tdp_route_loss(self):
+        if self._settings.get("hhd_tdp_prev") is None:
+            return None
+        previous = self._settings.get("tdp_control_enabled", True)
+        self._settings["tdp_control_enabled"] = False
+        try:
+            self._save()
+        except Exception as error:  # noqa: BLE001
+            self._settings["tdp_control_enabled"] = previous
+            return {
+                "ok": False,
+                "hardware_ok": False,
+                "marker_cleared": False,
+                "error": type(error).__name__,
+            }
+        return self._restore_hhd_tdp_status()
+
     async def get_tdp_control_enabled(self) -> bool:
         self._init()
         await self._ensure_recognised_desktop_migration()
@@ -3737,6 +3761,7 @@ class Plugin:
         return out
 
     def _capture_tdp_command(self, reason, on_ac=None, bump=True):
+        backend = self._tdp_backend
         ac = read_on_ac() if on_ac is None else bool(on_ac)
         limits = self._limits()
         active = self._active_max(limits, ac)
@@ -3750,13 +3775,13 @@ class Plugin:
                 "mode": "estable",
             }
         select_levels = getattr(
-            self._tdp_backend,
+            backend,
             "physical_levels",
             None,
         )
         if callable(select_levels):
             requested = select_levels(logical_requested)
-        elif getattr(self._tdp_backend, "supports_levels", False):
+        elif getattr(backend, "supports_levels", False):
             requested = {
                 rail: int(logical_requested[rail])
                 for rail in ("pl1", "pl2", "pl3")
@@ -3764,7 +3789,7 @@ class Plugin:
         else:
             requested = {"pl1": int(logical_requested["pl1"])}
         safe = self._cap_level_limits(
-            self._tdp_backend.level_limits(),
+            backend.level_limits(),
             active,
         )
         for rail in requested:
@@ -3776,6 +3801,7 @@ class Plugin:
             self._advance_tdp_generation()
         return _TdpCommand(
             generation=self._tdp_generation,
+            backend=backend,
             reason=str(reason),
             logical_requested={
                 rail: int(logical_requested[rail])
@@ -3786,7 +3812,7 @@ class Plugin:
                 for rail in requested
             },
             safe_bounds=safe,
-            primary_rail=getattr(self._tdp_backend, "primary_rail", "pl1"),
+            primary_rail=getattr(backend, "primary_rail", "pl1"),
             on_ac=ac,
         )
 
@@ -3814,6 +3840,7 @@ class Plugin:
         return observation
 
     def _apply_tdp_targets(self, target, on_ac):
+        self._tdp_backend_used = True
         apply_targets = getattr(self._tdp_backend, "apply_targets", None)
         if callable(apply_targets):
             return apply_targets(target, on_ac)
@@ -3841,6 +3868,13 @@ class Plugin:
                 None,
                 False,
                 "stale-generation",
+            )
+        if command.backend is not self._tdp_backend:
+            return TdpResult(
+                logical_watts,
+                None,
+                False,
+                "stale-backend",
             )
         if not self._tdp_supported():
             self._tdp_status, self._tdp_reason = "unsupported", ""
@@ -3888,6 +3922,7 @@ class Plugin:
             return result
         mode = self._firmware_mode()
         if mode != _CUSTOM_MODE:
+            self._tdp_backend_used = True
             if not self._tdp_backend.set_profile(mode):
                 self._tdp_status = "rejected"
                 self._tdp_reason = "firmware_mode_rejected"
@@ -4145,9 +4180,12 @@ class Plugin:
         )
 
     def _tdp_guard_delay(self):
+        if not self._tdp_backend.supported:
+            return _TDP_BACKEND_REPROBE_S
         now = time.monotonic()
-        interval = float(
-            getattr(self._tdp_backend, "guard_interval_s", 2.0)
+        interval = max(
+            0.05,
+            float(getattr(self._tdp_backend, "guard_interval_s", 2.0)),
         )
         due = []
         memory = self._tdp_reconcile_memory
@@ -4172,17 +4210,23 @@ class Plugin:
         while True:
             try:
                 await asyncio.sleep(self._tdp_guard_delay())
+                if not self._tdp_backend.supported:
+                    await self._probe_tdp_backend()
+                    continue
                 await self._offload_call(self._tdp_guard_tick)
+                if not self._tdp_supported():
+                    await self._probe_tdp_backend()
             except asyncio.CancelledError:
                 return
             except Exception:
                 decky.logger.exception("TDP guard tick failed")
 
     def _start_tdp_guard_loop(self):
+        lifecycle = getattr(self, "_lifecycle", None)
         if (
             self._tdp_shutdown
-            or not self._tdp_backend.supported
             or self._tdp_guard_task is not None
+            or getattr(lifecycle, "_task", None) is None
         ):
             return
         self._tdp_guard_task = asyncio.create_task(
@@ -7377,6 +7421,7 @@ class Plugin:
             "generation": self._tdp_generation,
             "backend": self._tdp_backend.name,
             "backend_descriptor": self._tdp_backend_diagnostics(),
+            "backend_history": list(self._tdp_backend_history),
             "desktop_recognition_migration": {
                 "pending": bool(
                     getattr(self, "_desktop_recognition_migration_pending", False)
@@ -7398,17 +7443,260 @@ class Plugin:
             },
         }
 
-    async def _probe_tdp_backend(self, *, force: bool = False) -> bool:
-        probe = getattr(self._tdp_backend, "probe", None)
+    @staticmethod
+    def _probe_tdp_candidate(candidate) -> dict:
+        probe = getattr(candidate, "probe", None)
         if not callable(probe):
-            return bool(self._tdp_backend.supported)
-        if not force and not getattr(self._tdp_backend, "probe_pending", True):
-            return bool(self._tdp_backend.supported)
-        ready = bool(await self._offload_call(probe))
-        if not ready:
+            return {"ready": bool(candidate.supported), "error": None}
+        try:
+            return {"ready": bool(probe()), "error": None}
+        except Exception as error:  # noqa: BLE001
+            decky.logger.warning(
+                "TDP backend probe failed (%s): %s",
+                candidate.name,
+                type(error).__name__,
+            )
+            return {"ready": False, "error": type(error).__name__}
+
+    def _record_tdp_backend_transition(
+        self,
+        previous,
+        probe,
+        release,
+        replacement,
+        replacement_probe,
+        outcome,
+        handoff=None,
+    ) -> None:
+        event = {
+            "at": round(time.monotonic(), 3),
+            "previous": previous.name,
+            "probe": dict(probe),
+            "release": release,
+            "selected": replacement.name if replacement is not None else None,
+            "selection_trace": [
+                dict(item)
+                for item in getattr(replacement, "probe_trace", ())
+            ],
+            "replacement_probe": replacement_probe,
+            "outcome": outcome,
+            "handoff": handoff,
+        }
+        self._tdp_backend_history.append(event)
+        log = decky.logger.info if outcome == "reselected" else decky.logger.warning
+        log(
+            "TDP backend transition %s",
+            json.dumps(event, sort_keys=True, separators=(",", ":")),
+        )
+
+    def _replace_unviable_tdp_backend(self, previous, probe) -> bool:
+        if getattr(previous, "safety_locked", False):
+            recovered = self._recover_tdp_backend_if_owned()
+            if recovered:
+                retry = self._probe_tdp_candidate(previous)
+                if retry["ready"]:
+                    self._tdp_status = "settling"
+                    self._tdp_reason = ""
+                    self._record_tdp_backend_transition(
+                        previous,
+                        retry,
+                        None,
+                        previous,
+                        retry,
+                        "recovered",
+                    )
+                    return True
             self._tdp_status = "unsupported"
-            self._tdp_reason = "readback_unavailable"
+            self._tdp_reason = "recovery_pending"
+            self._record_tdp_backend_transition(
+                previous, probe, None, None, None, "recovery_pending"
+            )
+            return False
+        selection_ready = getattr(previous, "selection_ready", None)
+        if callable(selection_ready):
+            try:
+                route_viable = bool(selection_ready())
+            except Exception as error:  # noqa: BLE001
+                route_viable = False
+                decky.logger.warning(
+                    "TDP route viability check failed (%s): %s",
+                    previous.name,
+                    type(error).__name__,
+                )
+            if route_viable:
+                self._tdp_status = "unsupported"
+                self._tdp_reason = "temporarily_unready"
+                self._record_tdp_backend_transition(
+                    previous,
+                    probe,
+                    None,
+                    None,
+                    None,
+                    "temporarily_unready",
+                )
+                return False
+        if self._tdp_backend_used and not getattr(
+            previous,
+            "reselection_safe_after_use",
+            False,
+        ):
+            self._tdp_status = "unsupported"
+            self._tdp_reason = "backend_in_use"
+            handoff = self._restore_hhd_after_tdp_route_loss()
+            if handoff is not None and not handoff.get("ok"):
+                self._tdp_status = "rejected"
+                self._tdp_reason = "handoff_failed"
+            self._record_tdp_backend_transition(
+                previous,
+                probe,
+                None,
+                None,
+                None,
+                "backend_in_use",
+                handoff,
+            )
+            return False
+        if not self._desktop_power.can_replace_cpu_backend():
+            self._tdp_status = "unverifiable"
+            self._tdp_reason = "desktop_power_owned"
+            self._record_tdp_backend_transition(
+                previous, probe, None, None, None, "desktop_power_owned"
+            )
+            return False
+        release = getattr(previous, "release", None)
+        released = True
+        release_error = None
+        if callable(release):
+            try:
+                released = bool(release())
+            except Exception as error:  # noqa: BLE001
+                released = False
+                release_error = type(error).__name__
+                decky.logger.warning(
+                    "TDP backend release failed (%s): %s",
+                    previous.name,
+                    release_error,
+                )
+        release_result = {"ok": released}
+        if release_error is not None:
+            release_result["error"] = release_error
+        if not released:
+            self._tdp_status = "rejected"
+            self._tdp_reason = "release_failed"
+            self._record_tdp_backend_transition(
+                previous,
+                probe,
+                release_result,
+                None,
+                None,
+                "release_failed",
+            )
+            return False
+        self._tdp_backend_used = False
+        self._advance_tdp_generation()
+        self._tdp_targets = None
+        self._tdp_observation = TdpObservation(
+            readable=bool(getattr(previous, "readback", True)),
+        )
+        self._tdp_observation_at = float("-inf")
+        self._tdp_conflict_persistent = False
+        selection_error = None
+        try:
+            replacement = tdp_factory.select_backend(
+                self._device,
+                os_id=self._os_id,
+            )
+        except Exception as error:  # noqa: BLE001
+            selection_error = type(error).__name__
+            decky.logger.warning(
+                "TDP backend selection failed: %s",
+                selection_error,
+            )
+            replacement = NullBackend("backend selection failed")
+            replacement.probe_trace = ({
+                "candidate": "factory",
+                "backend": None,
+                "supported": False,
+                "error": selection_error,
+            },)
+        self._desktop_power.replace_cpu_backend(replacement)
+        self._tdp_backend = replacement
+        self._tdp_observation = TdpObservation(
+            readable=bool(getattr(replacement, "readback", True)),
+        )
+        self._tdp_observation_at = float("-inf")
+        self._tdp_conflict_persistent = False
+        if not self._recover_tdp_backend_if_owned():
+            self._tdp_status = "unsupported"
+            self._tdp_reason = "recovery_pending"
+            self._record_tdp_backend_transition(
+                previous,
+                probe,
+                release_result,
+                replacement,
+                None,
+                "recovery_pending",
+            )
+            return False
+        replacement_probe = self._probe_tdp_candidate(replacement)
+        ready = replacement_probe["ready"]
+        if ready:
+            self._tdp_status = "settling"
+            self._tdp_reason = ""
+            outcome = "reselected"
+        else:
+            self._tdp_status = "unsupported"
+            if selection_error is not None:
+                self._tdp_reason = "selection_failed"
+                outcome = "selection_failed"
+            else:
+                self._tdp_reason = "readback_unavailable"
+                outcome = "replacement_unready"
+        handoff = None if ready else self._restore_hhd_after_tdp_route_loss()
+        if handoff is not None and not handoff.get("ok"):
+            self._tdp_status = "rejected"
+            self._tdp_reason = "handoff_failed"
+        self._record_tdp_backend_transition(
+            previous,
+            probe,
+            release_result,
+            replacement,
+            replacement_probe,
+            outcome,
+            handoff,
+        )
         return ready
+
+    async def _probe_tdp_backend(self, *, force: bool = False) -> bool:
+        async with self._tdp_probe_lock:
+            backend = self._tdp_backend
+            now = _monotonic()
+            if not force and now < self._tdp_reprobe_at:
+                return False
+            probe = getattr(backend, "probe", None)
+            if (
+                callable(probe)
+                and not force
+                and not getattr(backend, "probe_pending", True)
+            ):
+                return bool(backend.supported)
+            probe_result = await self._offload_call(
+                lambda: self._probe_tdp_candidate(backend)
+            )
+            if probe_result["ready"]:
+                self._tdp_reprobe_at = 0.0
+                return True
+            ready = bool(await self._offload_call(
+                lambda: self._replace_unviable_tdp_backend(
+                    backend,
+                    probe_result,
+                )
+            ))
+            self._tdp_reprobe_at = (
+                0.0 if ready else now + _TDP_BACKEND_REPROBE_S
+            )
+            self._start_tdp_guard_loop()
+            return ready
 
     def _tdp_delayed_recovery_pending(self) -> bool:
         return bool(
@@ -7451,6 +7739,13 @@ class Plugin:
         detail = result.get("detail") if isinstance(result, dict) else "invalid response"
         log("Interrupted TDP transaction recovery: %s", detail)
         return ok
+
+    def _recover_tdp_backend_if_owned(self) -> bool:
+        if not getattr(self._tdp_backend, "safety_locked", False):
+            return True
+        if not self._tdp_write_authorized():
+            return False
+        return self._recover_tdp_runtime_transaction()
 
     def _tdp_supported(self) -> bool:
         if not self._tdp_backend.supported:

--- a/opengamepadui/tests/test_package.py
+++ b/opengamepadui/tests/test_package.py
@@ -133,15 +133,6 @@ def _matches(path: str, patterns: list[str]) -> bool:
     return False
 
 
-def _matches_every(path: str, patterns: list[str]) -> bool:
-    return all(
-        not _matches(path, [pattern[1:]])
-        if pattern.startswith("!")
-        else _matches(path, [pattern])
-        for pattern in patterns
-    )
-
-
 class ConfigureExportTests(unittest.TestCase):
     def test_adds_limited_linux_preset_without_changing_existing_preset(self) -> None:
         existing = """[preset.0]
@@ -724,23 +715,49 @@ class BuildContractTests(unittest.TestCase):
 
 
 class WorkflowIsolationTests(unittest.TestCase):
-    def test_decky_classifier_routes_platform_and_mixed_changes(self) -> None:
+    def test_decky_classifier_routes_product_surfaces_and_platform_changes(
+        self,
+    ) -> None:
         decky = DECKY_WORKFLOW.read_text(encoding="utf-8")
         ogui = OGUI_WORKFLOW.read_text(encoding="utf-8")
         windows = WINDOWS_WORKFLOW.read_text(encoding="utf-8")
-        decky_paths = _filter_paths(decky, "decky")
+        backend_paths = _filter_paths(decky, "backend")
+        frontend_paths = _filter_paths(decky, "frontend")
 
         self.assertEqual(
-            decky_paths,
+            backend_paths,
             [
-                "**",
-                "!opengamepadui/**",
-                "!.github/workflows/opengamepadui-ci.yml",
-                "!windows/**",
-                "!.github/workflows/windows-ci.yml",
+                ".github/workflows/ci.yml",
+                "main.py",
+                "py_modules/**",
+                "tests/*.py",
+                "tests/**/*.py",
+                "conftest.py",
+                "requirements-dev.txt",
+                "ruff.toml",
+                "shared/**",
+                "plugin.json",
+                ".release-please-manifest.json",
+                "release-please-config.json",
+                "CHANGELOG.md",
             ],
         )
-        self.assertIn("predicate-quantifier: every", decky)
+        self.assertEqual(
+            frontend_paths,
+            [
+                ".github/workflows/ci.yml",
+                "src/**",
+                "tests/*.ts",
+                "tests/**/*.ts",
+                "scripts/**",
+                "shared/**",
+                "package.json",
+                "pnpm-lock.yaml",
+                "rollup.config.js",
+                "tsconfig.json",
+                "vitest.config.ts",
+            ],
+        )
 
         for event in ("push", "pull_request"):
             ogui_paths = _event_paths(ogui, event)
@@ -766,29 +783,32 @@ class WorkflowIsolationTests(unittest.TestCase):
         )
 
         cases = (
-            (["opengamepadui/plugin.gd"], False),
-            (["opengamepadui/plugin.json"], False),
-            ([".github/workflows/opengamepadui-ci.yml"], False),
-            (["windows/PanelDeControl.sln"], False),
-            ([".github/workflows/windows-ci.yml"], False),
-            (["src/index.tsx"], True),
-            (["opengamepadui/plugin.gd", "src/index.tsx"], True),
-            (["windows/PanelDeControl.sln", "src/index.tsx"], True),
-            (["shared/fixtures/auto_tdp.json"], True),
-            (["conftest.py"], True),
-            (["plugin.json"], True),
-            (["release-please-config.json"], True),
-            ([".github/workflows/release-please.yml"], True),
-            ([".github/workflows/prerelease.yml"], True),
-            (["README.md"], True),
-            (["future-root-config.toml"], True),
-            ([".github/workflows/ci.yml"], True),
+            (["opengamepadui/plugin.gd"], False, False),
+            (["windows/PanelDeControl.sln"], False, False),
+            (["main.py"], True, False),
+            (["py_modules/tdp/factory.py"], True, False),
+            (["tests/test_tdp_factory.py"], True, False),
+            (["src/index.tsx"], False, True),
+            (["tests/pluginPayload.test.ts"], False, True),
+            (["scripts/copy-plugin-payload.mjs"], False, True),
+            (["opengamepadui/plugin.gd", "src/index.tsx"], False, True),
+            (["windows/PanelDeControl.sln", "main.py"], True, False),
+            (["shared/fixtures/auto_tdp.json"], True, True),
+            (["plugin.json"], True, False),
+            (["release-please-config.json"], True, False),
+            (["README.md"], False, False),
+            (["future-root-config.toml"], False, False),
+            ([".github/workflows/ci.yml"], True, True),
         )
-        for changed_paths, expected_decky in cases:
+        for changed_paths, expected_backend, expected_frontend in cases:
             with self.subTest(changed_paths=changed_paths):
                 self.assertEqual(
-                    any(_matches_every(path, decky_paths) for path in changed_paths),
-                    expected_decky,
+                    any(_matches(path, backend_paths) for path in changed_paths),
+                    expected_backend,
+                )
+                self.assertEqual(
+                    any(_matches(path, frontend_paths) for path in changed_paths),
+                    expected_frontend,
                 )
 
     def test_decky_required_jobs_report_without_running_expensive_ogui_steps(
@@ -797,9 +817,13 @@ class WorkflowIsolationTests(unittest.TestCase):
         workflow = DECKY_WORKFLOW.read_text(encoding="utf-8")
 
         changes = _job_body(workflow, "changes")
-        self.assertIn("decky: ${{ steps.filter.outputs.decky }}", changes)
+        self.assertIn("backend: ${{ steps.filter.outputs.backend }}", changes)
+        self.assertIn("frontend: ${{ steps.filter.outputs.frontend }}", changes)
 
-        for job_name in ("backend-tests", "frontend-build"):
+        for job_name, output in (
+            ("backend-tests", "backend"),
+            ("frontend-build", "frontend"),
+        ):
             job = _job_body(workflow, job_name)
             header = job.split("steps:", maxsplit=1)[0]
             self.assertIn("needs: changes", header)
@@ -811,30 +835,30 @@ class WorkflowIsolationTests(unittest.TestCase):
                 for step in steps
                 if "Require successful path classification" in step
             ]
-            skipped = [step for step in steps if "Decky paths unchanged" in step]
+            skipped = [step for step in steps if "paths unchanged" in step]
             expensive = [
                 step for step in steps if step not in guards and step not in skipped
             ]
             self.assertEqual(len(guards), 1)
             self.assertIn("needs.changes.result != 'success'", guards[0])
             self.assertIn(
-                "needs.changes.outputs.decky != 'true'",
+                f"needs.changes.outputs.{output} != 'true'",
                 guards[0],
             )
             self.assertIn(
-                "needs.changes.outputs.decky != 'false'",
+                f"needs.changes.outputs.{output} != 'false'",
                 guards[0],
             )
             self.assertRegex(guards[0], r"(?m)^\s*exit 1$")
             self.assertEqual(len(skipped), 1)
             self.assertIn(
-                "if: needs.changes.outputs.decky == 'false'",
+                f"if: needs.changes.outputs.{output} == 'false'",
                 skipped[0],
             )
             self.assertGreater(len(expensive), 0)
             for step in expensive:
                 self.assertIn(
-                    "if: needs.changes.outputs.decky == 'true'",
+                    f"if: needs.changes.outputs.{output} == 'true'",
                     step,
                 )
 

--- a/opengamepadui/tests/test_package.py
+++ b/opengamepadui/tests/test_package.py
@@ -728,8 +728,11 @@ class WorkflowIsolationTests(unittest.TestCase):
             backend_paths,
             [
                 ".github/workflows/ci.yml",
+                ".github/workflows/release-please.yml",
                 "main.py",
                 "py_modules/**",
+                "scripts/*.py",
+                "scripts/**/*.py",
                 "tests/*.py",
                 "tests/**/*.py",
                 "conftest.py",
@@ -746,10 +749,13 @@ class WorkflowIsolationTests(unittest.TestCase):
             frontend_paths,
             [
                 ".github/workflows/ci.yml",
+                ".github/workflows/prerelease.yml",
                 "src/**",
                 "tests/*.ts",
                 "tests/**/*.ts",
-                "scripts/**",
+                "scripts/*.mjs",
+                "scripts/**/*.mjs",
+                "scripts/sync-plugin-payload.sh",
                 "shared/**",
                 "package.json",
                 "pnpm-lock.yaml",
@@ -791,6 +797,8 @@ class WorkflowIsolationTests(unittest.TestCase):
             (["src/index.tsx"], False, True),
             (["tests/pluginPayload.test.ts"], False, True),
             (["scripts/copy-plugin-payload.mjs"], False, True),
+            (["scripts/sync-plugin-payload.sh"], False, True),
+            (["scripts/release_guard.py"], True, False),
             (["opengamepadui/plugin.gd", "src/index.tsx"], False, True),
             (["windows/PanelDeControl.sln", "main.py"], True, False),
             (["shared/fixtures/auto_tdp.json"], True, True),
@@ -799,6 +807,8 @@ class WorkflowIsolationTests(unittest.TestCase):
             (["README.md"], False, False),
             (["future-root-config.toml"], False, False),
             ([".github/workflows/ci.yml"], True, True),
+            ([".github/workflows/release-please.yml"], True, False),
+            ([".github/workflows/prerelease.yml"], False, True),
         )
         for changed_paths, expected_backend, expected_frontend in cases:
             with self.subTest(changed_paths=changed_paths):

--- a/opengamepadui/tests/test_package.py
+++ b/opengamepadui/tests/test_package.py
@@ -782,6 +782,8 @@ class WorkflowIsolationTests(unittest.TestCase):
                 _matches(".github/workflows/windows-ci.yml", windows_paths)
             )
 
+        self.assertIn("branches: [main]", _event_body(decky, "push"))
+
         self.assertRegex(
             windows,
             r"python -m unittest\s+"

--- a/py_modules/desktop/power.py
+++ b/py_modules/desktop/power.py
@@ -56,6 +56,15 @@ class DesktopPowerCoordinator:
         self._mode = "free"
         self._load_persisted_state(persisted_state)
 
+    def can_replace_cpu_backend(self) -> bool:
+        return not self._active
+
+    def replace_cpu_backend(self, backend) -> bool:
+        if not self.can_replace_cpu_backend():
+            return False
+        self._cpu = backend
+        return True
+
     @staticmethod
     def _read_boot_id():
         try:

--- a/py_modules/tdp/asus_nb_wmi.py
+++ b/py_modules/tdp/asus_nb_wmi.py
@@ -17,6 +17,7 @@ class AsusNbWmiBackend(TDPBackend):
     """Standalone legacy ASUS TDP ABI used when asus-armoury is absent."""
 
     name = "asus-nb-wmi"
+    reselection_safe_after_use = True
 
     def __init__(
         self,
@@ -46,6 +47,7 @@ class AsusNbWmiBackend(TDPBackend):
         )
         self._ownership_recovery_pending = payload is not None
         self._recovery_blocked = False
+        self._selection_failure = {}
 
     @property
     def safety_locked(self) -> bool:
@@ -147,6 +149,36 @@ class AsusNbWmiBackend(TDPBackend):
             if rail in levels
         }
 
+    def ready(self) -> bool:
+        return self.selection_ready()
+
+    def probe(self) -> bool:
+        return self.ready()
+
+    def selection_ready(self) -> bool:
+        self._selection_failure = {}
+        if not self.supported:
+            self._selection_failure = {"unready_reason": "not_present"}
+            return False
+        if self.safety_locked:
+            self._selection_failure = {"unready_reason": "ownership_recovery"}
+            return False
+        unavailable = [
+            f"{self.name}/{rail}=unavailable"
+            for rail, path in self._paths.items()
+            if self._read_int(path) is None
+        ]
+        if unavailable:
+            self._selection_failure = {
+                "unready_reason": "snapshot_unavailable",
+                "unavailable": unavailable,
+            }
+            return False
+        return True
+
+    def selection_diagnostics(self) -> dict:
+        return dict(self._selection_failure)
+
     def release(self) -> bool:
         if self._owned_snapshot is None:
             return not self.safety_locked
@@ -189,12 +221,15 @@ class AsusNbWmiBackend(TDPBackend):
         return {"ok": True, "detail": "ASUS legacy ownership relinquished"}
 
     def diagnostics(self) -> dict:
-        return {
+        diagnostics = {
             "rails": list(self._rails),
             "transactional": True,
             "owns_state": self._owned_snapshot is not None,
             "recovery_blocked": self.safety_locked,
         }
+        if self._selection_failure:
+            diagnostics["selection_failure"] = dict(self._selection_failure)
+        return diagnostics
 
     def _rail_max(self, rail: str) -> int:
         if rail == "pl2":

--- a/py_modules/tdp/backend.py
+++ b/py_modules/tdp/backend.py
@@ -13,6 +13,7 @@ class TDPBackend(ABC):
     heartbeat_s: float | None = None
     authoritative_reassert_s: float | None = None
     read_tolerance_w: int = 0
+    reselection_safe_after_use: bool = False
     probe_trace: tuple[dict, ...] = ()
     primary_rail: str = "pl1"
 
@@ -49,6 +50,13 @@ class TDPBackend(ABC):
 
     def physical_levels(self, levels: dict) -> dict[str, int]:
         return self.reconciliation_levels(levels)
+
+    def selection_ready(self) -> bool:
+        """Whether this candidate is usable without performing a hardware write."""
+        return bool(self.supported)
+
+    def selection_diagnostics(self) -> dict:
+        return {}
 
     def apply_targets(self, targets: dict[str, int], ac: bool) -> TdpResult:
         primary = int(targets[self.primary_rail])

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -153,7 +153,7 @@ def _candidates(device, fallback, root, ryzenadj, os_id=None):
         if key in _STRICT_RYZENADJ_KEYS:
             return [asus, lenovo, msi, ryzenadj]
         if key.startswith("rog_"):
-            return [asus, lenovo, msi, *amd_tail]
+            return [asus, asus_nb_wmi, lenovo, msi, *amd_tail]
         if key.startswith("legion_"):
             return [lenovo, asus, msi, *amd_tail]
         return [asus, lenovo, msi, *amd_tail]
@@ -206,12 +206,30 @@ def select_backend(device, root="/", ryzenadj_resolve=None, os_id=None) -> TDPBa
                 "error": type(exc).__name__,
             })
             continue
-        trace.append({
+        trace_item = {
             "candidate": candidate,
             "backend": backend.name,
             "supported": bool(backend.supported),
-        })
-        if backend.supported or getattr(backend, "safety_locked", False):
+        }
+        safety_locked = bool(getattr(backend, "safety_locked", False))
+        ready = bool(backend.supported)
+        if ready and not safety_locked:
+            try:
+                ready = bool(backend.selection_ready())
+            except Exception as exc:  # noqa: BLE001
+                ready = False
+                trace_item["error"] = type(exc).__name__
+        if backend.supported and not ready:
+            trace_item["ready"] = False
+            try:
+                details = backend.selection_diagnostics()
+            except Exception as exc:  # noqa: BLE001
+                details = {}
+                trace_item["diagnostics_error"] = type(exc).__name__
+            if isinstance(details, dict):
+                trace_item.update(details)
+        trace.append(trace_item)
+        if ready or safety_locked:
             backend.probe_trace = tuple(trace)
             return backend
     backend = NullBackend(f"no supported TDP interface for {device.key}")

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -89,6 +89,7 @@ class FirmwareAttrBackend(TDPBackend):
         self._trust_live_bounds = bool(trust_live_bounds)
         self._safety_lock = RuntimeSafetyLock(safety_lock_path)
         self._restore_on_release = bool(restore_on_release)
+        self.reselection_safe_after_use = self._restore_on_release
         self._ownership_lock = RuntimeSafetyLock(ownership_lock_path)
         self._rail_floors = _normalise_rail_floors(rail_floors)
         self._ignored_live_maxes = _normalise_rail_values(ignored_live_maxes)
@@ -126,6 +127,7 @@ class FirmwareAttrBackend(TDPBackend):
         )
         self._owns_state = False
         self._ownership_recovery_pending = self._owned_payload is not None
+        self._selection_failure = {}
         complete_primary = all(rail in self._primary_rails for rail, _attr in _RAIL_ATTRS)
         complete_legacy = all(rail in self._legacy for rail, _attr in _RAIL_ATTRS)
         try:
@@ -425,11 +427,7 @@ class FirmwareAttrBackend(TDPBackend):
         )
 
     def ready(self):
-        if (
-            not self.supported
-            or self._write_circuit_open is not None
-            or self._ownership_recovery_pending
-        ):
+        if not self.selection_ready():
             return False
         if not self._trust_live_bounds:
             return True
@@ -448,6 +446,33 @@ class FirmwareAttrBackend(TDPBackend):
 
     def probe(self):
         return self.ready()
+
+    def selection_ready(self):
+        self._selection_failure = {}
+        if not self.supported:
+            self._selection_failure = {"unready_reason": "not_present"}
+            return False
+        if self._write_circuit_open is not None:
+            self._selection_failure = {"unready_reason": "transaction_locked"}
+            return False
+        if self._ownership_recovery_pending:
+            self._selection_failure = {"unready_reason": "ownership_recovery"}
+            return False
+        surfaces = self._transaction_surfaces({rail: 0 for rail in self._rails})
+        _snapshot, _profile, missing = self._capture_transaction(surfaces)
+        if not surfaces:
+            self._selection_failure = {"unready_reason": "no_transaction_surface"}
+            return False
+        if missing:
+            self._selection_failure = {
+                "unready_reason": "snapshot_unavailable",
+                "unavailable": list(missing),
+            }
+            return False
+        return True
+
+    def selection_diagnostics(self):
+        return dict(self._selection_failure)
 
     def _find_profile_dir(self):
         if not self._profile_name:
@@ -790,6 +815,8 @@ class FirmwareAttrBackend(TDPBackend):
                 for rail, attr in _RAIL_ATTRS
                 if rail in self._rails
             }
+        if self._selection_failure:
+            diagnostics["selection_failure"] = dict(self._selection_failure)
         return diagnostics
 
     def release(self):

--- a/tests/test_desktop_power.py
+++ b/tests/test_desktop_power.py
@@ -121,6 +121,25 @@ def test_free_mode_performs_no_writes_on_fresh_coordinator():
     assert cpu.read_calls == 0
 
 
+def test_cpu_backend_can_be_replaced_while_coordinator_is_free():
+    original, replacement = Cpu(applied=30), Cpu(applied=18)
+    coordinator = DesktopPowerCoordinator(original, UnsupportedGpu())
+
+    assert coordinator.can_replace_cpu_backend() is True
+    assert coordinator.replace_cpu_backend(replacement) is True
+    assert coordinator.state()["cpu_w"] == 18
+
+
+def test_cpu_backend_cannot_be_replaced_while_coordinator_owns_state():
+    original, replacement = Cpu(applied=30), Cpu(applied=18)
+    coordinator = DesktopPowerCoordinator(original, UnsupportedGpu())
+    assert coordinator.apply("silent")["ok"] is True
+
+    assert coordinator.can_replace_cpu_backend() is False
+    assert coordinator.replace_cpu_backend(replacement) is False
+    assert coordinator._cpu is original
+
+
 def test_performance_coordinates_cpu_30_and_gpu_110():
     cpu, gpu = Cpu(), Gpu()
     result = DesktopPowerCoordinator(cpu, gpu).apply("performance")

--- a/tests/test_tdp_control_rpc.py
+++ b/tests/test_tdp_control_rpc.py
@@ -12,6 +12,7 @@ import types
 import pytest
 
 from device_profiles import DEVICE_TABLE
+from tdp.backend import NullBackend
 from tdp.factory import select_backend as real_select_backend
 from tdp.types import TdpLimits, TdpResult
 
@@ -123,6 +124,359 @@ def test_dynamic_backend_readiness_controls_published_tdp_support(Plugin):
     assert plugin._tdp_supported() is True
 
 
+def test_backend_probe_errors_are_reported_without_escaping(Plugin):
+    backend = FakeBackend()
+
+    def broken_probe():
+        raise OSError("sysfs disappeared")
+
+    backend.probe = broken_probe
+
+    assert Plugin._probe_tdp_candidate(backend) == {
+        "ready": False,
+        "error": "OSError",
+    }
+
+
+def test_force_probe_reselects_safe_backend_atomically(Plugin, monkeypatch):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    failed = plugin._tdp_backend
+    failed.probe = lambda: False
+    failed.reselection_safe_after_use = True
+    plugin._tdp_backend_used = True
+    plugin._tdp_status = "applied"
+    plugin._tdp_reason = "old-route"
+    replacement = FakeBackend()
+    replacement.name = "fallback"
+    queued = plugin._capture_tdp_command("queued-before-reselection")
+    queued_result = []
+    during_selection = []
+    calls = []
+    selections = []
+
+    async def controlled_offload(fn):
+        result = fn()
+        calls.append(True)
+        if len(calls) == 2:
+            queued_result.append(plugin._execute_tdp_command(queued))
+        return result
+
+    def select_replacement(device, **kwargs):
+        assert failed.release_calls == 1
+        during_selection.append(
+            plugin._capture_tdp_command("during-reselection")
+        )
+        selections.append((device.key, kwargs))
+        return replacement
+
+    plugin._offload_call = controlled_offload
+    monkeypatch.setattr(main_mod.tdp_factory, "select_backend", select_replacement)
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is True
+    assert plugin._tdp_backend is replacement
+    assert plugin._desktop_power._cpu is replacement
+    assert failed.release_calls == 1
+    assert failed.set_levels_calls == 0
+    assert queued_result[0].detail == "stale-generation"
+    assert plugin._execute_tdp_command(during_selection[0]).detail == "stale-backend"
+    assert selections == [(plugin._device.key, {"os_id": plugin._os_id})]
+    assert plugin._tdp_status == "settling"
+    assert plugin._tdp_reason == ""
+    assert plugin._tdp_targets is None
+    transition = plugin._tdp_backend_history[-1]
+    assert transition["selected"] == "fallback"
+    assert transition["outcome"] == "reselected"
+    assert transition["release"] == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    ("condition", "reason", "status"),
+    (
+        ("recovery", "recovery_pending", "unsupported"),
+        ("temporary", "temporarily_unready", "unsupported"),
+        ("desktop", "desktop_power_owned", "unverifiable"),
+    ),
+)
+def test_force_probe_keeps_backend_when_reselection_is_unsafe(
+    Plugin,
+    monkeypatch,
+    condition,
+    reason,
+    status,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    backend = plugin._tdp_backend
+    backend.probe = lambda: False
+    if condition == "recovery":
+        backend.safety_locked = True
+        backend.recover_runtime_transaction = lambda: {
+            "ok": False,
+            "detail": "still locked",
+        }
+    elif condition == "temporary":
+        backend.selection_ready = lambda: True
+    elif condition == "desktop":
+        plugin._desktop_power._active = True
+    selections = []
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: selections.append(True) or FakeBackend(),
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert plugin._tdp_backend is backend
+    assert backend.release_calls == 0
+    assert selections == []
+    assert plugin._tdp_reason == reason
+    assert plugin._tdp_status == status
+
+
+def test_unrestorable_route_loss_returns_previous_hhd_owner(
+    Plugin,
+    fake_hhd,
+    monkeypatch,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    backend = plugin._tdp_backend
+    backend.probe = lambda: False
+    plugin._tdp_backend_used = True
+    plugin._settings["hhd_tdp_prev"] = True
+    plugin._settings["tdp_control_enabled"] = True
+    fake_hhd.set(False)
+    selections = []
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: selections.append(True) or FakeBackend(),
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert plugin._tdp_backend is backend
+    assert selections == []
+    assert plugin._settings["tdp_control_enabled"] is False
+    assert plugin._settings["hhd_tdp_prev"] is None
+    assert fake_hhd.value is True
+    assert plugin._tdp_backend_history[-1]["handoff"]["ok"] is True
+
+
+def test_locked_replacement_keeps_hhd_disabled_until_recovery(
+    Plugin,
+    fake_hhd,
+    monkeypatch,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    plugin._tdp_backend.probe = lambda: False
+    plugin._settings["hhd_tdp_prev"] = True
+    fake_hhd.set(False)
+    replacement = FakeBackend()
+    replacement.safety_locked = True
+    replacement.probe = lambda: False
+    replacement.recover_runtime_transaction = lambda: {
+        "ok": False,
+        "detail": "still locked",
+    }
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: replacement,
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert plugin._tdp_backend is replacement
+    assert plugin._tdp_reason == "recovery_pending"
+    assert plugin._settings["hhd_tdp_prev"] is True
+    assert fake_hhd.value is False
+
+
+def test_selection_failure_installs_diagnostic_null_backend(
+    Plugin,
+    monkeypatch,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    failed = plugin._tdp_backend
+    failed.probe = lambda: False
+
+    def fail_selection(*_args, **_kwargs):
+        raise OSError("factory failed")
+
+    monkeypatch.setattr(main_mod.tdp_factory, "select_backend", fail_selection)
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert failed.release_calls == 1
+    assert isinstance(plugin._tdp_backend, NullBackend)
+    assert plugin._desktop_power._cpu is plugin._tdp_backend
+    assert plugin._tdp_reason == "selection_failed"
+    assert plugin._tdp_backend_history[-1]["outcome"] == "selection_failed"
+    assert plugin._tdp_backend_history[-1]["selection_trace"] == [{
+        "candidate": "factory",
+        "backend": None,
+        "supported": False,
+        "error": "OSError",
+    }]
+
+
+def test_concurrent_backend_probes_perform_one_reselection(Plugin, monkeypatch):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    failed = plugin._tdp_backend
+    failed.probe = lambda: False
+    replacement = FakeBackend()
+    replacement.name = "fallback"
+    selections = []
+
+    async def yielding_offload(fn):
+        await asyncio.sleep(0)
+        return fn()
+
+    plugin._offload_call = yielding_offload
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: selections.append(True) or replacement,
+    )
+
+    async def probe_twice():
+        return await asyncio.gather(
+            plugin._probe_tdp_backend(force=True),
+            plugin._probe_tdp_backend(force=True),
+        )
+
+    assert asyncio.run(probe_twice()) == [True, True]
+    assert failed.release_calls == 1
+    assert len(selections) == 1
+
+
+def test_backend_guard_follows_route_loss_and_autonomous_recovery(
+    Plugin,
+    monkeypatch,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    plugin._tdp_backend.probe = lambda: False
+    plugin._lifecycle._task = object()
+    replacement = FakeBackend()
+    replacement.name = "fallback"
+    replacements = iter((NullBackend("not ready yet"), replacement))
+    monkeypatch.setattr(main_mod, "_TDP_BACKEND_REPROBE_S", 0.001)
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: next(replacements),
+    )
+
+    async def wait_for_recovery():
+        assert await plugin._probe_tdp_backend(force=True) is False
+        guard = plugin._tdp_guard_task
+        assert guard is not None
+        for _ in range(50):
+            if plugin._tdp_backend is replacement:
+                same_guard = plugin._tdp_guard_task is guard
+                plugin._stop_tdp_guard_loop()
+                return same_guard
+            await asyncio.sleep(0.005)
+        return False
+
+    assert asyncio.run(wait_for_recovery()) is True
+
+
+def test_force_probe_does_not_select_when_release_raises(Plugin, monkeypatch):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    failed = plugin._tdp_backend
+    failed.probe = lambda: False
+
+    def broken_release():
+        raise OSError("restore failed")
+
+    failed.release = broken_release
+    selections = []
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: selections.append(True) or FakeBackend(),
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert plugin._tdp_backend is failed
+    assert plugin._tdp_reason == "release_failed"
+    assert selections == []
+
+
+def test_unavailable_backend_reselection_is_rate_limited(Plugin, monkeypatch):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    plugin._tdp_backend = NullBackend("no viable route")
+    now = [100.0]
+    selections = []
+    monkeypatch.setattr(main_mod, "_monotonic", lambda: now[0])
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: selections.append(True)
+        or NullBackend("still unavailable"),
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend()) is False
+    assert asyncio.run(plugin._probe_tdp_backend()) is False
+    assert len(selections) == 1
+
+    now[0] += 30.0
+
+    assert asyncio.run(plugin._probe_tdp_backend()) is False
+    assert len(selections) == 2
+
+
+def test_route_loss_hands_hhd_back_and_disables_control(
+    Plugin,
+    fake_hhd,
+    monkeypatch,
+):
+    import main as main_mod
+
+    plugin = Plugin()
+    plugin._init()
+    plugin._tdp_backend.probe = lambda: False
+    plugin._tdp_backend.reselection_safe_after_use = True
+    plugin._tdp_backend_used = True
+    plugin._settings["hhd_tdp_prev"] = True
+    plugin._settings["tdp_control_enabled"] = True
+    fake_hhd.set(False)
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: NullBackend("no viable route"),
+    )
+
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
+    assert fake_hhd.value is True
+    assert plugin._settings["hhd_tdp_prev"] is None
+    assert plugin._settings["tdp_control_enabled"] is False
+    assert plugin._tdp_backend_history[-1]["handoff"]["ok"] is True
+
+
 def test_bazzite_legion_go_2_recovers_a_startup_lock_after_sysfs_appears(
     Plugin,
     tmp_path,
@@ -206,6 +560,7 @@ def test_bazzite_legion_go_2_recovers_a_startup_lock_after_sysfs_appears(
         encoding="utf-8",
     )
     (profile_dir / "profile").write_text("performance", encoding="utf-8")
+    plugin._lifecycle._task = object()
 
     async def recover():
         state = await plugin.get_tdp_state()
@@ -356,7 +711,10 @@ def test_anatase_startup_keeps_recovery_locked_when_hhd_is_unreadable(
     plugin._hhd_tdp_client = FakeHHD(None)
     events = []
     plugin._tdp_backend = types.SimpleNamespace(
+        name="locked",
+        supported=True,
         safety_locked=True,
+        probe=lambda: False,
         relinquish_ownership=lambda: events.append("relinquish"),
         recover_runtime_transaction=lambda: events.append("recover"),
     )
@@ -367,6 +725,7 @@ def test_anatase_startup_keeps_recovery_locked_when_hhd_is_unreadable(
     plugin._offload_call = direct
 
     assert asyncio.run(plugin._recover_tdp_startup_state()) is False
+    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
     assert plugin._tdp_external_owner is True
     assert events == []
 
@@ -470,11 +829,22 @@ def test_take_and_restore_hands_hhd_back(Plugin, fake_hhd):
     assert p._settings["hhd_tdp_prev"] is None
 
 
-def test_take_never_disables_hhd_when_deferred_backend_probe_fails(Plugin, fake_hhd):
+def test_take_never_disables_hhd_when_no_viable_backend_remains(
+    Plugin,
+    fake_hhd,
+    monkeypatch,
+):
+    import main as main_mod
+
     p = Plugin()
     p._init()
     probes = []
     p._tdp_backend.probe = lambda: probes.append(True) or False
+    monkeypatch.setattr(
+        main_mod.tdp_factory,
+        "select_backend",
+        lambda *_args, **_kwargs: NullBackend("no viable route"),
+    )
     fake_hhd.set(True)
 
     out = asyncio.run(p.take_tdp_control())

--- a/tests/test_tdp_control_rpc.py
+++ b/tests/test_tdp_control_rpc.py
@@ -124,6 +124,14 @@ def test_dynamic_backend_readiness_controls_published_tdp_support(Plugin):
     assert plugin._tdp_supported() is True
 
 
+def _plugin_with_unready_backend(Plugin):
+    plugin = Plugin()
+    plugin._init()
+    backend = plugin._tdp_backend
+    backend.probe = lambda: False
+    return plugin, backend
+
+
 def test_backend_probe_errors_are_reported_without_escaping(Plugin):
     backend = FakeBackend()
 
@@ -141,10 +149,7 @@ def test_backend_probe_errors_are_reported_without_escaping(Plugin):
 def test_force_probe_reselects_safe_backend_atomically(Plugin, monkeypatch):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    failed = plugin._tdp_backend
-    failed.probe = lambda: False
+    plugin, failed = _plugin_with_unready_backend(Plugin)
     failed.reselection_safe_after_use = True
     plugin._tdp_backend_used = True
     plugin._tdp_status = "applied"
@@ -197,6 +202,7 @@ def test_force_probe_reselects_safe_backend_atomically(Plugin, monkeypatch):
         ("recovery", "recovery_pending", "unsupported"),
         ("temporary", "temporarily_unready", "unsupported"),
         ("desktop", "desktop_power_owned", "unverifiable"),
+        ("release", "release_failed", "rejected"),
     ),
 )
 def test_force_probe_keeps_backend_when_reselection_is_unsafe(
@@ -208,10 +214,7 @@ def test_force_probe_keeps_backend_when_reselection_is_unsafe(
 ):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    backend = plugin._tdp_backend
-    backend.probe = lambda: False
+    plugin, backend = _plugin_with_unready_backend(Plugin)
     if condition == "recovery":
         backend.safety_locked = True
         backend.recover_runtime_transaction = lambda: {
@@ -222,6 +225,11 @@ def test_force_probe_keeps_backend_when_reselection_is_unsafe(
         backend.selection_ready = lambda: True
     elif condition == "desktop":
         plugin._desktop_power._active = True
+    else:
+        def broken_release():
+            raise OSError("restore failed")
+
+        backend.release = broken_release
     selections = []
     monkeypatch.setattr(
         main_mod.tdp_factory,
@@ -237,31 +245,32 @@ def test_force_probe_keeps_backend_when_reselection_is_unsafe(
     assert plugin._tdp_status == status
 
 
-def test_unrestorable_route_loss_returns_previous_hhd_owner(
+@pytest.mark.parametrize("reselection_safe", (False, True))
+def test_route_loss_returns_previous_hhd_owner_without_double_writer(
     Plugin,
     fake_hhd,
     monkeypatch,
+    reselection_safe,
 ):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    backend = plugin._tdp_backend
-    backend.probe = lambda: False
+    plugin, backend = _plugin_with_unready_backend(Plugin)
+    backend.reselection_safe_after_use = reselection_safe
     plugin._tdp_backend_used = True
     plugin._settings["hhd_tdp_prev"] = True
     plugin._settings["tdp_control_enabled"] = True
     fake_hhd.set(False)
     selections = []
+    replacement = NullBackend("no viable route")
     monkeypatch.setattr(
         main_mod.tdp_factory,
         "select_backend",
-        lambda *_args, **_kwargs: selections.append(True) or FakeBackend(),
+        lambda *_args, **_kwargs: selections.append(True) or replacement,
     )
 
     assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
-    assert plugin._tdp_backend is backend
-    assert selections == []
+    assert plugin._tdp_backend is (replacement if reselection_safe else backend)
+    assert len(selections) == int(reselection_safe)
     assert plugin._settings["tdp_control_enabled"] is False
     assert plugin._settings["hhd_tdp_prev"] is None
     assert fake_hhd.value is True
@@ -275,9 +284,7 @@ def test_locked_replacement_keeps_hhd_disabled_until_recovery(
 ):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    plugin._tdp_backend.probe = lambda: False
+    plugin, _failed = _plugin_with_unready_backend(Plugin)
     plugin._settings["hhd_tdp_prev"] = True
     fake_hhd.set(False)
     replacement = FakeBackend()
@@ -306,10 +313,7 @@ def test_selection_failure_installs_diagnostic_null_backend(
 ):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    failed = plugin._tdp_backend
-    failed.probe = lambda: False
+    plugin, failed = _plugin_with_unready_backend(Plugin)
 
     def fail_selection(*_args, **_kwargs):
         raise OSError("factory failed")
@@ -333,10 +337,7 @@ def test_selection_failure_installs_diagnostic_null_backend(
 def test_concurrent_backend_probes_perform_one_reselection(Plugin, monkeypatch):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    failed = plugin._tdp_backend
-    failed.probe = lambda: False
+    plugin, failed = _plugin_with_unready_backend(Plugin)
     replacement = FakeBackend()
     replacement.name = "fallback"
     selections = []
@@ -369,9 +370,7 @@ def test_backend_guard_follows_route_loss_and_autonomous_recovery(
 ):
     import main as main_mod
 
-    plugin = Plugin()
-    plugin._init()
-    plugin._tdp_backend.probe = lambda: False
+    plugin, _failed = _plugin_with_unready_backend(Plugin)
     plugin._lifecycle._task = object()
     replacement = FakeBackend()
     replacement.name = "fallback"
@@ -398,31 +397,6 @@ def test_backend_guard_follows_route_loss_and_autonomous_recovery(
     assert asyncio.run(wait_for_recovery()) is True
 
 
-def test_force_probe_does_not_select_when_release_raises(Plugin, monkeypatch):
-    import main as main_mod
-
-    plugin = Plugin()
-    plugin._init()
-    failed = plugin._tdp_backend
-    failed.probe = lambda: False
-
-    def broken_release():
-        raise OSError("restore failed")
-
-    failed.release = broken_release
-    selections = []
-    monkeypatch.setattr(
-        main_mod.tdp_factory,
-        "select_backend",
-        lambda *_args, **_kwargs: selections.append(True) or FakeBackend(),
-    )
-
-    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
-    assert plugin._tdp_backend is failed
-    assert plugin._tdp_reason == "release_failed"
-    assert selections == []
-
-
 def test_unavailable_backend_reselection_is_rate_limited(Plugin, monkeypatch):
     import main as main_mod
 
@@ -447,34 +421,6 @@ def test_unavailable_backend_reselection_is_rate_limited(Plugin, monkeypatch):
 
     assert asyncio.run(plugin._probe_tdp_backend()) is False
     assert len(selections) == 2
-
-
-def test_route_loss_hands_hhd_back_and_disables_control(
-    Plugin,
-    fake_hhd,
-    monkeypatch,
-):
-    import main as main_mod
-
-    plugin = Plugin()
-    plugin._init()
-    plugin._tdp_backend.probe = lambda: False
-    plugin._tdp_backend.reselection_safe_after_use = True
-    plugin._tdp_backend_used = True
-    plugin._settings["hhd_tdp_prev"] = True
-    plugin._settings["tdp_control_enabled"] = True
-    fake_hhd.set(False)
-    monkeypatch.setattr(
-        main_mod.tdp_factory,
-        "select_backend",
-        lambda *_args, **_kwargs: NullBackend("no viable route"),
-    )
-
-    assert asyncio.run(plugin._probe_tdp_backend(force=True)) is False
-    assert fake_hhd.value is True
-    assert plugin._settings["hhd_tdp_prev"] is None
-    assert plugin._settings["tdp_control_enabled"] is False
-    assert plugin._tdp_backend_history[-1]["handoff"]["ok"] is True
 
 
 def test_bazzite_legion_go_2_recovers_a_startup_lock_after_sysfs_appears(

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -565,6 +565,7 @@ def test_falls_back_to_null_when_nothing_present(tmp_path):
     assert b.supported is False and b.name == "unsupported"
     assert [item["candidate"] for item in b.probe_trace] == [
         "asus",
+        "asus_nb_wmi",
         "lenovo",
         "msi",
         "ryzenadj",
@@ -665,6 +666,55 @@ def test_backend_probe_failure_is_recorded_and_falls_through(tmp_path, monkeypat
             "supported": True,
         },
     )
+
+
+def test_factory_continues_after_a_present_candidate_is_not_ready(
+    tmp_path,
+    monkeypatch,
+):
+    calls = []
+
+    def unavailable():
+        calls.append("unavailable")
+
+        class Unavailable(NullBackend):
+            supported = True
+            name = "unavailable"
+
+            def selection_ready(self):
+                return False
+
+        return Unavailable("x")
+
+    def working():
+        calls.append("working")
+
+        class Working(NullBackend):
+            supported = True
+            name = "working"
+
+        return Working("x")
+
+    monkeypatch.setattr(
+        factory,
+        "_candidates",
+        lambda *args: [unavailable, working],
+    )
+
+    backend = select_backend(
+        GENERIC,
+        root=str(tmp_path),
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    assert backend.name == "working"
+    assert calls == ["unavailable", "working"]
+    assert backend.probe_trace[0] == {
+        "candidate": "unavailable",
+        "backend": "unavailable",
+        "supported": True,
+        "ready": False,
+    }
 
 
 def _mk_rapl(root):

--- a/tests/test_tdp_factory_matrix.py
+++ b/tests/test_tdp_factory_matrix.py
@@ -37,6 +37,15 @@ def _mk_firmware(root, provider):
         _write(os.path.join(path, "max_value"), maximum)
 
 
+def _mk_unreadable_firmware(root, provider):
+    base = os.path.join(root, "sys/class/firmware-attributes", provider, "attributes")
+    for attr in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
+        path = os.path.join(base, attr)
+        _write(os.path.join(path, "current_value"), "")
+        _write(os.path.join(path, "min_value"), "")
+        _write(os.path.join(path, "max_value"), "")
+
+
 def _mk_dptc(root):
     _mk_firmware(root, "amd-dptc")
     base = os.path.join(root, "sys/class/platform-profile/platform-profile-0")
@@ -74,6 +83,40 @@ def test_rog_ally_selects_standalone_legacy_backend(tmp_path):
     ]
 
 
+def test_bazzite_rog_xbox_ally_skips_unreadable_armoury_and_uses_legacy(
+    tmp_path,
+):
+    root = str(tmp_path)
+    _mk_unreadable_firmware(root, "asus-armoury")
+    _mk_legacy_asus(root)
+
+    backend = select_backend(
+        _profile("rog_xbox_ally"),
+        root=root,
+        ryzenadj_resolve=_no_ryzenadj,
+        os_id="bazzite",
+    )
+
+    assert backend.name == "asus-nb-wmi"
+    assert backend.probe_trace == (
+        {
+            "candidate": "asus",
+            "backend": "firmware-attr:asus-armoury",
+            "supported": True,
+            "ready": False,
+            "unready_reason": "snapshot_unavailable",
+            "unavailable": [
+                "firmware-attr:asus-armoury/pl3=unavailable",
+                "firmware-attr:asus-armoury/pl2=unavailable",
+                "firmware-attr:asus-armoury/pl1=unavailable",
+            ],
+        },
+        {
+            "candidate": "asus_nb_wmi",
+            "backend": "asus-nb-wmi",
+            "supported": True,
+        },
+    )
 def test_rog_with_armoury_and_legacy_keeps_coordinated_backend(tmp_path):
     root = str(tmp_path)
     _mk_firmware(root, "asus-armoury")
@@ -218,7 +261,7 @@ def test_generic_amd_prefers_complete_dptc_with_conservative_profile(tmp_path):
     assert backend.get_limits().max_ac_w == GENERIC.tdp_max_charger
 
 
-def test_non_anatase_keeps_historical_rog_fallback_chain(tmp_path):
+def test_non_anatase_rog_uses_viable_legacy_before_generic_fallbacks(tmp_path):
     root = str(tmp_path)
     _mk_legacy_asus(root)
     _mk_dptc(root)
@@ -230,13 +273,10 @@ def test_non_anatase_keeps_historical_rog_fallback_chain(tmp_path):
         os_id="bazzite",
     )
 
-    assert backend.supported is False
+    assert backend.name == "asus-nb-wmi"
     assert [item["candidate"] for item in backend.probe_trace] == [
         "asus",
-        "lenovo",
-        "msi",
-        "ryzenadj",
-        "alib",
+        "asus_nb_wmi",
     ]
 
 


### PR DESCRIPTION
## What does this change?

Closes #594.

Panel de Control now skips TDP routes that are present but cannot provide a usable snapshot, continues through safe alternatives, and recovers ownership without allowing stale or competing writers.

## How was it tested?

- Reproduced the reported RC73YA/Bazzite topology from the submitted bundles.
- Verified fallback, recovery, ownership and stale-command handling.
- 2,725 Python tests and 1,054 frontend tests passed.
- Typecheck, Ruff and the production build passed.
- The affected RC73YA was not physically available, so this remains a defensive fix rather than hardware-verified support.

## Checklist

- [x] The commit message follows Conventional Commits.
- [x] pnpm typecheck, pnpm test:fe, and pnpm build pass.
- [x] Ruff and the Python test suite pass.
- [x] No secrets, tokens, personal data or private report contents are included.
- [x] No third-party dependencies were added.