### PR TITLE
fix: recover Legion Go S firmware transactions

### DIFF
--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -44,7 +44,10 @@ def legion_go_s_83l3_firmware_attr_quirks(device, root: str = "/") -> dict:
         or _read_dmi(root, "product_name").casefold() != "83l3"
     ):
         return {}
-    return {"readback_settle_delays": (0.05, 0.10, 0.20, 0.40)}
+    return {
+        "readback_settle_delays": (0.05, 0.10, 0.20, 0.40),
+        "named_profile_owns_rails": True,
+    }
 
 
 def legion_go_s_83n6_rail_floors(device, root: str = "/") -> dict[str, int]:

--- a/py_modules/tdp/firmware_attr.py
+++ b/py_modules/tdp/firmware_attr.py
@@ -79,6 +79,7 @@ class FirmwareAttrBackend(TDPBackend):
         safety_lock_path=None,
         restore_on_release=False,
         ownership_lock_path=None,
+        named_profile_owns_rails=False,
     ):
         self.name = f"firmware-attr:{driver_prefix}"
         self._driver_prefix = driver_prefix
@@ -91,6 +92,7 @@ class FirmwareAttrBackend(TDPBackend):
         self._restore_on_release = bool(restore_on_release)
         self.reselection_safe_after_use = self._restore_on_release
         self._ownership_lock = RuntimeSafetyLock(ownership_lock_path)
+        self._named_profile_owns_rails = bool(named_profile_owns_rails)
         self._rail_floors = _normalise_rail_floors(rail_floors)
         self._ignored_live_maxes = _normalise_rail_values(ignored_live_maxes)
         self.cap_boost_to_active = bool(cap_boost_to_active)
@@ -99,8 +101,8 @@ class FirmwareAttrBackend(TDPBackend):
         )
         self._dir = self._find_driver_dir(driver_prefix)
         self.supported = self._dir is not None and os.path.exists(self._attr("ppt_pl1_spl"))
-        self._pp_dir = self._find_profile_dir()  # static, resolved once
-        self._pp_choices = None                  # parsed lazily, then cached
+        self._pp_dir = self._find_profile_dir()
+        self._pp_choices = None
         self._legacy = self._find_legacy_nodes(driver_prefix)  # ASUS dual-interface
         self._primary_rails = tuple(
             rail
@@ -224,14 +226,20 @@ class FirmwareAttrBackend(TDPBackend):
             missing.append("platform-profile=unavailable")
         return snapshot, profile, missing
 
-    def _snapshot_mismatches(self, surfaces, snapshot, profile):
+    def _snapshot_mismatches(
+        self,
+        surfaces,
+        snapshot,
+        profile,
+        compare_values=True,
+    ):
         mismatches = []
         for surface, rail, path in surfaces:
             current = self._read_int(path)
             expected = snapshot[path]
             if current is None:
                 mismatches.append(f"{self._surface_label(surface, rail)}=unavailable")
-            elif current != expected:
+            elif compare_values and current != expected:
                 mismatches.append(f"{self._surface_label(surface, rail)}={current}")
         if self._pp_dir:
             current_profile = self.read_profile()
@@ -241,23 +249,49 @@ class FirmwareAttrBackend(TDPBackend):
                 mismatches.append(f"platform-profile={current_profile}")
         return mismatches
 
-    def _rollback_transaction(self, surfaces, snapshot, profile):
+    def _named_profile_owns_transaction_rails(self, purpose, profile):
+        return (
+            purpose == "transaction"
+            and self._named_profile_owns_rails
+            and isinstance(profile, str)
+            and profile != "custom"
+            and profile in self.profile_choices()
+        )
+
+    def _rollback_transaction(
+        self,
+        surfaces,
+        snapshot,
+        profile,
+        restore_rails=True,
+    ):
         write_failures = []
-        for surface, rail, path in reversed(surfaces):
-            if not self._write(path, snapshot[path]):
-                write_failures.append(self._surface_label(surface, rail))
+        if restore_rails:
+            for surface, rail, path in reversed(surfaces):
+                if not self._write(path, snapshot[path]):
+                    write_failures.append(self._surface_label(surface, rail))
         if self._pp_dir and not self._write(
             os.path.join(self._pp_dir, "profile"),
             profile,
         ):
             write_failures.append("platform-profile")
 
-        mismatches = self._snapshot_mismatches(surfaces, snapshot, profile)
+        mismatches = self._snapshot_mismatches(
+            surfaces,
+            snapshot,
+            profile,
+            compare_values=restore_rails,
+        )
         for delay in self._readback_settle_delays:
             if not mismatches:
                 break
             time.sleep(delay)
-            mismatches = self._snapshot_mismatches(surfaces, snapshot, profile)
+            mismatches = self._snapshot_mismatches(
+                surfaces,
+                snapshot,
+                profile,
+                compare_values=restore_rails,
+            )
         return not mismatches, write_failures + mismatches
 
     def _restore_payload(self, purpose):
@@ -283,7 +317,24 @@ class FirmwareAttrBackend(TDPBackend):
             return {"ok": False, "detail": f"firmware {purpose} profile unavailable"}
         if self._pp_dir and not isinstance(profile, str):
             return {"ok": False, "detail": f"firmware {purpose} profile unavailable"}
-        recovered, problems = self._rollback_transaction(surfaces, snapshot, profile)
+        if (
+            purpose == "transaction"
+            and self._named_profile_owns_rails
+            and isinstance(profile, str)
+            and profile != "custom"
+            and profile not in self.profile_choices()
+        ):
+            return {"ok": False, "detail": "firmware transaction profile invalid"}
+        profile_owns_rails = self._named_profile_owns_transaction_rails(
+            purpose,
+            profile,
+        )
+        recovered, problems = self._rollback_transaction(
+            surfaces,
+            snapshot,
+            profile,
+            restore_rails=not profile_owns_rails,
+        )
         if not recovered:
             detail = f"firmware {purpose} recovery failed: " + ", ".join(problems)
             payload = {**payload, "state": "rollback_failed", "detail": detail}
@@ -693,6 +744,9 @@ class FirmwareAttrBackend(TDPBackend):
                 surfaces,
                 snapshot,
                 previous_profile,
+                restore_rails=not self._named_profile_owns_transaction_rails(
+                    "transaction", previous_profile
+                ),
             )
             rollback_detail = "rollback confirmed"
             if not rollback_ok:

