### PR TITLE
fix(tdp): restore GPD Win Mini 2025 control

### DIFF
--- a/main.py
+++ b/main.py
@@ -861,6 +861,17 @@ class Plugin:
             else {}
         )
         self._save()
+        if (
+            module_id == "power"
+            and not disabled
+            and self._retired_experimental_tdp_unlock()
+        ):
+            activated = await self.set_tdp_control_enabled(True)
+            if not activated:
+                if self._tdp_control_on():
+                    await self.set_tdp_control_enabled(False)
+                self._sync_sampler()
+                return {"disabled": self._user_disabled_all()}
         if module_id == "chargeLimit":
             if not self._module_enabled("chargeLimit"):
                 self._publish_charge_limit_handoff(charge_generation)
@@ -2371,7 +2382,12 @@ class Plugin:
                 requested=requested,
             )
         else:
-            await self._apply_tdp_now("control-enabled")
+            if self._retired_experimental_tdp_unlock():
+                retired = await self._retire_experimental_tdp_unlock_or_disable()
+                if not retired.get("ok"):
+                    return False
+            else:
+                await self._apply_tdp_now("control-enabled")
         return enabled
 
     async def set_seen_autotdp_notice(self, seen: bool) -> bool:
@@ -3101,10 +3117,20 @@ class Plugin:
             and self._settings.get("experimental_tdp_unlock") is True
         )
 
+    def _retired_experimental_tdp_unlock(self) -> bool:
+        return bool(
+            self._device.key == "gpd_win_mini_2025"
+            and self._device.experimental_tdp_max_ac is None
+            and self._settings.get("experimental_tdp_unlock") is True
+        )
+
     async def set_experimental_tdp_unlock(self, enabled: bool) -> dict:
         """Opt into a charger-only ceiling above the manufacturer range."""
         self._init()
-        previous = await self.get_experimental_tdp_unlock()
+        previous = (
+            await self.get_experimental_tdp_unlock()
+            or self._retired_experimental_tdp_unlock()
+        )
         enabled = bool(enabled is True and self._device.experimental_tdp_max_ac)
         if enabled == previous:
             return {"enabled": previous, "ok": True, "detail": "unchanged"}
@@ -3132,7 +3158,12 @@ class Plugin:
             if callable(recover):
                 recover()
         result = await self._apply_tdp_now("experimental-ac-ceiling")
-        if result.ok:
+        safe_reclamp_confirmed = bool(
+            result.ok
+            and result.applied_w is not None
+            and self._limits().min_w <= result.applied_w <= self._limits().max_ac_w
+        )
+        if result.ok and (enabled or safe_reclamp_confirmed):
             if not enabled:
                 try:
                     self._save()
@@ -3160,7 +3191,20 @@ class Plugin:
                         f"{type(error).__name__}"
                     ),
                 }
-        return {"enabled": previous, "ok": False, "detail": result.detail}
+        detail = result.detail
+        if not enabled and result.ok:
+            detail = (
+                f"{detail}; safe ceiling unconfirmed"
+                if detail
+                else "safe ceiling unconfirmed"
+            )
+        return {"enabled": previous, "ok": False, "detail": detail}
+
+    async def _retire_experimental_tdp_unlock_or_disable(self) -> dict:
+        result = await self.set_experimental_tdp_unlock(False)
+        if not result.get("ok"):
+            await self.set_tdp_control_enabled(False)
+        return result
 
     def _qam_boost_active(self) -> bool:
         """The QAM-open responsive floor applies ONLY when its opt-in setting is on
@@ -3258,6 +3302,9 @@ class Plugin:
                 if not self._module_enabled("autoTdp"):
                     self._reset_auto_windows()
                     continue
+                if not self._auto_tdp_supported():
+                    self._reset_auto_windows()
+                    continue
                 # Hold when auto-TDP is off for THIS game (per-game, own or global) or a
                 # named firmware mode owns the rails — either way we don't drive PL1.
                 if (not self._tdp_profiles.auto_tdp(self._current_appid)
@@ -3298,7 +3345,8 @@ class Plugin:
         game already demands >= the responsive floor (the number IS the in-game one),
         or when not auto / no game / UI closed. Don't claim a raise that
         isn't happening."""
-        if not (self._qam_boost_active() and self._current_appid is not None
+        if not (self._auto_tdp_supported()
+                and self._qam_boost_active() and self._current_appid is not None
                 and self._tdp_profiles.auto_tdp(self._current_appid)):
             return False
         lim = self._limits()
@@ -3313,7 +3361,10 @@ class Plugin:
     async def get_power_draw(self) -> dict:
         self._init()
         pr = await asyncio.to_thread(self._power_reader.read)
-        auto = self._tdp_profiles.auto_tdp(self._current_appid)
+        auto = (
+            self._auto_tdp_supported()
+            and self._tdp_profiles.auto_tdp(self._current_appid)
+        )
         ac = read_on_ac()
         setpoint = self._effective_levels(self._current_appid, ac)[0]["pl1"]
         if getattr(self._tdp_backend, "blocking", False):
@@ -3345,13 +3396,20 @@ class Plugin:
         context_appid=_RPC_CONTEXT_UNSET,
     ) -> dict:
         self._init()
