### PR TITLE
fix(tdp): recover delayed Legion Go 2 firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Español
+
+* **Legion Go 2:** Recupera el control de TDP en el modelo 83N0 cuando el firmware tarda en reflejar los nuevos límites o una transacción anterior lo dejó bloqueado.
+
+### English
+
+* **Legion Go 2:** Restores TDP control on model 83N0 when firmware takes time to reflect new limits or a previous transaction left it locked.
+
+### Italiano
+
+* **Legion Go 2:** Ripristina il controllo del TDP sul modello 83N0 quando il firmware tarda a mostrare i nuovi limiti o una transazione precedente lo ha lasciato bloccato.
+
+### Deutsch
+
+* **Legion Go 2:** Stellt die TDP-Steuerung beim Modell 83N0 wieder her, wenn die Firmware neue Grenzwerte verzögert anzeigt oder eine frühere Transaktion sie gesperrt hat.
+
 ## [0.46.2](https://github.com/Hooandee/panel-de-control/compare/panel-de-control-v0.46.1...panel-de-control-v0.46.2) (2026-09-11)
 
 

--- a/py_modules/device_quirks.py
+++ b/py_modules/device_quirks.py
@@ -38,6 +38,16 @@ def asus_tdp_authoritative_reassert_s(device, root: str = "/") -> float | None:
     return None
 
 
+def legion_go_2_83n0_firmware_attr_quirks(device, root: str = "/") -> dict:
+    if (
+        getattr(device, "key", None) != "legion_go_2"
+        or _read_dmi(root, "sys_vendor").casefold() != "lenovo"
+        or _read_dmi(root, "product_name").casefold() != "83n0"
+    ):
+        return {}
+    return {"readback_settle_delays": (0.25, 0.50, 1.0, 2.0)}
+
+
 def is_legion_go_s_83n6(device, root: str = "/") -> bool:
     return (
         getattr(device, "key", None) == "legion_go_s"

--- a/py_modules/tdp/factory.py
+++ b/py_modules/tdp/factory.py
@@ -3,6 +3,7 @@ import os
 from device_quirks import (
     asus_tdp_authoritative_reassert_s,
     is_gpd_win_mini_2025_tdp_recovery,
+    legion_go_2_83n0_firmware_attr_quirks,
     legion_go_s_83l3_firmware_attr_quirks,
     legion_go_s_83n6_firmware_attr_quirks,
     legion_go_s_83n6_rail_floors,
@@ -80,6 +81,7 @@ def _candidates(device, fallback, root, ryzenadj, os_id=None):
                 root,
                 "firmware-lenovo-wmi-other.lock",
             ),
+            **legion_go_2_83n0_firmware_attr_quirks(device, root),
             **legion_go_s_83l3_firmware_attr_quirks(device, root),
             **legion_go_s_83n6_firmware_attr_quirks(device, root),
         )

--- a/tests/test_device_quirks.py
+++ b/tests/test_device_quirks.py
@@ -140,3 +140,26 @@ def test_legion_go_s_83l3_named_profile_recovery_requires_exact_identity(tmp_pat
             "named_profile_owns_rails",
             False,
         ) is expected
+
+
+def test_legion_go_2_83n0_async_readback_requires_exact_identity(tmp_path):
+    assert hasattr(
+        device_quirks,
+        "legion_go_2_83n0_firmware_attr_quirks",
+    )
+    cases = (
+        ("LENOVO", "83N0", _profile("legion_go_2"), True),
+        ("OTHER", "83N0", _profile("legion_go_2"), False),
+        ("LENOVO", "83N1", _profile("legion_go_2"), False),
+        ("LENOVO", "83N0-X", _profile("legion_go_2"), False),
+        ("LENOVO", "83N0", _profile("legion_go"), False),
+        ("LENOVO", "83N0", GENERIC, False),
+    )
+
+    for vendor, product, device, expected in cases:
+        _write_dmi(str(tmp_path), vendor, product)
+        quirks = device_quirks.legion_go_2_83n0_firmware_attr_quirks(
+            device,
+            str(tmp_path),
+        )
+        assert bool(quirks.get("readback_settle_delays")) is expected

--- a/tests/test_tdp_factory.py
+++ b/tests/test_tdp_factory.py
@@ -350,6 +350,122 @@ def test_legion_uses_lenovo_firmware_attr(tmp_path):
     assert b.diagnostics()["readback_settle_ms"] == 0
 
 