--- a/tests/test_device_quirks.py
+++ b/tests/test_device_quirks.py
@@ -118,3 +118,25 @@ def test_legion_go_s_rail_floors_are_empty_without_dmi(tmp_path):
         _profile("legion_go_s"),
         str(tmp_path),
     ) == {}
+
+
+def test_legion_go_s_83l3_named_profile_recovery_requires_exact_identity(tmp_path):
+    cases = (
+        ("LENOVO", "83L3", _profile("legion_go_s"), True),
+        ("OTHER", "83L3", _profile("legion_go_s"), False),
+        ("LENOVO", "83L3-S", _profile("legion_go_s"), False),
+        ("LENOVO", "83N6", _profile("legion_go_s"), False),
+        ("LENOVO", "83L3", _profile("legion_go_2"), False),
+        ("LENOVO", "83L3", GENERIC, False),
+    )
+
+    for vendor, product, device, expected in cases:
+        _write_dmi(str(tmp_path), vendor, product)
+        quirks = device_quirks.legion_go_s_83l3_firmware_attr_quirks(
+            device,
+            str(tmp_path),
+        )
+        assert quirks.get(
+            "named_profile_owns_rails",
+            False,
+        ) is expected

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import os
 
 import pytest
@@ -48,6 +49,18 @@ def _mk_dmi(root, vendor, product):
             f.write(value)
 
 
+def _mk_platform_profile(root, current="balanced"):
+    base = os.path.join(root, "sys/class/platform-profile/platform-profile-0")
+    os.makedirs(base, exist_ok=True)
+    for name, value in (
+        ("name", "lenovo-wmi-gamezone"),
+        ("profile", current),
+        ("choices", "low-power balanced performance custom"),
+    ):
+        with open(os.path.join(base, name), "w") as handle:
+            handle.write(value)
+
+
 def _mk_readable_ryzenadj(root):
     path = os.path.join(root, "fake-ryzenadj")
     with open(path, "w") as handle:
@@ -78,6 +91,72 @@ def _set_fw_max(root, rail, value):
     )
     with open(path, "w") as handle:
         handle.write(str(value))