+        auto_tdp = (
+            self._auto_tdp_supported()
+            and self._tdp_profiles.auto_tdp(self._current_appid)
+        )
         if (
             context_appid is not _RPC_CONTEXT_UNSET
             and not self._scope_context_is_current(scope, appid, context_appid)
         ):
-            return {"auto_tdp": self._tdp_profiles.auto_tdp(self._current_appid)}
+            return {"auto_tdp": auto_tdp}
+        if not self._auto_tdp_supported():
+            self._tdp_profiles.set_auto_tdp(scope, False, appid=appid)
+            return {"auto_tdp": False}
         if not self._tdp_control_on():
-            return {"auto_tdp": self._tdp_profiles.auto_tdp(self._current_appid)}
+            return {"auto_tdp": auto_tdp}
         self._clear_eco()
         self._tdp_profiles.set_auto_tdp(scope, bool(enabled), appid=appid)
         await self._apply_tdp_now("auto-toggle")
@@ -3367,7 +3425,8 @@ class Plugin:
         the REAL in-game TDP. Only affects AUTO mode + a running game."""
         self._init()
         self._ui_active = bool(enabled)
-        if (self._qam_boost_active() and self._current_appid is not None
+        if (self._auto_tdp_supported()
+                and self._qam_boost_active() and self._current_appid is not None
                 and self._tdp_profiles.auto_tdp(self._current_appid)
                 and self._firmware_mode() == _CUSTOM_MODE):
             lim = self._limits()
@@ -5536,7 +5595,10 @@ class Plugin:
             if "pdc_eco" in active_ids:
                 snap["eco"] = bool(self._settings.get("eco_enabled"))
             if "pdc_tdp" in active_ids:
-                snap["auto"] = self._tdp_profiles.auto_tdp(appid)
+                snap["auto"] = (
+                    self._auto_tdp_supported()
+                    and self._tdp_profiles.auto_tdp(appid)
+                )
                 observation = self._fresh_pdc_source(
                     extras,
                     "tdp",
@@ -5551,7 +5613,10 @@ class Plugin:
                 reading = primary.get(primary_rail)
                 snap["applied"] = reading.applied_w if reading is not None else None
             if "pdc_auto_tdp" in active_ids:
-                snap["auto_tdp"] = self._tdp_profiles.auto_tdp(appid)
+                snap["auto_tdp"] = (
+                    self._auto_tdp_supported()
+                    and self._tdp_profiles.auto_tdp(appid)
+                )
             if "pdc_tdp_learn" in active_ids:
                 snap["learn"] = self._tdp_learned_info(appid)
         if self._fan_ctrl.supported and "pdc_fan" in active_ids:
@@ -7393,6 +7458,7 @@ class Plugin:
             "applied_w": applied_w,
             "primary_rail": primary_rail,
             "ppt": ppt,
+            "supports_auto_tdp": self._auto_tdp_supported(),
             "supports_advanced": ("pl2" in ll or "pl3" in ll),
             "level_limits": ll,
             "levels": levels,
@@ -7790,6 +7856,9 @@ class Plugin:
             return bool(ready())
         except Exception:  # noqa: BLE001
             return False
+
+    def _auto_tdp_supported(self) -> bool:
+        return bool(getattr(self._tdp_backend, "auto_tdp_supported", True))
 
     def _tdp_backend_diagnostics(self):
         errors = {}
@@ -8628,6 +8697,13 @@ class Plugin:
         await self._offload_call(self._recover_recognised_desktop_migration)
         await self._recover_tdp_startup_state()
         await self._probe_tdp_backend(force=True)
+        if self._tdp_control_on() and self._retired_experimental_tdp_unlock():
+            retired = await self._retire_experimental_tdp_unlock_or_disable()
+            if not retired.get("ok"):
+                decky.logger.warning(
+                    "Retired experimental TDP ceiling remains pending: %s",
+                    retired.get("detail"),
+                )
         self._theme_executor = ThreadPoolExecutor(max_workers=1)
         self._theme_accepting_work = True
         try:

--- a/py_modules/device_profiles.py
+++ b/py_modules/device_profiles.py
@@ -175,7 +175,7 @@ DEVICE_TABLE = (
                       DmiMatch("G1617-02-L", "GPD"),
                   ),
                   experimental=True,
-                  tdp_presets=(20, 25, 30, 35), experimental_tdp_max_ac=55),
+                  tdp_presets=(20, 25, 30, 35)),
     DeviceProfile("msi_claw_a8", "MSI Claw A8", "AMD Ryzen Z2 Extreme", "amd",
                   6, 17, 35, 35, match_names=("Claw A8",), experimental=True,
                   tdp_presets=(10, 20, 33, 33)),

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -17,6 +17,15 @@ def is_gpd_win_mini_2025(device, root: str = "/") -> bool:
     )
 
 
+def is_gpd_win_mini_2025_tdp_recovery(device, root: str = "/") -> bool:
+    return (
+        getattr(device, "key", None) == "gpd_win_mini_2025"
+        and _read_dmi(root, "sys_vendor").casefold() == "gpd"
+        and _read_dmi(root, "product_name").casefold()
+        in {"g1617-02", "g1617-02-l"}
+    )
+
+
 def asus_tdp_authoritative_reassert_s(device, root: str = "/") -> float | None:
     vendor = _read_dmi(root, "sys_vendor").casefold()
     product = _read_dmi(root, "product_name").casefold()

--- a/py_modules/tdp/backend.py
+++ b/py_modules/tdp/backend.py
@@ -5,6 +5,7 @@ from tdp.types import RailReading, TdpLimits, TdpObservation, TdpResult
 
 class TDPBackend(ABC):
     supported: bool = True
+    auto_tdp_supported: bool = True
     supports_levels: bool = False
     blocking: bool = False
     name: str = "base"

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -2,7 +2,7 @@ import os
 
 from device_quirks import (
     asus_tdp_authoritative_reassert_s,
-    is_gpd_win_mini_2025,
+    is_gpd_win_mini_2025_tdp_recovery,
     legion_go_s_83l3_firmware_attr_quirks,
     legion_go_s_83n6_firmware_attr_quirks,
     legion_go_s_83n6_rail_floors,
@@ -19,7 +19,7 @@ from tdp.steamdeck_hwmon import SteamDeckHwmonBackend
 from tdp.types import TdpLimits
 
 
-_STRICT_RYZENADJ_KEYS = frozenset({
+_RYZENADJ_ONLY_KEYS = frozenset({
     "onexplayer_superx",
     "zotac_gaming_zone",
     "rog_flow_z13",
@@ -27,6 +27,8 @@ _STRICT_RYZENADJ_KEYS = frozenset({
     "gpd_win_mini_2025",
     "ayaneo_3",
 })
+
+_STRICT_RYZENADJ_KEYS = _RYZENADJ_ONLY_KEYS - {"gpd_win_mini_2025"}
 
 
 def _runtime_lock_path(root, name):
@@ -150,7 +152,7 @@ def _candidates(device, fallback, root, ryzenadj, os_id=None):
             return [ryzenadj]
         if key == "onexplayer_apex":
             return [alib, ryzenadj]
-        if key in _STRICT_RYZENADJ_KEYS:
+        if key in _RYZENADJ_ONLY_KEYS:
             return [asus, lenovo, msi, ryzenadj]
         if key.startswith("rog_"):
             return [asus, asus_nb_wmi, lenovo, msi, *amd_tail]
@@ -162,7 +164,7 @@ def _candidates(device, fallback, root, ryzenadj, os_id=None):
         return [msi_a8, ryzenadj]
     if key == "onexplayer_apex":
         return [dptc, alib, ryzenadj]
-    if key in _STRICT_RYZENADJ_KEYS:
+    if key in _RYZENADJ_ONLY_KEYS:
         return [dptc, asus, lenovo, msi, ryzenadj]
     if key.startswith("rog_"):
         return [asus, asus_nb_wmi, *amd_tail]
@@ -180,12 +182,18 @@ def select_backend(device, root="/", ryzenadj_resolve=None, os_id=None) -> TDPBa
 
     def ryzenadj():
         kwargs = {"resolve": ryzenadj_resolve} if ryzenadj_resolve is not None else {}
+        gpd_recovery = is_gpd_win_mini_2025_tdp_recovery(device, root)
+        strict_readback = device.key in _STRICT_RYZENADJ_KEYS or (
+            device.key == "gpd_win_mini_2025" and not gpd_recovery
+        )
         return RyzenadjBackend(
             fallback,
             write_max=device.cooler_max,
-            write_max_ac=device.experimental_tdp_max_ac,
-            power_only_retry=is_gpd_win_mini_2025(device, root),
-            require_readback=device.key in _STRICT_RYZENADJ_KEYS,
+            write_max_ac=(
+                None if gpd_recovery else device.experimental_tdp_max_ac
+            ),
+            power_only_retry=gpd_recovery,
+            require_readback=strict_readback,
             safety_lock_path=_runtime_lock_path(
                 root,
                 f"ryzenadj-{device.key}.lock",

--- a/py_modules/tdp/ryzenadj.py
+++ b/py_modules/tdp/ryzenadj.py
@@ -113,10 +113,15 @@ class RyzenadjBackend(TDPBackend):
         self._bin = resolve()
         self._power_only_retry = power_only_retry
         self._require_readback = bool(require_readback)
+        self.auto_tdp_supported = not (
+            self._power_only_retry and not self._require_readback
+        )
         self._safety_lock = RuntimeSafetyLock(safety_lock_path)
         self.supported = self._bin is not None
         self._runtime_lock_payload = (
-            self._safety_lock.load_payload() if self._require_readback else None
+            self._safety_lock.load_payload()
+            if self._require_readback or self._power_only_retry
+            else None
         )
         durable_lock = (
             self._runtime_lock_payload.get("state")
@@ -416,12 +421,15 @@ class RyzenadjBackend(TDPBackend):
         target: int,
         detail: str,
     ) -> TdpResult:
-        if (
+        safe_recovery_confirmed = (
             self._readback_state == "recovery_pending"
+            and applied is not None
+            and self._fallback.min_w <= applied <= self._fallback.max_ac_w
             and target <= self._fallback.max_ac_w
-        ):
+        )
+        if safe_recovery_confirmed:
             self._readback_state = "ready"
-        if self._require_readback:
+        if self._require_readback or safe_recovery_confirmed:
             if self._safety_lock.clear():
                 self._runtime_lock_payload = None
             else:
@@ -517,7 +525,15 @@ class RyzenadjBackend(TDPBackend):
         }
 
     def recover_safe_range(self) -> bool:
-        if self._readback_state != "circuit_open_restored" or self._bin is None:
+        degraded_recovery = (
+            self._power_only_retry
+            and not self._require_readback
+            and self._readback_state.startswith("circuit_open")
+        )
+        if (
+            self._readback_state != "circuit_open_restored"
+            and not degraded_recovery
+        ) or self._bin is None:
             return bool(self.supported)
         self.supported = True
         self._readback_state = "recovery_pending"
@@ -525,6 +541,14 @@ class RyzenadjBackend(TDPBackend):
 
     def recover_runtime_transaction(self) -> dict:
         payload = self._runtime_lock_payload
+        if (
+            isinstance(payload, dict)
+            and str(payload.get("state", "")).startswith("circuit_open")
+            and self._power_only_retry
+            and not self._require_readback
+            and self.recover_safe_range()
+        ):
+            return {"ok": True, "detail": "ryzenadj safe-range recovery pending"}
         if (
             not isinstance(payload, dict)
             or payload.get("state") != "circuit_open_transaction"

--- a/src/api.ts
+++ b/src/api.ts
@@ -221,6 +221,7 @@ export interface TdpState {
   applied_w: number | null;
   primary_rail?: "pl1" | "pl2" | "pl3";
   ppt?: SteamDeckPptState | null;
+  supports_auto_tdp: boolean;
   supports_advanced: boolean;
   level_limits: { pl1?: LevelBound; pl2?: LevelBound; pl3?: LevelBound };
   levels: Levels;

--- a/src/components/TdpSection.test.tsx
+++ b/src/components/TdpSection.test.tsx
@@ -48,6 +48,7 @@ const deckState = {
   global_watts: 15,
   applied_w: 15,
   supports_advanced: true,
+  supports_auto_tdp: true,
   level_limits: {},
   levels: { pl1: 15, pl2: 22, pl3: 28 },
   requested_levels: { pl1: 15, pl2: 22, pl3: 28 },

--- a/src/sections/powerBlocks.tsx
+++ b/src/sections/powerBlocks.tsx
@@ -49,6 +49,9 @@ export function registerPowerBlocks(): void {
   registerBlock("autoTdp", {
     sectionId: "power",
     Component: AutoTdpBlock,
-    useAvailable: () => !!usePotencia().tdp?.supported,
+    useAvailable: () => {
+      const tdp = usePotencia().tdp;
+      return !!tdp?.supported && tdp.supports_auto_tdp;
+    },
   });
 }

--- a/src/sections/providerMounts.tsx
+++ b/src/sections/providerMounts.tsx
@@ -70,7 +70,8 @@ export const PotenciaProviderMount: FC<{ children: ReactNode }> = ({ children })
   const { tdp, refresh } = tdpCtl;
   const conflict = useTdpConflict(tdp?.supported ?? false, tdp?.tdp_control_enabled ?? true);
   const disabled = useModules();
-  const autoTdpEnabled = effectiveEnabled("autoTdp", disabled);
+  const autoTdpEnabled = effectiveEnabled("autoTdp", disabled)
+    && tdp?.supports_auto_tdp !== false;
 
   // Re-enable the power module (master switch on) via the editor's path, then re-pull
   // the TDP state so the monitor view clears. Returns the promise for the button guard.

--- a/tests/test_auto_adapt_rpc.py
+++ b/tests/test_auto_adapt_rpc.py
@@ -299,6 +299,20 @@ def test_loop_does_not_touch_global_when_no_game(Plugin, monkeypatch):
     assert p._tdp_profiles.effective(None)["pl1"] == 20  # global untouched
 
 
+def test_loop_never_writes_when_backend_disables_auto_tdp(Plugin, monkeypatch):
+    p = Plugin()
+    p._init()
+    p._tdp_backend.auto_tdp_supported = False
+    p._current_appid = "g"
+    p._tdp_profiles.set_pl1("game", 20, appid="g")
+    reads = [{"gpu_busy": 99} for _ in range(4)]
+
+    _run_loop_ticks(p, reads, monkeypatch)
+
+    assert p._tdp_profiles.effective("g")["pl1"] == 20
+    assert p._tdp_backend._levels is None
+
+
 def test_loop_clears_gpu_window_on_pl1_change(Plugin, monkeypatch):
     # A PL1 change must clear the GPU% window so it stays HOMOGENEOUS (only samples
     # taken at the CURRENT PL1). Otherwise decide averages GPU% across different PL1s.

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -211,7 +211,7 @@ def test_gpd_win_mini_2025_is_recognised_experimental(tmp_path):
     assert prof.tdp_default == 20
     assert prof.tdp_max == 35
     assert prof.tdp_max_charger == 35
-    assert prof.experimental_tdp_max_ac == 55
+    assert prof.experimental_tdp_max_ac is None
     assert prof.tdp_presets == (20, 25, 30, 35)
 
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -70,7 +70,7 @@ def test_get_device_surfaces_experimental_flag(Plugin, monkeypatch):
     assert dev["is_generic"] is False
 
 
-def test_get_device_surfaces_experimental_ac_unlock_capability(Plugin, monkeypatch):
+def test_get_device_hides_unvalidated_experimental_ac_unlock(Plugin, monkeypatch):
     import device_registry
     import main
     from device_profiles import DEVICE_TABLE
@@ -82,7 +82,7 @@ def test_get_device_surfaces_experimental_ac_unlock_capability(Plugin, monkeypat
     dev = asyncio.run(Plugin().get_device())
 
     assert dev["tdp_max_charger"] == 35
-    assert dev["experimental_tdp_max_ac"] == 55
+    assert dev["experimental_tdp_max_ac"] is None
 
 
 def test_telemetry_enabled_default_true(Plugin):

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -74,6 +74,37 @@ def _mk_readable_ryzenadj(root):
     return path
 
 
+def _mk_gpd_partial_readback_ryzenadj(root, initial_w=20, readback_offset=0):
+    state = os.path.join(root, "gpd-ryzenadj-state")
+    with open(state, "w") as handle:
+        handle.write(str(initial_w))
+    path = os.path.join(root, "gpd-ryzenadj")
+    with open(path, "w") as handle:
+        handle.write(
+            "#!/bin/sh\n"
+            f"state='{state}'\n"
+            "if [ \"$1\" = \"-i\" ]; then\n"
+            "  raw=$(cat \"$state\")\n"
+            f"  watts=$((raw + {readback_offset}))\n"
+            "  printf '| STAPM LIMIT | %s.000 | stapm-limit |\\n' \"$watts\"\n"
+            "  exit 0\n"
+            "fi\n"
+            "target=\n"
+            "with_temp=0\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    --stapm-limit) shift; target=$1 ;;\n"
+            "    --tctl-temp) with_temp=1 ;;\n"
+            "  esac\n"
+            "  shift\n"
+            "done\n"
+            "if [ \"$with_temp\" -eq 1 ]; then exit 1; fi\n"
+            "echo $((target / 1000)) > \"$state\"\n"
+        )
+    os.chmod(path, 0o755)
+    return path, state
+
+
 def _mk_asus_legacy(root):
     base = os.path.join(root, "sys/devices/platform/asus-nb-wmi")
     os.makedirs(base, exist_ok=True)
@@ -339,33 +370,76 @@ def test_new_experimental_profile_defers_ryzenadj_probe_and_rejects_before_write
     assert "readback unavailable before write" in result.detail
 
 
-def test_gpd_win_mini_backend_reserves_55w_for_explicit_ac_unlock(tmp_path):
-    backend = select_backend(
-        _p("gpd_win_mini_2025"),
-        root=str(tmp_path),
-        ryzenadj_resolve=lambda: "/bin/true",
-    )
-
-    assert backend.get_limits().max_ac_w == 35
-    assert backend._write_limits.max_w == 35
-    assert backend._write_limits.max_ac_w == 55
-
-
-def test_factory_keeps_runtime_locked_gpd_backend_available_for_safe_recovery(tmp_path):
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "circuit_open_restored",
+        "circuit_open_unresolved",
+        json.dumps({
+            "state": "circuit_open_transaction",
+            "baseline": {"stapm": 55, "fast": 55, "slow": 55},
+            "experimental": True,
+        }),
+    ),
+)
+def test_factory_keeps_runtime_locked_gpd_backend_available_for_safe_recovery(
+    tmp_path,
+    payload,
+):
+    _mk_dmi(str(tmp_path), "GPD", "G1617-02")
+    binary, _state = _mk_gpd_partial_readback_ryzenadj(str(tmp_path))
     lock = tmp_path / "run/panel-de-control/ryzenadj-gpd_win_mini_2025.lock"
     lock.parent.mkdir(parents=True)
-    lock.write_text("circuit_open_restored", encoding="utf-8")
+    lock.write_text(payload, encoding="utf-8")
 
     backend = select_backend(
         _p("gpd_win_mini_2025"),
         root=str(tmp_path),
-        ryzenadj_resolve=lambda: "/bin/true",
+        ryzenadj_resolve=lambda: binary,
     )
 
     assert backend.name == "ryzenadj"
     assert backend.supported is False
     assert backend.safety_locked is True
-    assert backend.recover_safe_range() is True
+    assert backend.recover_runtime_transaction() == {
+        "ok": True,
+        "detail": "ryzenadj safe-range recovery pending",
+    }
+
+    result = backend.set_tdp(25, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 25
+    assert backend.safety_locked is False
+    assert lock.exists() is False
+
+
+def test_gpd_recovery_keeps_lock_when_tolerated_readback_exceeds_oem_ceiling(
+    tmp_path,
+):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", "G1617-02")
+    binary, _state = _mk_gpd_partial_readback_ryzenadj(
+        root,
+        readback_offset=2,
+    )
+    lock = tmp_path / "run/panel-de-control/ryzenadj-gpd_win_mini_2025.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("circuit_open_restored", encoding="utf-8")
+    backend = select_backend(
+        _p("gpd_win_mini_2025"),
+        root=root,
+        ryzenadj_resolve=lambda: binary,
+    )
+
+    assert backend.recover_runtime_transaction()["ok"] is True
+
+    result = backend.set_tdp(35, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 37
+    assert backend.safety_locked is True
+    assert lock.exists() is True
 
 
 def test_only_exact_legion_go_s_83n6_gets_measured_rail_floors(tmp_path):
@@ -845,9 +919,9 @@ def test_only_exact_gpd_enables_ryzenadj_power_only_retry(tmp_path):
     assert other._power_only_retry is False
 
 
-def test_gpd_profile_with_different_dmi_keeps_default_ryzenadj(tmp_path):
+def test_gpd_profile_with_unrecognised_dmi_keeps_default_ryzenadj(tmp_path):
     root = str(tmp_path)
-    _mk_dmi(root, "GPD", "G1617-02-L")
+    _mk_dmi(root, "GPD", "G1617-03")
     binary = _mk_readable_ryzenadj(root)
 
     backend = select_backend(
@@ -857,6 +931,64 @@ def test_gpd_profile_with_different_dmi_keeps_default_ryzenadj(tmp_path):
     )
 
     assert backend._power_only_retry is False
+
+
+@pytest.mark.parametrize("product", ("G1617-02", "G1617-02-L"))
+def test_gpd_safe_range_survives_partial_readback_and_temperature_rejection(
+    tmp_path,
+    product,
+):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", product)
+    binary, _state = _mk_gpd_partial_readback_ryzenadj(root)
+    backend = select_backend(
+        _p("gpd_win_mini_2025"),
+        root=root,
+        ryzenadj_resolve=lambda: binary,
+    )
+
+    result = backend.set_tdp(25, ac=True)
+
+    assert backend.name == "ryzenadj"
+    assert result.ok is True
+    assert result.applied_w == 25
+    assert "variant=power-only" in result.detail
+
+
+def test_gpd_partial_readback_route_disables_auto_tdp(tmp_path):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", "G1617-02")
+    binary, _state = _mk_gpd_partial_readback_ryzenadj(root)
+
+    backend = select_backend(
+        _p("gpd_win_mini_2025"),
+        root=root,
+        ryzenadj_resolve=lambda: binary,
+    )
+
+    assert backend.auto_tdp_supported is False
+
+
+def test_gpd_unvalidated_55w_request_stays_within_oem_ceiling(tmp_path):
+    root = str(tmp_path)
+    _mk_dmi(root, "GPD", "G1617-02")
+    binary, state = _mk_gpd_partial_readback_ryzenadj(root)
+    device = dataclasses.replace(
+        _p("gpd_win_mini_2025"),
+        experimental_tdp_max_ac=55,
+    )
+    backend = select_backend(
+        device,
+        root=root,
+        ryzenadj_resolve=lambda: binary,
+    )
+
+    result = backend.set_tdp(55, ac=True)
+
+    assert result.ok is True
+    assert result.applied_w == 35
+    with open(state) as handle:
+        assert handle.read().strip() == "35"
 
 
 def test_backend_probe_failure_is_recorded_and_falls_through(tmp_path, monkeypatch):

--- a/tests/test_tdp_rpc.py
+++ b/tests/test_tdp_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import importlib
 import sys
 import types
@@ -8,6 +9,15 @@ import pytest
 from tdp.types import RailReading, TdpLimits, TdpObservation, TdpResult
 
 _FAKE_POWER = {"watts": 13.1, "gpu_busy": 49}
+
+
+def _device_with_experimental_tdp_unlock():
+    from device_profiles import DEVICE_TABLE
+
+    device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    return dataclasses.replace(device, experimental_tdp_max_ac=55)
 
 
 class FakeBackend:
@@ -590,7 +600,7 @@ def test_cooler_boost_ignored_when_device_has_no_cooler(Plugin):
     assert p._limits().max_w == 20  # unchanged
 
 
-def test_gpd_win_mini_experimental_ceiling_is_opt_in_and_ac_only(Plugin):
+def test_gpd_win_mini_does_not_offer_unvalidated_experimental_ceiling(Plugin):
     from device_profiles import DEVICE_TABLE
 
     p = Plugin()
@@ -603,13 +613,202 @@ def test_gpd_win_mini_experimental_ceiling_is_opt_in_and_ac_only(Plugin):
     assert p._limits() == TdpLimits(20, 20, 35, 35)
     assert asyncio.run(p.get_experimental_tdp_unlock()) is False
 
-    assert asyncio.run(p.set_experimental_tdp_unlock(True))["enabled"] is True
-    assert p._limits() == TdpLimits(20, 20, 35, 55)
-    assert p._limits().clamp(55, on_ac=False) == 35
-    assert p._limits().clamp(55, on_ac=True) == 55
+    result = asyncio.run(p.set_experimental_tdp_unlock(True))
 
-    assert asyncio.run(p.set_experimental_tdp_unlock(False))["enabled"] is False
+    assert result == {"enabled": False, "ok": True, "detail": "unchanged"}
     assert p._limits() == TdpLimits(20, 20, 35, 35)
+
+
+def test_retired_gpd_unlock_is_not_forgotten_while_control_is_disabled(Plugin):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    p._settings["tdp_control_enabled"] = False
+
+    result = asyncio.run(p.set_experimental_tdp_unlock(False))
+
+    assert result == {
+        "enabled": True,
+        "ok": False,
+        "detail": "TDP control disabled",
+    }
+    assert p._settings["experimental_tdp_unlock"] is True
+
+
+def test_retired_gpd_unlock_is_cleared_only_after_safe_reapply(Plugin, monkeypatch):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    saves = []
+    monkeypatch.setattr(p, "_save", lambda: saves.append(True))
+
+    async def apply_safe(*_args, **_kwargs):
+        return TdpResult(35, 35, True, "confirmed")
+
+    monkeypatch.setattr(p, "_apply_tdp_now", apply_safe)
+
+    result = asyncio.run(p.set_experimental_tdp_unlock(False))
+
+    assert result == {"enabled": False, "ok": True, "detail": "confirmed"}
+    assert p._settings["experimental_tdp_unlock"] is False
+    assert saves == [True]
+
+
+def test_retired_gpd_unlock_survives_unconfirmed_safe_reapply(Plugin, monkeypatch):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+
+    async def apply_unconfirmed(*_args, **_kwargs):
+        return TdpResult(35, None, True, "applied (limit readback unavailable)")
+
+    monkeypatch.setattr(p, "_apply_tdp_now", apply_unconfirmed)
+
+    result = asyncio.run(p.set_experimental_tdp_unlock(False))
+
+    assert result["enabled"] is True
+    assert result["ok"] is False
+    assert "safe ceiling unconfirmed" in result["detail"]
+    assert p._settings["experimental_tdp_unlock"] is True
+
+
+def test_enabling_control_retires_gpd_unlock_after_safe_reapply(Plugin, monkeypatch):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    p._settings["tdp_control_enabled"] = False
+
+    async def probe(*_args, **_kwargs):
+        return True
+
+    async def apply_safe(*_args, **_kwargs):
+        return TdpResult(35, 35, True, "confirmed")
+
+    monkeypatch.setattr(p, "_probe_tdp_backend", probe)
+    monkeypatch.setattr(p, "_apply_tdp_now", apply_safe)
+
+    assert asyncio.run(p.set_tdp_control_enabled(True)) is True
+    assert p._settings["experimental_tdp_unlock"] is False
+
+
+def test_enabling_control_rolls_back_when_gpd_reclamp_is_unconfirmed(
+    Plugin,
+    monkeypatch,
+):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    p._settings["tdp_control_enabled"] = False
+
+    async def probe(*_args, **_kwargs):
+        return True
+
+    async def apply_unconfirmed(*_args, **_kwargs):
+        return TdpResult(35, None, True, "applied (limit readback unavailable)")
+
+    monkeypatch.setattr(p, "_probe_tdp_backend", probe)
+    monkeypatch.setattr(p, "_apply_tdp_now", apply_unconfirmed)
+    monkeypatch.setattr(p, "_restore_power_handoff", lambda: True)
+
+    assert asyncio.run(p.set_tdp_control_enabled(True)) is False
+    assert p._settings["tdp_control_enabled"] is False
+    assert p._settings["experimental_tdp_unlock"] is True
+
+
+def test_ui_power_activation_uses_guarded_gpd_reclamp(Plugin, monkeypatch):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    p._settings["tdp_control_enabled"] = False
+
+    async def probe(*_args, **_kwargs):
+        return True
+
+    async def apply_unconfirmed(*_args, **_kwargs):
+        return TdpResult(35, None, True, "applied (limit readback unavailable)")
+
+    monkeypatch.setattr(p, "_probe_tdp_backend", probe)
+    monkeypatch.setattr(p, "_apply_tdp_now", apply_unconfirmed)
+    monkeypatch.setattr(p, "_restore_power_handoff", lambda: True)
+
+    state = asyncio.run(p.set_ui_module("power", False))
+
+    assert "power" in state["disabled"]
+    assert p._settings["tdp_control_enabled"] is False
+    assert p._settings["experimental_tdp_unlock"] is True
+
+
+def test_ui_power_activation_stays_off_when_gpd_backend_is_not_ready(
+    Plugin,
+    monkeypatch,
+):
+    from device_profiles import DEVICE_TABLE
+
+    p = Plugin()
+    p._init()
+    p._device = next(
+        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
+    )
+    p._settings["experimental_tdp_unlock"] = True
+    p._settings["tdp_control_enabled"] = False
+
+    async def probe(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(p, "_probe_tdp_backend", probe)
+    monkeypatch.setattr(p, "_restore_power_handoff", lambda: True)
+
+    state = asyncio.run(p.set_ui_module("power", False))
+
+    assert "power" in state["disabled"]
+    assert p._settings["tdp_control_enabled"] is False
+    assert p._settings["experimental_tdp_unlock"] is True
+
+
+def test_backend_without_auto_tdp_rejects_and_clears_stored_auto(PluginWithPower):
+    p = PluginWithPower()
+    p._init()
+    p._tdp_backend.auto_tdp_supported = False
+    p._tdp_profiles.set_auto_tdp("global", True)
+
+    result = asyncio.run(p.set_auto_tdp(True))
+    state = asyncio.run(p.get_tdp_state())
+    power = asyncio.run(p.get_power_draw())
+
+    assert result == {"auto_tdp": False}
+    assert p._tdp_profiles.auto_tdp(None) is False
+    assert state["supports_auto_tdp"] is False
+    assert power["auto_tdp"] is False
 
 
 def test_gpd_win_mini_corrupt_string_false_never_unlocks_55w(Plugin):
@@ -648,14 +847,10 @@ def test_gpd_win_mini_upgrade_preserves_legacy_low_profile_intent(Plugin):
     assert p._effective_levels(None, on_ac=True)[0]["pl1"] == 20
 
 
-def test_failed_55w_disable_keeps_unlock_visibly_active(Plugin, monkeypatch):
-    from device_profiles import DEVICE_TABLE
-
+def test_failed_experimental_disable_keeps_unlock_visibly_active(Plugin, monkeypatch):
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     p._settings["experimental_tdp_unlock"] = True
     saves = []
     monkeypatch.setattr(p, "_save", lambda: saves.append(True))
@@ -676,17 +871,13 @@ def test_failed_55w_disable_keeps_unlock_visibly_active(Plugin, monkeypatch):
     assert saves == []
 
 
-def test_successful_55w_disable_restarts_guard_after_runtime_lock_recovery(
+def test_successful_experimental_disable_restarts_guard_after_runtime_lock_recovery(
     Plugin,
     monkeypatch,
 ):
-    from device_profiles import DEVICE_TABLE
-
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     p._settings["experimental_tdp_unlock"] = True
     p._tdp_backend.supported = False
     p._tdp_backend.recover_safe_range = lambda: setattr(
@@ -709,17 +900,13 @@ def test_successful_55w_disable_restarts_guard_after_runtime_lock_recovery(
     assert starts == [True]
 
 
-def test_failed_55w_enable_reports_durable_unlock_if_rollback_save_fails(
+def test_failed_experimental_enable_reports_durable_unlock_if_rollback_save_fails(
     Plugin,
     monkeypatch,
 ):
-    from device_profiles import DEVICE_TABLE
-
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     saves = 0
 
     def save():
@@ -742,14 +929,10 @@ def test_failed_55w_enable_reports_durable_unlock_if_rollback_save_fails(
     assert p._settings["experimental_tdp_unlock"] is True
 
 
-def test_55w_disable_requires_panel_ownership_to_confirm_safe_ceiling(Plugin):
-    from device_profiles import DEVICE_TABLE
-
+def test_experimental_disable_requires_panel_ownership_to_confirm_safe_ceiling(Plugin):
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     p._settings["experimental_tdp_unlock"] = True
     p._settings["tdp_control_enabled"] = False
 
@@ -763,15 +946,15 @@ def test_55w_disable_requires_panel_ownership_to_confirm_safe_ceiling(Plugin):
     assert p._settings["experimental_tdp_unlock"] is True
 
 
-def test_gpd_win_mini_automation_and_presets_remain_capped_at_35w(Plugin, monkeypatch):
+def test_experimental_unlock_keeps_automation_and_presets_at_base_ceiling(
+    Plugin,
+    monkeypatch,
+):
     import main
-    from device_profiles import DEVICE_TABLE
 
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     p._tdp_backend.get_limits = lambda: TdpLimits(20, 20, 35, 35)
     p._settings["experimental_tdp_unlock"] = True
 
@@ -786,15 +969,12 @@ def test_gpd_win_mini_automation_and_presets_remain_capped_at_35w(Plugin, monkey
     assert p._tdp_profiles.effective(None)["pl1"] == 35
 
 
-def test_gpd_win_mini_manual_55w_request_requires_ac(Plugin, monkeypatch):
+def test_manual_experimental_request_requires_ac(Plugin, monkeypatch):
     import main
-    from device_profiles import DEVICE_TABLE
 
     p = Plugin()
     p._init()
-    p._device = next(
-        profile for profile in DEVICE_TABLE if profile.key == "gpd_win_mini_2025"
-    )
+    p._device = _device_with_experimental_tdp_unlock()
     p._tdp_backend.get_limits = lambda: TdpLimits(20, 20, 35, 35)
     p._settings["experimental_tdp_unlock"] = True
 


### PR DESCRIPTION
## Summary

- restore manual 20–35 W control on exact GPD Win Mini 2025 DMI variants when RyzenAdj exposes partial STAPM readback
- retry power-limit writes without the unsupported temperature argument while keeping unavailable or mismatched readback honest
- disable Auto-TDP on this degraded route across backend, RPC, loops, HUD, and UI
- retire the unvalidated 55 W ceiling without losing its legacy marker until a safe 20–35 W readback is confirmed
- recover inherited restored, unresolved, and in-flight runtime locks without clearing them above the OEM ceiling

## Root cause

Version 0.46.1 moved this device onto strict three-rail RyzenAdj readback. The affected firmware can expose a usable STAPM reading while omitting FAST/SLOW and can reject writes containing the temperature argument, so backend selection failed before the previously working power-only path was attempted.

## Validation

- Python: 2,748 passed, 1 skipped, 58 subtests
- Frontend: 1,068 passed across 127 files
- TypeScript, Ruff, production build, and diff checks passed
- independent focal code review: no blockers
- Steam Deck OLED shared path was smoke-tested on the candidate with a confirmed 15 → 14 → 15 W transition

## Hardware gap

No GPD Win Mini 2025 is available locally. The route is therefore intentionally limited to exact DMI matches, manual OEM range only, with durable recovery guards. Physical validation on G1617-02 or G1617-02-L remains required before claiming the machine verified.