+def test_exact_legion_go_2_83n0_waits_for_async_readback_before_rollback(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_legion_firmware(root, "83N0", "custom", current=(21, 17, 36))
+    backend = select_backend(
+        _p("legion_go_2"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    lock_path = os.path.join(
+        root,
+        "run/panel-de-control/firmware-lenovo-wmi-other.lock",
+    )
+    original_write = backend._write
+    target_writes = []
+    settle_delays = []
+    settled = False
+
+    def delayed_firmware_write(path, value):
+        if path.endswith("current_value") and value == 8:
+            target_writes.append(path)
+            if len(target_writes) == 3:
+                for attr, transient in zip(
+                    ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"),
+                    (25, 25, 30),
+                ):
+                    _set_fw_current(root, attr, transient)
+            return True
+        if target_writes and path.endswith("current_value") and not settled:
+            return False
+        return original_write(path, value)
+
+    def finish_delayed_write(delay):
+        nonlocal settled
+        settle_delays.append(delay)
+        if len(settle_delays) < 4:
+            return
+        settled = True
+        for attr in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
+            _set_fw_current(root, attr, 8)
+
+    monkeypatch.setattr(backend, "_write", delayed_firmware_write)
+    monkeypatch.setattr("tdp.firmware_attr.time.sleep", finish_delayed_write)
+
+    result = backend.set_levels(8, 8, 8, ac=False)
+
+    assert result.ok is True
+    assert result.applied_w == 8
+    assert backend.safety_locked is False
+    assert not os.path.exists(lock_path)
+    assert settle_delays == [0.25, 0.5, 1.0, 2.0]
+    assert backend.diagnostics()["readback_settle_ms"] == 3750
+
+
+def test_exact_legion_go_2_83n0_recovers_delayed_persisted_transaction(
+    tmp_path,
+    monkeypatch,
+):
+    root = str(tmp_path)
+    _mk_legion_firmware(root, "83N0", "custom", current=(25, 25, 30))
+    lock_path = _arm_lenovo_transaction_lock(
+        root,
+        "custom",
+        snapshot={
+            "firmware-attr:lenovo-wmi-other/pl1": 8,
+            "firmware-attr:lenovo-wmi-other/pl2": 8,
+            "firmware-attr:lenovo-wmi-other/pl3": 8,
+        },
+    )
+    backend = select_backend(
+        _p("legion_go_2"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+    original_write = backend._write
+    settle_delays = []
+
+    def accept_delayed_restore(path, value):
+        if path.endswith("current_value"):
+            return True
+        return original_write(path, value)
+
+    def finish_delayed_restore(delay):
+        settle_delays.append(delay)
+        if len(settle_delays) < 4:
+            return
+        for attr in ("ppt_pl1_spl", "ppt_pl2_sppt", "ppt_pl3_fppt"):
+            _set_fw_current(root, attr, 8)
+
+    monkeypatch.setattr(backend, "_write", accept_delayed_restore)
+    monkeypatch.setattr("tdp.firmware_attr.time.sleep", finish_delayed_restore)
+
+    recovered = backend.recover_runtime_transaction()
+
+    assert recovered == {"ok": True, "detail": "no firmware recovery pending"}
+    assert backend.read_applied() == 8
+    assert backend.safety_locked is False
+    assert not os.path.exists(lock_path)
+    assert settle_delays == [0.25, 0.5, 1.0, 2.0]
+
+
+def test_legion_go_2_83n1_keeps_existing_strict_readback(tmp_path):
+    root = str(tmp_path)
+    _mk_legion_firmware(root, "83N1", "custom")
+
+    backend = select_backend(
+        _p("legion_go_2"),
+        root=root,
+        ryzenadj_resolve=_NO_RYZENADJ,
+    )
+
+    assert backend.diagnostics()["readback_settle_ms"] == 0
+
+
 def test_new_experimental_profile_defers_ryzenadj_probe_and_rejects_before_write(tmp_path):
     backend = select_backend(
         _p("onexplayer_f1"),


### PR DESCRIPTION
## What does this change?

- Allows delayed `lenovo-wmi-other` readback to settle before rollback on the exact Legion Go 2 `LENOVO/83N0` DMI.
- Uses the same bounded readback cadence to recover an existing firmware transaction lock.
- Keeps `83N1` and every other Lenovo, ASUS, GPD, MSI, generic, and Steam Deck route unchanged.
- Adds factory-to-backend regressions for delayed apply, persisted-lock recovery, and nearby DMI exclusion.

Closes #598.
Related to #591.

## How was it tested?

- `ruff check py_modules main.py tests`
- `python -m pytest -q` — 2752 passed, 1 skipped, 58 subtests passed
- `pnpm typecheck`
- `pnpm test:i18n` — 34 passed
- `pnpm test:fe` — 1068 passed
- `pnpm build`

No physical Legion Go 2 `83N0` was available. The regression fixtures reproduce the delayed `25/25/30` readback and persistent transaction lock from the report, but reporter hardware validation is still required.

## Checklist

- [x] The commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, …). Only `feat:`/`fix:` trigger a release.
- [x] `pnpm typecheck`, `pnpm test:fe`, and `pnpm build` pass.
- [x] `ruff check py_modules main.py tests` and `python -m pytest` pass.
- [x] No secrets, tokens, or personal data are included.
- [x] I did not add new third-party dependencies without noting them (and their license) in `THIRD_PARTY_NOTICES.md`.