+
+
+def _set_fw_current(root, rail, value):
+    path = os.path.join(
+        root,
+        "sys/class/firmware-attributes/lenovo-wmi-other-0/attributes",
+        rail,
+        "current_value",
+    )
+    with open(path, "w") as handle:
+        handle.write(str(value))
+
+
+def _mk_legion_firmware(root, product_name, profile, current=(21, 17, 36)):
+    _mk_fw(root, "lenovo-wmi-other-0")
+    _mk_dmi(root, "LENOVO", product_name)
+    _mk_platform_profile(root, current=profile)
+    for attr, value in zip(
+        ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"),
+        current,
+    ):
+        _set_fw_current(root, attr, value)
+
+
+def _arm_lenovo_transaction_lock(root, profile, snapshot=None):
+    lock_path = os.path.join(
+        root,
+        "run/panel-de-control/firmware-lenovo-wmi-other.lock",
+    )
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    with open(lock_path, "w") as handle:
+        json.dump(
+            {
+                "state": "rollback_failed",
+                "detail": "firmware transaction recovery failed",
+                "snapshot": snapshot or {
+                    "firmware-attr:lenovo-wmi-other/pl1": 25,
+                    "firmware-attr:lenovo-wmi-other/pl2": 25,
+                    "firmware-attr:lenovo-wmi-other/pl3": 25,
+                },
+                "profile": profile,
+            },
+            handle,
+        )
+    return lock_path
+
+
+def _locked_legion_backend(
+    root,
+    product_name="83L3",
+    current_profile="low-power",
+    saved_profile=None,
+    snapshot=None,
+):
+    _mk_legion_firmware(root, product_name, current_profile)
+    lock_path = _arm_lenovo_transaction_lock(
+        root,
+        saved_profile or current_profile,
+        snapshot=snapshot,
+    )
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    return backend, lock_path
 
 
 def _observation(backend, pl1, pl2, pl3):
@@ -310,6 +389,167 @@ def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
 
     assert getattr(exact, "_rail_floors", None) == {"pl2": 15, "pl3": 20}
     assert getattr(nearby, "_rail_floors", None) == {}
+
+
+@pytest.mark.parametrize("profile", ("low-power", "balanced", "performance"))
+def test_exact_legion_go_s_83l3_recovers_named_profile_without_restoring_rails(
+    tmp_path,
+    monkeypatch,
+    profile,
+):
+    root = str(tmp_path)
+    backend, lock_path = _locked_legion_backend(root, current_profile=profile)
+    original_write = backend._write
+
+    def firmware_owns_rails(path, value):
+        if path.endswith("current_value"):
+            return False
+        return original_write(path, value)
+
+    monkeypatch.setattr(backend, "_write", firmware_owns_rails)
+
+    recovered = backend.recover_runtime_transaction()
+
+    assert recovered["ok"] is True
+    assert backend.read_profile() == profile
+    assert backend.read_applied() == 21
+    assert not os.path.exists(lock_path)
+
+
+def test_exact_legion_go_s_83l3_confirms_named_profile_rollback_with_live_rails(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_legion_firmware(root, "83L3", "low-power", current=(25, 25, 25))
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    profile_path = os.path.join(
+        root,
+        "sys/class/platform-profile/platform-profile-0/profile",
+    )
+    original_write = backend._write
+
+    def recalculate_named_profile_rails(path, value):
+        if path.endswith("ppt_pl3_fppt/current_value") and value == 15:
+            return original_write(path, 20)
+        written = original_write(path, value)
+        if path == profile_path and value == "low-power":
+            _set_fw_current(root, "ppt_pl1_spl", 21)
+            _set_fw_current(root, "ppt_pl2_sppt", 17)
+            _set_fw_current(root, "ppt_pl3_fppt", 36)
+        return written
+
+    monkeypatch.setattr(backend, "_write", recalculate_named_profile_rails)
+
+    result = backend.set_levels(15, 15, 15, ac=False)
+
+    assert result.ok is False
+    assert result.applied_w == 21
+    assert "rollback confirmed" in result.detail
+    assert backend.read_profile() == "low-power"
+    assert backend.safety_locked is False
+    assert backend.ready() is True
+
+
+@pytest.mark.parametrize(
+    ("product_name", "profile"),
+    (("83L3", "custom"), ("83N6", "low-power")),
+)
+def test_legion_go_s_keeps_strict_recovery_outside_83l3_named_profiles(
+    tmp_path,
+    monkeypatch,
+    product_name,
+    profile,
+):
+    root = str(tmp_path)
+    backend, lock_path = _locked_legion_backend(
+        root,
+        product_name=product_name,
+        current_profile=profile,
+    )
+    original_write = backend._write
+
+    def reject_rail_restore(path, value):
+        if path.endswith("current_value"):
+            return False
+        return original_write(path, value)
+
+    monkeypatch.setattr(backend, "_write", reject_rail_restore)
+
+    recovered = backend.recover_runtime_transaction()
+
+    assert recovered["ok"] is False
+    assert backend.safety_locked is True
+    assert os.path.exists(lock_path)
+
+
+def test_exact_legion_go_s_83l3_without_platform_profile_recovers_strictly(tmp_path):
+    root = str(tmp_path)
+    _mk_fw(root, "lenovo-wmi-other-0")
+    _mk_dmi(root, "LENOVO", "83L3")
+    for attr, value in zip(
+        ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"),
+        (21, 17, 36),
+    ):
+        _set_fw_current(root, attr, value)
+    lock_path = _arm_lenovo_transaction_lock(root, None)
+    backend = select_backend(
+        _p("legion_go_s"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    recovered = backend.recover_runtime_transaction()
+
+    assert recovered["ok"] is True
+    assert backend.read_applied() == 25
+    assert not os.path.exists(lock_path)
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_detail"),
+    (
+        ("profile-unreadable", "platform-profile=unavailable"),
+        ("lock-clear", "runtime lock clear failed"),
+        ("unknown-profile", "firmware transaction profile invalid"),
+        ("surface-changed", "firmware transaction surfaces changed"),
+        ("rail-unreadable", "pl2=unavailable"),
+    ),
+)
+def test_exact_legion_go_s_83l3_named_recovery_fails_closed(
+    tmp_path,
+    monkeypatch,
+    failure,
+    expected_detail,
+):
+    root = str(tmp_path)
+    backend, lock_path = _locked_legion_backend(
+        root,
+        saved_profile="turbo" if failure == "unknown-profile" else None,
+        snapshot=(
+            {"firmware-attr:lenovo-wmi-other/pl1": 25}
+            if failure == "surface-changed"
+            else None
+        ),
+    )
+    if failure == "profile-unreadable":
+        monkeypatch.setattr(backend, "read_profile", lambda: None)
+        monkeypatch.setattr("tdp.firmware_attr.time.sleep", lambda _delay: None)
+    elif failure == "lock-clear":
+        monkeypatch.setattr(backend._safety_lock, "clear", lambda: False)
+    elif failure == "rail-unreadable":
+        _set_fw_current(root, "ppt_pl2_sppt", "invalid")
+
+    recovered = backend.recover_runtime_transaction()
+
+    assert recovered["ok"] is False
+    assert expected_detail in recovered["detail"]
+    assert backend.safety_locked is True
+    assert os.path.exists(lock_path)
 
 
 @pytest.mark.parametrize("product_name", ("83L3", "83N6"))


### PR DESCRIPTION
## What does this change?

Fixes #609.

On the exact `LENOVO/83L3` Legion Go S, restoring a named platform profile can legitimately recalculate the firmware TDP rails. This change accepts that firmware-owned result instead of treating it as a failed rollback and permanently locking TDP control.

`custom` profiles, missing or invalid profiles, unreadable rails, changed firmware surfaces, other Legion models, and every other device keep the existing strict rollback behavior.

## How was it tested?

- Added regression coverage for the reported partial-write and named-profile recalculation sequence.
- Covered boot recovery, strict `custom` rollback, sibling devices, invalid profiles, missing or unreadable rails, changed surfaces, lock-clear failure, and systems without `platform-profile`.
- `python -m pytest`: 2747 passed, 1 skipped, 58 subtests passed.
- `pnpm test:fe`: 1059 passed.
- `ruff check py_modules main.py tests`, `pnpm typecheck`, and `pnpm build` pass.
- The final artifact was smoke-tested on a `LENOVO/83N6` Legion Go S sibling control: the installed hash matched, the firmware backend loaded, startup reapplied the persisted TDP successfully, and no transaction lock remained.

Exact `83L3` hardware was not available locally, so this PR remains a draft until the reporter validates the candidate on the affected machine.

## Checklist

- [x] The commit messages follow Conventional Commits.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] No new third-party dependencies were added.
